### PR TITLE
pcie: fallback on PciIoProtocol to read config

### DIFF
--- a/test_pool/peripherals/test_d001.c
+++ b/test_pool/peripherals/test_d001.c
@@ -43,11 +43,17 @@ payload()
       interface = val_pcie_read_cfg(bdf, 0x8);
       interface = (interface >> 8) & 0xFF;
       if ((interface < 0x20) || (interface == 0xFF)) {
-          val_print(AVS_PRINT_ERR, "\n       Detected USB CTRL not EHCI/XHCI %d  ", interface);
-          val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
-          return;
-      }
+          val_print(AVS_PRINT_WARN, "\n       WARN: Using ECAM access, USB CTRL detected is not EHCI/XHCI 0x%x  ", interface);
+          val_print(AVS_PRINT_WARN, "\n       Re-checking USB CTRL using PciIo protocol       ", 0);
+          interface = val_pcie_io_read_cfg(bdf, 0x8);
+          interface = (interface >> 8) & 0xFF;
+          if ((interface < 0x20) || (interface == 0xFF)) {
+              val_print(AVS_PRINT_ERR, "\n       Detected USB CTRL not EHCI/XHCI 0x%x  ", interface);
+              val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
+              return;
+          }
       count--;
+    }
   }
   val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
   return;

--- a/test_pool/peripherals/test_d002.c
+++ b/test_pool/peripherals/test_d002.c
@@ -43,9 +43,15 @@ payload()
       interface = val_pcie_read_cfg(bdf, 0x8);
       interface = (interface >> 8) & 0xFF;
       if (interface != 0x01) {
-          val_print(AVS_PRINT_ERR, "\n Detected SATA CTRL not AHCI        ", 0);
-          val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
-          return;
+          val_print(AVS_PRINT_WARN, "\n       WARN: Using ECAM access, SATA CTRL detected is not AHCI %x  ", interface);
+          val_print(AVS_PRINT_WARN, "\n       Re-checking SATA CTRL using PciIo protocol       ", 0);
+          interface = val_pcie_io_read_cfg(bdf, 0x8);
+          interface = (interface >> 8) & 0xFF;
+          if (interface != 0x01) {
+              val_print(AVS_PRINT_ERR, "\n Detected SATA CTRL not AHCI        ", 0);
+              val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
+              return;
+          }
       }
       count--;
   }

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -221,6 +221,7 @@ typedef struct {
 
 uint64_t pal_pcie_get_mcfg_ecam(void);
 void     pal_pcie_create_info_table(PCIE_INFO_TABLE *PcieTable);
+uint32_t pal_pcie_read_cfg(uint32_t bdf, uint32_t offset);
 
 /**
   @brief  Instance of SMMU INFO block

--- a/val/include/sbsa_avs_pcie.h
+++ b/val/include/sbsa_avs_pcie.h
@@ -66,6 +66,9 @@ uint32_t
 val_pcie_get_dma_coherent(uint32_t bdf);
 
 uint32_t
+val_pcie_io_read_cfg(uint32_t bdf, uint32_t offset);
+
+uint32_t
 p001_entry(uint32_t num_pe);
 
 uint32_t

--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -45,6 +45,7 @@ val_pcie_read_cfg(uint32_t bdf, uint32_t offset)
   addr_t   ecam_base = 0;
   uint32_t i = 0;
 
+
   if ((bus >= PCIE_MAX_BUS) || (dev >= PCIE_MAX_DEV) || (func >= PCIE_MAX_FUNC)) {
      val_print(AVS_PRINT_ERR, "Invalid Bus/Dev/Func  %x \n", bdf);
      return 0;
@@ -80,6 +81,22 @@ val_pcie_read_cfg(uint32_t bdf, uint32_t offset)
 
   return pal_mmio_read(ecam_base + cfg_addr + offset);
 
+}
+
+/**
+  @brief   Read 32bit data  from PCIe config space pointed by Bus,
+           Device, Function and offset using UEFI PciIoProtocol interface
+           1. Caller       -  Test Suite
+           2. Prerequisite -  val_pcie_create_info_table
+  @param   bdf    - concatenated Bus(8-bits), device(8-bits) & function(8-bits)
+  @param   offset - Register offset within a device PCIe config space
+
+  @return  32-bit data read from the config space
+**/
+uint32_t
+val_pcie_io_read_cfg(uint32_t bdf, uint32_t offset)
+{
+    return pal_pcie_read_cfg(bdf, offset);
 }
 
 /**


### PR DESCRIPTION
Added to support testing emulated PCIe devices in UEFI.
Such systems are not recommended by SBSA, and whether such systems
are fully SBSA compliant will be decided on case to case basis.

Signed-off-by: Sakar Arora <sakar.arora@arm.com>