### PR TITLE
bug fixes for test #15 and test #71

### DIFF
--- a/linux_app/sbsa-acs-app/include/sbsa_app.h
+++ b/linux_app/sbsa-acs-app/include/sbsa_app.h
@@ -20,7 +20,7 @@
 
 
 #define SBSA_APP_VERSION_MAJOR  1
-#define SBSA_APP_VERSION_MINOR  0
+#define SBSA_APP_VERSION_MINOR  1
 
 #include "sbsa_drv_intf.h"
 

--- a/test_pool/io_virt/test_i004.c
+++ b/test_pool/io_virt/test_i004.c
@@ -50,7 +50,7 @@ payload()
 
   while (num_smmu--) {
       if (val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu) == 2) {
-          val_print(AVS_PRINT_WARN, "\n        Not Valid for SMMU v2       ", 0);
+          val_print(AVS_PRINT_WARN, "\n        Not valid for SMMU v2           ", 0);
           val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
           return;
       }

--- a/test_pool/io_virt/test_i005.c
+++ b/test_pool/io_virt/test_i005.c
@@ -39,7 +39,7 @@ payload()
 
   while (num_smmu--) {
       if (val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu) == 3) {
-          val_print(AVS_PRINT_WARN, "\n        Not Valid for SMMU v3       ", 0);
+          val_print(AVS_PRINT_WARN, "\n        Not valid for SMMU v3           ", 0);
           val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 2));
           return;
       }

--- a/test_pool/pe/test_c015.c
+++ b/test_pool/pe/test_c015.c
@@ -34,7 +34,7 @@
 #define MASK_CCSIDR       0xFFFFFF0
 #define MASK_PMCR         0xFFFF
 
-#define MAX_CACHE_LEVEL   8
+#define MAX_CACHE_LEVEL   7
 
 uint64_t rd_data_array[NUM_OF_REGISTERS];
 uint64_t cache_list[MAX_CACHE_LEVEL];

--- a/test_pool/pe/test_c015.c
+++ b/test_pool/pe/test_c015.c
@@ -34,7 +34,10 @@
 #define MASK_CCSIDR       0xFFFFFF0
 #define MASK_PMCR         0xFFFF
 
+#define MAX_CACHE_LEVEL   8
+
 uint64_t rd_data_array[NUM_OF_REGISTERS];
+uint64_t cache_list[MAX_CACHE_LEVEL];
 
 typedef struct{
     uint32_t reg_name;
@@ -44,6 +47,7 @@ typedef struct{
 }reg_details;
 
 reg_details reg_list[] = {
+    {CCSIDR_EL1,       MASK_CCSIDR,    "CCSIDR_EL1"      , 0x0 },
     {ID_AA64PFR0_EL1,  0x0,            "ID_AA64PFR0_EL1" , 0x0 },
     {ID_AA64PFR1_EL1,  0x0,            "ID_AA64PFR1_EL1" , 0x0 },
     {ID_AA64DFR0_EL1,  0x0,            "ID_AA64DFR0_EL1" , 0x0 },
@@ -56,7 +60,6 @@ reg_details reg_list[] = {
     {ID_AA64ISAR1_EL1, 0x0,            "ID_AA64ISAR1_EL1", 0x0 },
     {MPIDR_EL1,        MASK_MPIDR,     "MPIDR_EL1"       , 0x0 },
     {MIDR_EL1,         MASK_MIDR,      "MIDR_EL1"        , 0x0 },
-    {CCSIDR_EL1,       MASK_CCSIDR,    "CCSIDR_EL1"      , 0x0 },
     {ID_DFR0_EL1,      0x0,            "ID_DFR0_EL1"     , AA32},
     {ID_ISAR0_EL1,     0x0,            "ID_ISAR0_EL1"    , AA32},
     {ID_ISAR1_EL1,     0x0,            "ID_ISAR1_EL1"    , AA32},
@@ -145,10 +148,26 @@ id_regs_check(void)
 {
   uint64_t reg_read_data;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
-  uint32_t i;
+  uint32_t i = 0;
 
-  for (i = 0; i < NUM_OF_REGISTERS; i++)
-  {
+  /* Loop CLIDR to check if a cache level is implemented before comparing */
+  while (i < MAX_CACHE_LEVEL) {
+      reg_read_data = val_pe_reg_read(CLIDR_EL1);
+      if (reg_read_data & ((0x7) << (i * 3))) {
+          /* Select the correct cache in csselr register */
+          val_pe_reg_write(CSSELR_EL1, i << 1);
+          reg_read_data = return_reg_value(reg_list[0].reg_name, reg_list[i].dependency);
+
+          if ((reg_read_data & (~reg_list[0].reg_mask)) != (cache_list[i] & (~reg_list[0].reg_mask))) {
+              val_set_test_data(index, (reg_read_data & (~reg_list[i].reg_mask)), 0);
+              val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
+              return;
+          }
+      }
+      i++;
+  }
+
+  for (i = 1; i < NUM_OF_REGISTERS; i++) {
       reg_read_data = return_reg_value(reg_list[i].reg_name, reg_list[i].dependency);
 
       if((reg_read_data & (~reg_list[i].reg_mask)) != (rd_data_array[i] & (~reg_list[i].reg_mask)))
@@ -171,7 +190,7 @@ payload(uint32_t num_pe)
   uint32_t my_index = val_pe_get_index_mpid(val_pe_get_mpid());
   uint32_t i;
   uint32_t timeout;
-  uint64_t debug_data=0, array_index=0;
+  uint64_t reg_read_data, debug_data=0, array_index=0;
 
   if (num_pe == 1) {
       val_print(AVS_PRINT_WARN, "\n       Skipping as num of PE is 1        ", 0);
@@ -179,7 +198,20 @@ payload(uint32_t num_pe)
       return;
   }
 
-  for (i = 0; i < NUM_OF_REGISTERS; i++) {
+  /* Loop CLIDR to check if a cache level is implemented */
+  i = 0;
+  while (i < MAX_CACHE_LEVEL) {
+      reg_read_data = val_pe_reg_read(CLIDR_EL1);
+      if (reg_read_data & ((0x7) << (i * 3))) {
+         /* Select the correct cache level in csselr register */
+         val_pe_reg_write(CSSELR_EL1, i << 1);
+         cache_list[i] = return_reg_value(reg_list[0].reg_name, reg_list[i].dependency);
+         val_print(AVS_PRINT_INFO, "\n      cache size read is %x ", cache_list[i]);
+      }
+      i++;
+  }
+
+  for (i = 1; i < NUM_OF_REGISTERS; i++) {
       rd_data_array[i] = return_reg_value(reg_list[i].reg_name, reg_list[i].dependency);
       val_data_cache_ops_by_va((addr_t)(rd_data_array + i), CLEAN_AND_INVALIDATE);
   }

--- a/test_pool/pe/test_c015.c
+++ b/test_pool/pe/test_c015.c
@@ -31,7 +31,7 @@
 #define MASK_MIDR         0x00F0FFFF
 #define MASK_MPIDR        0xFF3FFFFFFF
 #define MASK_CTR          0xC000
-#define MASK_CCSIDR       0xFFFFFF0
+#define MASK_CCSIDR       0xFFFFFF8
 #define MASK_PMCR         0xFFFF
 
 #define MAX_CACHE_LEVEL   7

--- a/test_pool/power_wakeup/test_u001.c
+++ b/test_pool/power_wakeup/test_u001.c
@@ -230,7 +230,7 @@ payload5()
 
   timer_num = val_timer_get_info(TIMER_INFO_NUM_PLATFORM_TIMERS, 0);
   if(!timer_num){
-      val_print(AVS_PRINT_WARN, "\n       No system timers implemented   ", 0);
+      val_print(AVS_PRINT_WARN, "\n       No system timers implemented      ", 0);
       val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM5, 01));
       return;
   }

--- a/uefi_app/SbsaAvs.h
+++ b/uefi_app/SbsaAvs.h
@@ -20,7 +20,7 @@
 
 
   #define SBSA_ACS_MAJOR_VER  1
-  #define SBSA_ACS_MINOR_VER  0
+  #define SBSA_ACS_MINOR_VER  1
 
   #define G_SBSA_LEVEL  3
   #define G_PRINT_LEVEL AVS_PRINT_TEST

--- a/val/include/sbsa_avs_pe.h
+++ b/val/include/sbsa_avs_pe.h
@@ -52,6 +52,7 @@ typedef enum {
   MDCR_EL2,
   VBAR_EL2,
   CCSIDR_EL1,
+  CSSELR_EL1,
   CLIDR_EL1,
   ID_DFR0_EL1,
   ID_ISAR0_EL1,
@@ -143,6 +144,10 @@ void AA64WritePmintenclr(uint64_t write_data);
 
 uint64_t AA64ReadCcsidr(void);
 
+uint64_t AA64ReadCsselr(void);
+
+void AA64WriteCsselr(uint64_t write_data);
+
 uint64_t AA64ReadClidr(void);
 
 uint64_t ArmReadDfr0(void);
@@ -222,6 +227,8 @@ uint64_t AA64ReadSp(void);
 uint64_t AA64WriteSp(uint64_t write_data);
 
 uint64_t AA64ReadFar2(void);
+
+void ArmCallWFI(void);
 
 void SpeProgramUnderProfiling(uint64_t interval, uint64_t address);
 

--- a/val/src/AArch64/PeRegSysSupport.S
+++ b/val/src/AArch64/PeRegSysSupport.S
@@ -65,6 +65,8 @@ GCC_ASM_EXPORT (AA64WritePmintenset)
 GCC_ASM_EXPORT (AA64WritePmovsclr)
 GCC_ASM_EXPORT (AA64WritePmintenclr)
 GCC_ASM_EXPORT (AA64ReadCcsidr)
+GCC_ASM_EXPORT (AA64ReadCsselr)
+GCC_ASM_EXPORT (AA64WriteCsselr)
 GCC_ASM_EXPORT (AA64ReadClidr)
 GCC_ASM_EXPORT (ArmReadDfr0)
 GCC_ASM_EXPORT (ArmReadIsar0)
@@ -216,6 +218,15 @@ ASM_PFX(AA64WritePmintenclr):
 
 ASM_PFX(AA64ReadCcsidr):
   mrs   x0, ccsidr_el1
+  ret
+
+ASM_PFX(AA64ReadCsselr):
+  mrs   x0, csselr_el1
+  ret
+
+ASM_PFX(AA64WriteCsselr):
+  msr   csselr_el1, x0
+  isb
   ret
 
 ASM_PFX(AA64ReadClidr):

--- a/val/src/AArch64/PeTestSupport.S
+++ b/val/src/AArch64/PeTestSupport.S
@@ -19,9 +19,14 @@
 .text
 .align 3
 
+GCC_ASM_EXPORT (ArmCallWFI)
 GCC_ASM_EXPORT (SpeProgramUnderProfiling)
 GCC_ASM_EXPORT (DisableSpe)
 GCC_ASM_EXPORT (BigEndianCheck)
+
+ASM_PFX(ArmCallWFI):
+  wfi
+  ret
 
 ASM_PFX(SpeProgramUnderProfiling):
   mov   x2,#12    // No of instructions in the loop

--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -198,7 +198,7 @@ val_pcie_execute_tests(uint32_t level, uint32_t num_pe)
   status |= p005_entry(num_pe);
   status |= p006_entry(num_pe);
   status |= p007_entry(num_pe);
-  status |= p008_entry(num_pe);
+//test needs to be changed  status |= p008_entry(num_pe);
   status |= p009_entry(num_pe);
   status |= p010_entry(num_pe);
   status |= p011_entry(num_pe);

--- a/val/src/avs_pe.c
+++ b/val/src/avs_pe.c
@@ -133,6 +133,8 @@ val_pe_reg_read(uint32_t reg_id)
           return AA64ReadVbar2();
       case CCSIDR_EL1:
           return AA64ReadCcsidr();
+      case CSSELR_EL1:
+          return AA64ReadCsselr();
       case CLIDR_EL1:
           return AA64ReadClidr();
       case ID_DFR0_EL1:
@@ -220,6 +222,9 @@ val_pe_reg_write(uint32_t reg_id, uint64_t write_data)
 {
 
   switch(reg_id) {
+      case CSSELR_EL1:
+          AA64WriteCsselr(write_data);
+          break;
       case PMCR_EL0:
           AA64WritePmcr(write_data);
           break;

--- a/val/src/avs_wakeup.c
+++ b/val/src/avs_wakeup.c
@@ -66,7 +66,6 @@ val_suspend_pe(uint32_t power_state, uint64_t entry, uint32_t context_id)
   smc_args.Arg2 = entry;
   smc_args.Arg3 = context_id;
   pal_pe_call_smc(&smc_args);
-
 }
 
 
@@ -82,7 +81,7 @@ val_power_enter_semantic(SBSA_POWER_SEM_e semantic)
 
   switch(semantic) {
       case SBSA_POWER_SEM_B:
-          val_suspend_pe(0, 0, 0);
+          ArmCallWFI();
           break;
       default:
           break;


### PR DESCRIPTION
Test #15 more robust - first select the cache level before doing a compare of the values.
Test #71 - use wfi instruction instead of PSCI_SUSPEND as wfi is architecturally consistent across platforms.
remove test #58 from the runlist. This test requires a design change.