### PR TITLE
Test 84 bug fix. Pick UART address from SPCR table.

### DIFF
--- a/test_pool/pcie/test_p013.c
+++ b/test_pool/pcie/test_p013.c
@@ -60,8 +60,9 @@ payload (void)
       data = val_pcie_is_devicedma_64bit(dev_bdf);
       if (data == 0) {
           if(!val_pcie_is_device_behind_smmu(dev_bdf)) {
-              val_print (AVS_STATUS_ERR, "\n       The device with bdf=0x%x doesn't support 64 bit addressing", dev_bdf);
-              val_print (AVS_STATUS_ERR, "\n       and is not behind SMMU", 0);
+              val_print (AVS_STATUS_ERR, "\n       WARNING:The device with bdf=0x%x doesn't support 64 bit addressing", dev_bdf);
+              val_print (AVS_STATUS_ERR, "\n       and is not behind SMMU. Please install driver for this device and", 0);
+              val_print (AVS_STATUS_ERR, "\n       test again. If driver is already installed, this test has failed.", 0);
               val_print (AVS_STATUS_ERR, "\n       The device is of type = %d", dev_type);
               val_set_status (index, RESULT_FAIL (g_sbsa_level, TEST_NUM, 1));
               return;

--- a/test_pool/peripherals/test_d003.c
+++ b/test_pool/peripherals/test_d003.c
@@ -213,7 +213,7 @@ payload1()
           val_set_status(index, RESULT_PENDING(g_sbsa_level, TEST_NUM2));
           val_gic_install_isr(int_id, isr);
           uart_enable_txintr();
-          val_print(g_print_level, "\n       Test Message                      ", 0);
+          val_print_raw(g_print_level, "\n       Test Message                      ", 0);
 
           while ((--timeout > 0) && (IS_RESULT_PENDING(val_get_status(index))));
 


### PR DESCRIPTION
Use val_print_raw to print test message instead of val_print, since
former uses UART base address taken from SPCR table, and the latter
uses PCD defined UART base address. The GSIV on which ISR is
installed in this test is also from SPCR table. With this change
test message will always trigger the expected interrupt.

Signed-off-by: Prasanth Pulla <prasanth.pulla@arm.com>