### PR TITLE
Bug fix test 58: use msi desc irq number

### DIFF
--- a/test_pool/pcie/test_p008.c
+++ b/test_pool/pcie/test_p008.c
@@ -62,17 +62,20 @@ check_list_duplicates (PERIPHERAL_VECTOR_LIST *list_one, PERIPHERAL_VECTOR_LIST 
 
   uint32_t fcount = 0;
   uint32_t scount = 0;
+  uint32_t irq_start1, irq_end1;
+  uint32_t irq_start2, irq_end2;
 
   flist_node = list_one;
   slist_node = list_two;
 
   while (flist_node != NULL) {
     while (slist_node != NULL) {
-      if ((flist_node->vector.vector_lower_addr == slist_node->vector.vector_lower_addr) &&
-          (flist_node->vector.vector_upper_addr == slist_node->vector.vector_upper_addr) &&
-          (flist_node->vector.vector_data == slist_node->vector.vector_data)) {
+      irq_start1 = flist_node->vector.vector_irq_base;
+      irq_end1 = flist_node->vector.vector_irq_base + flist_node->vector.vector_n_irqs - 1;
+      irq_start2 = slist_node->vector.vector_irq_base;
+      irq_end2 = slist_node->vector.vector_irq_base + slist_node->vector.vector_n_irqs - 1;
+      if (!(irq_end1 < irq_start2 || irq_start1 > irq_end2))
         return 1;
-      }
       slist_node = slist_node->next;
       scount++;
     }

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -374,6 +374,7 @@ typedef struct {
   uint32_t         vector_data;       ///< Base Address of the controller
   uint32_t         vector_control;    ///< IRQ to install an ISR
   uint32_t         vector_irq_base;   ///< Base IRQ for the vectors in the block
+  uint32_t         vector_n_irqs;     ///< Number of irq vectors in the block
 }PERIPHERAL_VECTOR_BLOCK;
 
 typedef struct PERIPHERAL_VECTOR_LIST_STRUCT

--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -201,7 +201,7 @@ val_pcie_execute_tests(uint32_t level, uint32_t num_pe)
   status |= p005_entry(num_pe);
   status |= p006_entry(num_pe);
   status |= p007_entry(num_pe);
-//test needs to be changed  status |= p008_entry(num_pe);
+  status |= p008_entry(num_pe);
   status |= p009_entry(num_pe);
   status |= p010_entry(num_pe);
   status |= p011_entry(num_pe);


### PR DESCRIPTION
Instead of relying on vector address and data values.

Signed-off-by: Sakar Arora <sakar.arora@arm.com>