### PR TITLE
Modified API used for updating ELR and added init code in PMUIRQ test

### DIFF
--- a/platform/pal_uefi/src/AArch64/AvsTestInfra.S
+++ b/platform/pal_uefi/src/AArch64/AvsTestInfra.S
@@ -18,12 +18,9 @@
 .text
 .align 3
 
-GCC_ASM_EXPORT(UpdateElr)
 GCC_ASM_EXPORT(DataCacheCleanInvalidateVA)
 GCC_ASM_EXPORT(DataCacheInvalidateVA)
 GCC_ASM_EXPORT(DataCacheCleanVA)
-
-#define FP_CONTEXT_SIZE   0x200
 
 ASM_PFX(DataCacheCleanInvalidateVA):
   dc  civac, x0
@@ -43,20 +40,3 @@ ASM_PFX(DataCacheInvalidateVA):
   isb
   ret
 
-ASM_PFX(UpdateElr):
-  // This function returns the stacked address of ELR in UEFI exception path
-  // The sequence of context save before the control is handed over
-  // to test-specific handler includes:
-  // 1. General Purpose registers, occupying 0x100 bytes (32*8)
-  // 2. Floating Point registers, occupying 0x200 bytes (32*16)
-  // 3. System Registers, occupying 0x30 (6*8) - ELR,SPSR,FPSR,ESR,FAR
-  // X28 points to start of FP context, and an offset of 0x200 should be
-  // added to make it point to system register context and
-  // ELR is the first register stacked there.
-  // For more info on the calculation of stacked address, please refer following file:
-  // <EDK2_PATH>/ArmPkg/Library/ArmExceptionLib/AArch64/ExceptionSupport.S
-
-  add   x1, x28, #FP_CONTEXT_SIZE
-  str   x0, [x1]    // Update the stacked location with user address
-
-  ret

--- a/platform/pal_uefi/src/pal_pe.c
+++ b/platform/pal_uefi/src/pal_pe.c
@@ -169,7 +169,7 @@ pal_pe_create_info_table(PE_INFO_TABLE *PeTable)
   @return status of the API
 **/
 UINT32
-pal_pe_install_esr(UINT32 ExceptionType,  VOID (*esr)())
+pal_pe_install_esr(UINT32 ExceptionType,  VOID (*esr)(UINT64, VOID *))
 {
 
   EFI_STATUS  Status;
@@ -195,7 +195,7 @@ pal_pe_install_esr(UINT32 ExceptionType,  VOID (*esr)())
   //
   // Register to receive interrupts
   //
-  Status = Cpu->RegisterInterruptHandler (Cpu, ExceptionType, esr);
+  Status = Cpu->RegisterInterruptHandler (Cpu, ExceptionType, (EFI_CPU_INTERRUPT_HANDLER)esr);
   if (EFI_ERROR (Status)) {
     return Status;
   }
@@ -244,13 +244,9 @@ pal_pe_execute_payload(ARM_SMC_ARGS *ArmSmcArgs)
 }
 
 VOID
-UpdateElr(UINT64 offset);
-
-
-VOID
-pal_pe_update_elr(UINT64 offset)
+pal_pe_update_elr(VOID *context, UINT64 offset)
 {
-  UpdateElr(offset);
+  ((EFI_SYSTEM_CONTEXT_AARCH64*)context)->ELR = offset;
 }
 
 VOID

--- a/test_pool/pe/test_c011.c
+++ b/test_pool/pe/test_c011.c
@@ -27,7 +27,12 @@ void
 set_pmu_overflow()
 {
   uint64_t pmcr;
-  
+
+  //Initializing the state of overflow status and interrupt request registers
+  val_pe_reg_write(PMINTENCLR_EL1, 0xFFFFFFFF);
+  val_pe_reg_write(PMOVSCLR_EL0, 0xFFFFFFFF);
+
+  //Sequence to generate PMUIRQ
   pmcr = val_pe_reg_read(PMCR_EL0);
   val_pe_reg_write(PMCR_EL0, pmcr|0x1);
 

--- a/test_pool/peripherals/test_m001.c
+++ b/test_pool/peripherals/test_m001.c
@@ -35,12 +35,12 @@ payload();
 
 static
 void
-esr()
+esr(uint64_t interrupt_type, void *context)
 {
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
   /* Update the ELR to point to next instrcution */
-  val_pe_update_elr((uint64_t)branch_to_test);
+  val_pe_update_elr(context, (uint64_t)branch_to_test);
 
   val_print(AVS_PRINT_INFO, "\n       Received DAbort Exception ", 0);
   val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));

--- a/test_pool/peripherals/test_m002.c
+++ b/test_pool/peripherals/test_m002.c
@@ -28,13 +28,13 @@ static void *branch_to_test;
 
 static
 void
-esr()
+esr(uint64_t interrupt_type, void *context)
 {
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
   uint64_t syndrome;
 
   /* Update the ELR to return to test specified address */
-  val_pe_update_elr((uint64_t)branch_to_test);
+  val_pe_update_elr(context, (uint64_t)branch_to_test);
 
   syndrome = val_pe_reg_read(ESR_EL2);
   syndrome &= 0x3F;    // Get the DFSC field from ESR

--- a/test_pool/secure/test_s002.c
+++ b/test_pool/secure/test_s002.c
@@ -28,12 +28,12 @@ static void *branch_to_test;
 
 static
 void
-esr()
+esr(uint64_t interrupt_type, void *context)
 {
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
   /* Update the ELR to return to test specified address */
-  val_pe_update_elr((uint64_t)branch_to_test);
+  val_pe_update_elr(context, (uint64_t)branch_to_test);
 
   val_print(AVS_PRINT_INFO, "\n       Received exception           ", 0);
   val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -82,7 +82,7 @@ typedef struct {
 
 void pal_pe_call_smc(ARM_SMC_ARGS *args);
 void pal_pe_execute_payload(ARM_SMC_ARGS *args);
-uint32_t pal_pe_install_esr(uint32_t exception_type, void (*esr)(void));
+uint32_t pal_pe_install_esr(uint32_t exception_type, void (*esr)(uint64_t, void *));
 /* ********** PE INFO END **********/
 
 
@@ -404,7 +404,7 @@ uint64_t pal_mem_get_shared_addr(void);
 uint32_t pal_mmio_read(uint64_t addr);
 void     pal_mmio_write(uint64_t addr, uint32_t data);
 
-void     pal_pe_update_elr(uint64_t offset);
+void     pal_pe_update_elr(void *context, uint64_t offset);
 void     pal_pe_data_cache_ops_by_va(uint64_t addr, uint32_t type);
 
 #define CLEAN_AND_INVALIDATE  0x1

--- a/val/include/sbsa_avs_pe.h
+++ b/val/include/sbsa_avs_pe.h
@@ -222,7 +222,7 @@ void DisableSpe(void);
 
 uint32_t BigEndianCheck(uint64_t *ptr);
 
-void val_pe_update_elr(uint32_t offset);
+void val_pe_update_elr(void *context, uint64_t offset);
 
 void val_pe_spe_program_under_profiling(uint64_t interval, addr_t address);
 

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -51,7 +51,7 @@ uint64_t val_pe_get_mpid_index(uint32_t index);
 uint32_t val_pe_get_pmu_gsiv(uint32_t index);
 uint64_t val_pe_get_mpid(void);
 uint32_t val_pe_get_index_mpid(uint64_t mpid);
-uint32_t val_pe_install_esr(uint32_t exception_type, void (*esr)(void));
+uint32_t val_pe_install_esr(uint32_t exception_type, void (*esr)(uint64_t, void *));
 
 void     val_execute_on_pe(uint32_t index, void (*payload)(void), uint64_t args);
 void     val_suspend_pe(uint32_t power_state, uint64_t entry, uint32_t context_id);

--- a/val/src/avs_pe.c
+++ b/val/src/avs_pe.c
@@ -318,30 +318,6 @@ val_pe_get_pmu_gsiv(uint32_t index)
 
 }
 
-
-/**
-  @brief   This API installs the Exception handler pointed
-           by the function pointer to the input exception type.
-           1. Caller       -  Test Suite
-           2. Prerequisite -  None
-  @param   exception_type - one of the four exceptions defined by AARCH64
-  @param   esr            - Function pointer of the exception handler
-  @return  0 if success or ERROR for invalid Exception type.
-**/
-uint32_t
-val_pe_install_esr(uint32_t exception_type, void (*esr)(void))
-{
-
-  if (exception_type > 3) {
-      val_print(AVS_PRINT_ERR, "Invalid Exception type %x \n", exception_type);
-      return AVS_STATUS_ERR;
-  }
-
-  pal_pe_install_esr(exception_type, esr);
-
-  return 0;
-}
-
 /**
   @brief   This API will call an assembly sequence with interval
            as argument over which an SPE event is exected to be generated.

--- a/val/src/avs_pe_infra.c
+++ b/val/src/avs_pe_infra.c
@@ -244,3 +244,26 @@ val_pe_cache_clean_range(uint64_t start_addr, uint64_t length)
       aligned_addr += line_length;
   }
 }
+
+/**
+  @brief   This API installs the Exception handler pointed
+           by the function pointer to the input exception type.
+           1. Caller       -  Test Suite
+           2. Prerequisite -  None
+  @param   exception_type - one of the four exceptions defined by AARCH64
+  @param   esr            - Function pointer of the exception handler
+  @return  0 if success or ERROR for invalid Exception type.
+**/
+uint32_t
+val_pe_install_esr(uint32_t exception_type, void (*esr)(uint64_t, void *))
+{
+
+  if (exception_type > 3) {
+      val_print(AVS_PRINT_ERR, "Invalid Exception type %x \n", exception_type);
+      return AVS_STATUS_ERR;
+  }
+
+  pal_pe_install_esr(exception_type, esr);
+
+  return 0;
+}

--- a/val/src/avs_status.c
+++ b/val/src/avs_status.c
@@ -73,7 +73,7 @@ val_set_status(uint32_t index, uint32_t status)
   mem = mem + index;
   mem->status = status;
 
-  val_data_cache_ops_by_va((addr_t)mem, CLEAN_AND_INVALIDATE);
+  val_data_cache_ops_by_va((addr_t)&mem->status, CLEAN_AND_INVALIDATE);
 }
 
 /**
@@ -91,7 +91,7 @@ val_get_status(uint32_t index)
   mem = (VAL_SHARED_MEM_t *) pal_mem_get_shared_addr();
   mem = mem + index;
 
-  val_data_cache_ops_by_va((addr_t)mem, INVALIDATE);
+  val_data_cache_ops_by_va((addr_t)&mem->status, INVALIDATE);
 
   return (uint32_t)(mem->status);
 

--- a/val/src/avs_test_infra.c
+++ b/val/src/avs_test_infra.c
@@ -198,7 +198,8 @@ val_set_test_data(uint32_t index, uint64_t addr, uint64_t test_data)
   mem->data0 = addr;
   mem->data1 = test_data;
 
-  val_data_cache_ops_by_va((addr_t)mem, CLEAN_AND_INVALIDATE);
+  val_data_cache_ops_by_va((addr_t)&mem->data0, CLEAN_AND_INVALIDATE);
+  val_data_cache_ops_by_va((addr_t)&mem->data1, CLEAN_AND_INVALIDATE);
 }
 
 /**
@@ -227,7 +228,8 @@ val_get_test_data(uint32_t index, uint64_t *data0, uint64_t *data1)
   mem = (VAL_SHARED_MEM_t *) pal_mem_get_shared_addr();
   mem = mem + index;
 
-  val_data_cache_ops_by_va((addr_t)mem, INVALIDATE);
+  val_data_cache_ops_by_va((addr_t)&mem->data0, INVALIDATE);
+  val_data_cache_ops_by_va((addr_t)&mem->data1, INVALIDATE);
 
   *data0 = mem->data0;
   *data1 = mem->data1;
@@ -379,7 +381,7 @@ val_data_cache_ops_by_va(addr_t addr, uint32_t type)
   @brief  Update ELR based on the offset provided
 **/
 void
-val_pe_update_elr(uint32_t offset)
+val_pe_update_elr(void *context, uint64_t offset)
 {
-    pal_pe_update_elr(offset);
+    pal_pe_update_elr(context, offset);
 }


### PR DESCRIPTION
- API to update ELR will now use UEFI APIs instead of relying on assembly sequence.

- PMUIRQ test will now include init code for few registers so that they are in know state before programming the interrupt

- Cache ops to happen on the struct member accessed, instead of base memory pointer