### PR TITLE
pcie: bug fix reading config space

### DIFF
--- a/platform/pal_uefi/include/pal_uefi.h
+++ b/platform/pal_uefi/include/pal_uefi.h
@@ -26,6 +26,8 @@ extern UINT32 g_print_level;
 #define AVS_PRINT_DEBUG 2      /* For Debug statements. contains register dumps etc */
 #define AVS_PRINT_INFO  1      /* Print all statements. Do not use unless really needed */
 
+#define PCIE_READ_ERR -1
+
 typedef struct {
   UINT64   Arg0;
   UINT64   Arg1;

--- a/platform/pal_uefi/src/pal_iovirt.c
+++ b/platform/pal_uefi/src/pal_iovirt.c
@@ -99,7 +99,7 @@ dump_iort_table(IOVIRT_INFO_TABLE *iovirt)
 {
   UINT32 i;
   IOVIRT_BLOCK *block = &iovirt->blocks[0];
-  sbsa_print(AVS_PRINT_INFO, "Number of IOVIRT blocks = %d\n", iovirt->num_blocks);
+  sbsa_print(AVS_PRINT_INFO, L"Number of IOVIRT blocks = %d\n", iovirt->num_blocks);
   for(i = 0; i < iovirt->num_blocks; i++, block = IOVIRT_NEXT_BLOCK(block))
     dump_block(block);
 }

--- a/test_pool/peripherals/test_d001.c
+++ b/test_pool/peripherals/test_d001.c
@@ -29,6 +29,7 @@ payload()
 {
 
   uint32_t interface = 0;
+  uint32_t ret;
   uint32_t bdf;
   uint64_t count = val_peripheral_get_info(NUM_USB, 0);
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
@@ -40,12 +41,17 @@ payload()
 
   while (count != 0) {
       bdf = val_peripheral_get_info(USB_BDF, count - 1);
-      interface = val_pcie_read_cfg(bdf, 0x8);
+      ret = val_pcie_read_cfg(bdf, 0x8, &interface);
       interface = (interface >> 8) & 0xFF;
-      if ((interface < 0x20) || (interface == 0xFF)) {
-          val_print(AVS_PRINT_WARN, "\n       WARN: Using ECAM access, USB CTRL detected is not EHCI/XHCI 0x%x  ", interface);
+      if (ret == PCIE_READ_ERR || (interface < 0x20) || (interface == 0xFF)) {
+          val_print(AVS_PRINT_WARN, "\n       WARN: USB CTRL ECAM access failed 0x%x  ", interface);
           val_print(AVS_PRINT_WARN, "\n       Re-checking USB CTRL using PciIo protocol       ", 0);
-          interface = val_pcie_io_read_cfg(bdf, 0x8);
+          ret = val_pcie_io_read_cfg(bdf, 0x8, &interface);
+          if (ret == PCIE_READ_ERR) {
+              val_print(AVS_PRINT_ERR, "\n       Reading device class code using PciIo protocol failed ", 0);
+              val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 02));
+              return;
+          }
           interface = (interface >> 8) & 0xFF;
           if ((interface < 0x20) || (interface == 0xFF)) {
               val_print(AVS_PRINT_ERR, "\n       Detected USB CTRL not EHCI/XHCI 0x%x  ", interface);

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -39,6 +39,7 @@
 #define TIMEOUT_MEDIUM   0x100000
 #define TIMEOUT_SMALL    0x1000
 
+#define PCIE_READ_ERR  -1
 
 /**  PE Test related Definitions **/
 
@@ -221,7 +222,7 @@ typedef struct {
 
 uint64_t pal_pcie_get_mcfg_ecam(void);
 void     pal_pcie_create_info_table(PCIE_INFO_TABLE *PcieTable);
-uint32_t pal_pcie_read_cfg(uint32_t bdf, uint32_t offset);
+uint32_t pal_pcie_read_cfg(uint32_t bdf, uint32_t offset, uint32_t *data);
 
 /**
   @brief  Instance of SMMU INFO block

--- a/val/include/sbsa_avs_pcie.h
+++ b/val/include/sbsa_avs_pcie.h
@@ -29,7 +29,7 @@
 #define PCIE_MAX_FUNC    8
 
 void     val_pcie_write_cfg(uint32_t bdf, uint32_t offset, uint32_t data);
-uint32_t val_pcie_read_cfg(uint32_t bdf, uint32_t offset);
+uint32_t val_pcie_read_cfg(uint32_t bdf, uint32_t offset, uint32_t *data);
 uint32_t val_get_msi_vectors (uint32_t bdf, PERIPHERAL_VECTOR_LIST **mvector);
 
 typedef enum {
@@ -66,7 +66,7 @@ uint32_t
 val_pcie_get_dma_coherent(uint32_t bdf);
 
 uint32_t
-val_pcie_io_read_cfg(uint32_t bdf, uint32_t offset);
+val_pcie_io_read_cfg(uint32_t bdf, uint32_t offset, uint32_t *data);
 
 uint32_t
 p001_entry(uint32_t num_pe);

--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -31,11 +31,12 @@ pal_get_mcfg_ptr(void);
            2. Prerequisite -  val_pcie_create_info_table
   @param   bdf    - concatenated Bus(8-bits), device(8-bits) & function(8-bits)
   @param   offset - Register offset within a device PCIe config space
+  @param   *data  - 32-bit data read from the config space
 
-  @return  32-bit data read from the config space
+  @return  success/failure
 **/
 uint32_t
-val_pcie_read_cfg(uint32_t bdf, uint32_t offset)
+val_pcie_read_cfg(uint32_t bdf, uint32_t offset, uint32_t *data)
 {
   uint32_t bus     = PCIE_EXTRACT_BDF_BUS(bdf);
   uint32_t dev     = PCIE_EXTRACT_BDF_DEV(bdf);
@@ -48,12 +49,12 @@ val_pcie_read_cfg(uint32_t bdf, uint32_t offset)
 
   if ((bus >= PCIE_MAX_BUS) || (dev >= PCIE_MAX_DEV) || (func >= PCIE_MAX_FUNC)) {
      val_print(AVS_PRINT_ERR, "Invalid Bus/Dev/Func  %x \n", bdf);
-     return 0;
+     return PCIE_READ_ERR;
   }
 
   if (g_pcie_info_table == NULL) {
       val_print(AVS_PRINT_ERR, "\n    Read_PCIe_CFG: PCIE info table is not created", 0);
-      return 0;
+      return PCIE_READ_ERR;
   }
 
   while (i < val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0))
@@ -70,7 +71,7 @@ val_pcie_read_cfg(uint32_t bdf, uint32_t offset)
 
   if (ecam_base == 0) {
       val_print(AVS_PRINT_ERR, "\n    Read PCIe_CFG: ECAM Base is zero ", 0);
-      return 0;
+      return PCIE_READ_ERR;
   }
 
   /* There are 8 functions / device, 32 devices / Bus and each has a 4KB config space */
@@ -79,7 +80,8 @@ val_pcie_read_cfg(uint32_t bdf, uint32_t offset)
 
   val_print(AVS_PRINT_INFO, "   calculated config address is %x \n", ecam_base + cfg_addr + offset);
 
-  return pal_mmio_read(ecam_base + cfg_addr + offset);
+  *data = pal_mmio_read(ecam_base + cfg_addr + offset);
+  return 0;
 
 }
 
@@ -90,13 +92,14 @@ val_pcie_read_cfg(uint32_t bdf, uint32_t offset)
            2. Prerequisite -  val_pcie_create_info_table
   @param   bdf    - concatenated Bus(8-bits), device(8-bits) & function(8-bits)
   @param   offset - Register offset within a device PCIe config space
+  @param   *data - 32-bit data read from the config space
 
-  @return  32-bit data read from the config space
+  @return success/failure
 **/
 uint32_t
-val_pcie_io_read_cfg(uint32_t bdf, uint32_t offset)
+val_pcie_io_read_cfg(uint32_t bdf, uint32_t offset, uint32_t *data)
 {
-    return pal_pcie_read_cfg(bdf, offset);
+    return pal_pcie_read_cfg(bdf, offset, data);
 }
 
 /**


### PR DESCRIPTION
Check segment also when searching for device
using BDF value.
Handle pcie config read errors better.

Signed-off-by: Sakar Arora <sakar.arora@arm.com>