### PR TITLE
Changed the timeout value

### DIFF
--- a/test_pool/power_wakeup/test_u001.c
+++ b/test_pool/power_wakeup/test_u001.c
@@ -216,7 +216,7 @@ void
 payload5()
 {
   uint64_t cnt_base_n;
-  uint32_t timeout = TIMEOUT_MEDIUM;
+  uint32_t timeout = 100000;
   uint32_t status;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 


### PR DESCRIPTION
The timeout value TIMEOUT_MEDIUM was very high compared to the
timeout value of failsafe interrupt as a result of which the failsafe
interrupt occurs before system timer interrupt causing the testcase to
fail

Signed-off-by: Chandni Cherukuri <chandni.cherukuri@arm.com>