### PR TITLE
Updated interrupt tests to generate interrupt from all platform timers

### DIFF
--- a/linux_app/sbsa-acs-app/sbsa_app_main.c
+++ b/linux_app/sbsa-acs-app/sbsa_app_main.c
@@ -108,16 +108,16 @@ main (int argc, char **argv)
     }
 
 
-    printf ("\n ************ SBSA Architecture Compliance Suite ********* \n");
-    printf ("                version %d.%d  \n", SBSA_APP_VERSION_MAJOR, SBSA_APP_VERSION_MINOR);
+    printf ("\n ************ SBSA Architectural Suite ********* \n");
+    printf ("                Version %d.%d  \n", SBSA_APP_VERSION_MAJOR, SBSA_APP_VERSION_MINOR);
 
 
-    printf ("\n Starting Compliance verification for Level %2d (Print level is %2d)\n\n", g_sbsa_level, g_print_level);
+    printf ("\n Starting tests for level %2d (Print level is %2d)\n\n", g_sbsa_level, g_print_level);
 
-    printf (" Gathering System information.... \n");
+    printf (" Gathering system information.... \n");
     status = initialize_test_environment(g_print_level);
     if (status) {
-        printf ("Cannot Initialize test environment. Exiting.... \n");
+        printf ("Cannot initialize test environment. Exiting.... \n");
         return 0;
     }
 
@@ -125,7 +125,7 @@ main (int argc, char **argv)
     execute_tests_pcie(1, g_sbsa_level, g_print_level);
 
 
-    printf("\n   *** SBSA Compliance Test Complete *** \n\n");
+    printf("\n   *** SBSA tests complete *** \n\n");
 
     cleanup_test_environment();
 

--- a/test_pool/pcie/test_p015.c
+++ b/test_pool/pcie/test_p015.c
@@ -19,7 +19,7 @@
 #include "val/include/sbsa_avs_pcie.h"
 
 #define TEST_NUM   (AVS_PCIE_TEST_NUM_BASE + 15)
-#define TEST_DESC  "PCIe No Snoop transaction attribute"
+#define TEST_DESC  "PCIe No Snoop transaction attr    "
 
 static
 void

--- a/test_pool/pe/test_c015.c
+++ b/test_pool/pe/test_c015.c
@@ -177,29 +177,30 @@ payload(uint32_t num_pe)
   uint32_t timeout;
   uint64_t debug_data=0, array_index=0;
 
-  for (i = 0; i < NUM_OF_REGISTERS; i++)
-  {
+  if (num_pe == 1) {
+      val_print(AVS_PRINT_WARN, "\n       Skipping as num of PE is 1        ", 0);
+      val_set_status(my_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+      return;
+  }
+
+  for (i = 0; i < NUM_OF_REGISTERS; i++) {
       rd_data_array[i] = return_reg_value(reg_list[i].reg_name, reg_list[i].dependency);
       val_data_cache_ops_by_va((addr_t)(rd_data_array + i), CLEAN_AND_INVALIDATE);
   }
 
-  for (i = 0; i < num_pe; i++)
-  {
-      if (i != my_index)
-      {
+  for (i = 0; i < num_pe; i++) {
+      if (i != my_index) {
           timeout=TIMEOUT_LARGE;
           val_execute_on_pe(i, id_regs_check, 0);
           while ((--timeout) && (IS_RESULT_PENDING(val_get_status(i))));
 
-          if(timeout == 0)
-          {
-              val_print(AVS_PRINT_ERR, "\n **Timed out** for PE index = %d", i);
+          if(timeout == 0) {
+              val_print(AVS_PRINT_ERR, "\n       **Timed out** for PE index = %d", i);
               val_set_status(i, RESULT_FAIL(g_sbsa_level, TEST_NUM, 02));
               return;
           }
 
-          if(IS_TEST_FAIL(val_get_status(i)))
-          {
+          if(IS_TEST_FAIL(val_get_status(i))) {
               val_get_test_data(i, &debug_data, &array_index);
               val_print(AVS_PRINT_ERR, "\n       Reg compare failed for PE index=%d for Register: ", i);
               val_print(AVS_PRINT_ERR, reg_list[array_index].reg_desc, 0);

--- a/test_pool/peripherals/test_d003.c
+++ b/test_pool/peripherals/test_d003.c
@@ -80,7 +80,7 @@ void
 uart_disable_txintr()
 {
   uint32_t data;
-  
+
   /* mask TX interrupt bit 5 in */
   data = uart_reg_read(SBSA_UARTIMSC, WIDTH_BIT32);
   data = data & (~(1<<5));
@@ -211,7 +211,7 @@ payload1()
           val_set_status(index, RESULT_PENDING(g_sbsa_level, TEST_NUM2));
           val_gic_install_isr(int_id, isr);
           uart_enable_txintr();
-          val_print(AVS_PRINT_DEBUG, "\n      Test Message                   ", 0);
+          val_print(g_print_level, "\n      Test Message                   ", 0);
       } else {
           val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM2, 01));
       }

--- a/test_pool/power_wakeup/test_u001.c
+++ b/test_pool/power_wakeup/test_u001.c
@@ -209,7 +209,6 @@ payload4()
       } else {
           val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM4, 01));
       }
-      break;
   }
 
   if(!ns_wdg){
@@ -274,7 +273,6 @@ payload5()
           val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM5, 01));
           return;
       }
-      break;
   }
 
   if(!ns_timer){

--- a/test_pool/secure/test_s001.c
+++ b/test_pool/secure/test_s001.c
@@ -39,9 +39,9 @@ static
 void
 payload()
 {
-  uint32_t int_id_ws0, int_id_ws1;
-  uint64_t wd_num = 1; //val_wd_get_info(0, INFO_WD_COUNT);
-  uint32_t timeout = 2, timeout_intr=TIMEOUT_LARGE;
+  uint32_t int_id_ws0, int_id_ws1, ns_wdg = 0;
+  uint64_t wd_num = val_wd_get_info(0, WD_INFO_COUNT);
+  uint32_t timeout = 2, timeout_intr;
   uint32_t timer_expire_ticks = 1000;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
@@ -49,8 +49,8 @@ payload()
 
 
   if (wd_num == 0) {
-      //no watchdogs in the system. Fail this test and return
-      val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
+      val_print(AVS_PRINT_WARN, "\n       No Watchdogs reported          %d  ", wd_num);
+      val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
       return;
   }
 
@@ -60,6 +60,10 @@ payload()
 
       if (val_wd_get_info(wd_num, WD_INFO_ISSECURE))
           continue;    //Skip Secure watchdog
+
+      ns_wdg++;
+      timeout_intr = TIMEOUT_LARGE;
+      val_set_status(index, RESULT_PENDING(g_sbsa_level, TEST_NUM));     // Set the initial result to pending
 
       int_id_ws0 = val_wd_get_info(wd_num, WD_INFO_GSIV);
       int_id_ws1 = val_wd_get_info(wd_num+1, WD_INFO_GSIV);  // ACPI table for WS1 may need to be populated
@@ -97,13 +101,19 @@ payload()
               val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 03));
       }
 
+      // Stop watchdog and signal end of interrupt to gic, it should be done after receiving both
+      // WS0 and WS1 interrupts
+      val_wd_set_ws0(wd_num, 0);
+      val_gic_end_of_interrupt(int_id_ws0);
 
   }while(wd_num);
 
-  // Stop watchdog and signal end of interrupt to gic, it should be done after receiving both
-  // WS0 and WS1 interrupts
-  val_wd_set_ws0(0, 0);
-  val_gic_end_of_interrupt(int_id_ws0);
+  if(!ns_wdg) {
+      val_print(AVS_PRINT_WARN, "\n       No non-secure Watchdogs reported", 0);
+      val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 02));
+      return;
+  }
+
 }
 
 uint32_t

--- a/test_pool/timer_wd/test_t007.c
+++ b/test_pool/timer_wd/test_t007.c
@@ -114,18 +114,10 @@ payload()
           return;
       }
 
-      data = 0xA5A500FF;
-      val_mmio_write(cnt_base_n + 0x28, data);
-      if(data != val_mmio_read(cnt_base_n + 0x28)) {
-          val_print(AVS_PRINT_ERR, "\n       Read-write check failed for CNTBaseN.CNTP_TVAL, expected value %x ", data);
-          val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 0x8));
-          return;
-      }
-
       data = val_mmio_read(cnt_base_n + 0xFD0);
       if ((data == 0x0) || ((data & 0xFFFF) == 0xFFFF)) {
           val_print(AVS_PRINT_ERR, "\n      Unexpected value for CNTBaseN.CounterID %x  ", data);
-          val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 0x9));
+          val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 0x8));
           return;
       }
 

--- a/test_pool/timer_wd/test_w001.c
+++ b/test_pool/timer_wd/test_w001.c
@@ -31,13 +31,13 @@ payload()
   uint64_t refresh_base;
   uint64_t wd_num = val_wd_get_info(0, WD_INFO_COUNT);
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
-  uint32_t data;
+  uint32_t data, ns_wdg = 0;
 
   val_print(AVS_PRINT_DEBUG, "\n       Found %d watchdogs in ACPI table ", wd_num);
 
   if (wd_num == 0) {
       val_print(AVS_PRINT_WARN, "\n       No Watchdogs reported          %d  ", wd_num);
-      val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+      val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
       return;
   }
 
@@ -47,6 +47,7 @@ payload()
       if (val_wd_get_info(wd_num, WD_INFO_ISSECURE))
           continue;    //Skip Secure watchdog
 
+      ns_wdg++;
       refresh_base = val_wd_get_info(wd_num, WD_INFO_REFRESH_BASE);
       val_print(AVS_PRINT_INFO, "\n      Watchdog Refresh base is %x ", refresh_base);
       ctrl_base    = val_wd_get_info(wd_num, WD_INFO_CTRL_BASE);
@@ -66,6 +67,12 @@ payload()
           return;
       }
   } while(wd_num);
+
+  if(!ns_wdg) {
+      val_print(AVS_PRINT_WARN, "\n       No non-secure Watchdogs reported", 0);
+      val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 02));
+      return;
+  }
 
   val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
 

--- a/test_pool/timer_wd/test_w002.c
+++ b/test_pool/timer_wd/test_w002.c
@@ -24,20 +24,14 @@
 #define TEST_DESC  "Check Watchdog WS0 interrupt      "
 
 static uint32_t int_id;
+static uint64_t wd_num;
 
 static
 void
 isr()
 {
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
-//  uint64_t wd_num = val_wd_get_info(0, WD_INFO_COUNT);
-
-  /* We received our interrupt, we don't know which WD instance generated
-     the interrupt, so just ahead and disable all */
-//  while(wd_num)
-//    val_wd_set_ws0(wd_num, 0);
-
-  val_wd_set_ws0(0, 0);
+  val_wd_set_ws0(wd_num, 0);
   val_print(AVS_PRINT_DEBUG, "\n       Received WS0 interrupt            ", 0);
   val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
   val_gic_end_of_interrupt(int_id);
@@ -49,14 +43,14 @@ void
 payload()
 {
 
-  uint64_t wd_num = 1; //val_wd_get_info(0, INFO_WD_COUNT);
-  uint32_t timeout = TIMEOUT_LARGE;
+  uint32_t timeout, ns_wdg = 0;
   uint64_t timer_expire_ticks = 100;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
+  wd_num = val_wd_get_info(0, WD_INFO_COUNT);
 
 
   if (wd_num == 0) {
-      //no watchdogs in the system. Fail this test and return
+      val_print(AVS_PRINT_WARN, "\n       No Watchdogs reported          %d  ", wd_num);
       val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
       return;
   }
@@ -66,6 +60,10 @@ payload()
 
       if (val_wd_get_info(wd_num, WD_INFO_ISSECURE))
           continue;    //Skip Secure watchdog
+
+      ns_wdg++;
+      timeout = TIMEOUT_LARGE;
+      val_set_status(index, RESULT_PENDING(g_sbsa_level, TEST_NUM));     // Set the initial result to pending
 
       int_id       = val_wd_get_info(wd_num, WD_INFO_GSIV);
       val_print(AVS_PRINT_DEBUG, "\n       WS0 Interrupt id  %d        ", int_id);
@@ -78,11 +76,17 @@ payload()
 
       if (timeout == 0) {
           val_print(AVS_PRINT_ERR, "\n       WS0 Interrupt not received on %d   ", int_id);
-          val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
+          val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 02));
           return;
       }
 
   } while(wd_num);
+
+  if(!ns_wdg) {
+      val_print(AVS_PRINT_WARN, "\n       No non-secure Watchdogs reported", 0);
+      val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 02));
+      return;
+  }
 
 }
 

--- a/uefi_app/SbsaAvsMain.c
+++ b/uefi_app/SbsaAvsMain.c
@@ -373,11 +373,11 @@ ShellAppMain (
   g_sbsa_tests_pass  = 0;
   g_sbsa_tests_fail  = 0;
 
-  Print(L"\n\n SBSA Compliance Suite \n");
+  Print(L"\n\n SBSA Architectural Suite \n");
   Print(L"    Version %d.%d  \n", SBSA_ACS_MAJOR_VER, SBSA_ACS_MINOR_VER);
 
 
-  Print(L"\n Starting Compliance verification for Level %2d (Print level is %2d)\n\n", g_sbsa_level, g_print_level);
+  Print(L"\n Starting tests for level %2d (Print level is %2d)\n\n", g_sbsa_level, g_print_level);
 
 
   Print(L" Creating Platform Information Tables \n");
@@ -405,7 +405,7 @@ ShellAppMain (
   if (g_execute_secure == TRUE) {
     Print(L"\n      ***  Starting Secure FW tests ***  \n");
     val_secure_execute_tests(g_sbsa_level, val_pe_get_num());
-    Print(L"\n      ***  Secure FW tests Completed ***  \n");
+    Print(L"\n      ***  Secure FW tests completed ***  \n");
   }
 
   Print(L"\n      ***  Starting PE tests ***  \n");
@@ -445,7 +445,7 @@ print_test_status:
     ShellCloseFile(&g_sbsa_log_file_handle);
   }
 
-  Print(L"\n      *** SBSA Compliance Test Complete. Reset the System. *** \n\n");
+  Print(L"\n      *** SBSA tests complete. Reset the system. *** \n\n");
 
   val_pe_context_restore(AA64WriteSp(g_stack_pointer));
 


### PR DESCRIPTION
All watchdogs and system timers would generate interrupt now instead of one.
Removed whitespace, removed check for CNTP_TVAL read-write test.