### PR TITLE
pal/uefi: iort: Support PMCG nodes

### DIFF
--- a/platform/pal_uefi/include/pal_iovirt.h
+++ b/platform/pal_uefi/include/pal_iovirt.h
@@ -89,6 +89,12 @@ typedef struct {
         UINT32 gerr_gsiv;
         UINT32 sync_gsiv;
 }IORT_SMMU_V3;
+
+typedef struct {
+        UINT64 base_address;
+        UINT32 overflow_interrupt_gsiv;
+        UINT32 node_reference;
+}IORT_PMCG;
 #pragma pack()
 
 #endif

--- a/platform/pal_uefi/include/pal_uefi.h
+++ b/platform/pal_uefi/include/pal_uefi.h
@@ -182,23 +182,30 @@ typedef struct {
 }SMMU_INFO_BLOCK;
 
 typedef struct {
-	UINT32 segment;
-	UINT32 ats_attr;
-	UINT32 cca;			//Cache Coherency Attribute
+  UINT32 segment;
+  UINT32 ats_attr;
+  UINT32 cca;             //Cache Coherency Attribute
 }IOVIRT_RC_INFO_BLOCK;
+
+typedef struct {
+  UINT64 base;
+  UINT32 overflow_gsiv;
+  UINT32 node_ref;
+} IOVIRT_PMCG_INFO_BLOCK;
 
 typedef enum {
   IOVIRT_NODE_ITS_GROUP = 0x00,
   IOVIRT_NODE_NAMED_COMPONENT = 0x01,
   IOVIRT_NODE_PCI_ROOT_COMPLEX = 0x02,
   IOVIRT_NODE_SMMU = 0x03,
-  IOVIRT_NODE_SMMU_V3 = 0x04
+  IOVIRT_NODE_SMMU_V3 = 0x04,
+  IOVIRT_NODE_PMCG = 0x05
 }IOVIRT_NODE_TYPE;
 
 typedef enum {
-        IOVIRT_FLAG_DEVID_OVERLAP_SHIFT,
-        IOVIRT_FLAG_STRID_OVERLAP_SHIFT,
-        IOVIRT_FLAG_SMMU_CTX_INT_SHIFT,
+  IOVIRT_FLAG_DEVID_OVERLAP_SHIFT,
+  IOVIRT_FLAG_STRID_OVERLAP_SHIFT,
+  IOVIRT_FLAG_SMMU_CTX_INT_SHIFT,
 }IOVIRT_FLAG_SHIFT;
 
 typedef struct {
@@ -216,6 +223,7 @@ typedef union {
 typedef union {
   CHAR8 name[16];
   IOVIRT_RC_INFO_BLOCK rc;
+  IOVIRT_PMCG_INFO_BLOCK pmcg;
   UINT32 its_count;
   SMMU_INFO_BLOCK smmu;
 }NODE_DATA;
@@ -234,6 +242,7 @@ typedef struct {
   UINT32 num_pci_rcs;
   UINT32 num_named_components;
   UINT32 num_its_groups;
+  UINT32 num_pmcgs;
   IOVIRT_BLOCK blocks[];
 }IOVIRT_INFO_TABLE;
 

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -232,23 +232,30 @@ typedef struct {
 }SMMU_INFO_BLOCK;
 
 typedef struct {
-	uint32_t segment;
-	uint32_t ats_attr;
-	uint32_t cca;          //Cache Coherency Attribute
+  uint32_t segment;
+  uint32_t ats_attr;
+  uint32_t cca;          //Cache Coherency Attribute
 }IOVIRT_RC_INFO_BLOCK;
 
+typedef struct {
+  uint64_t base;
+  uint32_t overflow_gsiv;
+  uint32_t node_ref;
+} IOVIRT_PMCG_INFO_BLOCK;
+
 typedef enum {
-        IOVIRT_NODE_ITS_GROUP = 0x00,
-        IOVIRT_NODE_NAMED_COMPONENT = 0x01,
-        IOVIRT_NODE_PCI_ROOT_COMPLEX = 0x02,
-        IOVIRT_NODE_SMMU = 0x03,
-        IOVIRT_NODE_SMMU_V3 = 0x04
+  IOVIRT_NODE_ITS_GROUP = 0x00,
+  IOVIRT_NODE_NAMED_COMPONENT = 0x01,
+  IOVIRT_NODE_PCI_ROOT_COMPLEX = 0x02,
+  IOVIRT_NODE_SMMU = 0x03,
+  IOVIRT_NODE_SMMU_V3 = 0x04,
+  IOVIRT_NODE_PMCG = 0x05
 }IOVIRT_NODE_TYPE;
 
 typedef enum {
-        IOVIRT_FLAG_DEVID_OVERLAP_SHIFT,
-        IOVIRT_FLAG_STRID_OVERLAP_SHIFT,
-        IOVIRT_FLAG_SMMU_CTX_INT_SHIFT,
+  IOVIRT_FLAG_DEVID_OVERLAP_SHIFT,
+  IOVIRT_FLAG_STRID_OVERLAP_SHIFT,
+  IOVIRT_FLAG_SMMU_CTX_INT_SHIFT,
 }IOVIRT_FLAG_SHIFT;
 
 typedef struct {
@@ -266,6 +273,7 @@ typedef union {
 typedef union {
   char name[16];
   IOVIRT_RC_INFO_BLOCK rc;
+  IOVIRT_PMCG_INFO_BLOCK pmcg;
   uint32_t its_count;
   SMMU_INFO_BLOCK smmu;
 }NODE_DATA;
@@ -287,6 +295,7 @@ typedef struct {
   uint32_t num_pci_rcs;
   uint32_t num_named_components;
   uint32_t num_its_groups;
+  uint32_t num_pmcgs;
   IOVIRT_BLOCK blocks[];
 }IOVIRT_INFO_TABLE;
 


### PR DESCRIPTION
IO Remapping Table RevC describes Performance
Monitoring Counter Group nodes. Aligning code
with documentation.

Signed-off-by: Sakar Arora <sakar.arora@arm.com>