### PR TITLE
psci: enhance PSCI_CPU_ON error handling

### DIFF
--- a/val/src/avs_status.c
+++ b/val/src/avs_status.c
@@ -40,10 +40,10 @@ val_report_status(uint32_t index, uint32_t status)
     val_print(AVS_PRINT_TEST, ": Result:  PASS \n", status);
   else
     if (IS_TEST_FAIL(status))
-      val_print(AVS_PRINT_ERR, ": Result:  --FAIL-- %x \n", status & 0xFF);
+      val_print(AVS_PRINT_ERR, ": Result:  --FAIL-- %x \n", status & 0xFFFF);
     else
       if (IS_TEST_SKIP(status))
-        val_print(AVS_PRINT_WARN, ": Result:  -SKIPPED- %x \n", status & 0xFF);
+        val_print(AVS_PRINT_WARN, ": Result:  -SKIPPED- %x \n", status & 0xFFFF);
       else
         if (IS_TEST_START(status))
           val_print(AVS_PRINT_INFO, "         START  ", status);


### PR DESCRIPTION
1. Wait for a fixed time period for the cpu
   to turn off, if its already on. Assumption
   being that cpu off operation is still pending.

2. Maximum size for error code values increased
   to 16 bits.

Signed-off-by: Sakar Arora <sakar.arora@arm.com>