### PR TITLE
Fix for wrong Affinity bits in val_pe_get_mpid

### DIFF
--- a/val/include/sbsa_avs_pe.h
+++ b/val/include/sbsa_avs_pe.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,8 @@
 
 #define MAX_NUM_PE_LEVEL0        0x8
 #define MAX_NUM_PE_LEVEL2        (2 << 27)
+
+#define MPIDR_AFF_MASK           (0xFF00FFFFFF)
 
 //
 //  AARCH64 processor exception types.

--- a/val/src/avs_pe_infra.c
+++ b/val/src/avs_pe_infra.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2020 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -86,11 +86,11 @@ val_pe_get_num()
 
 
 /**
-  @brief   This API reads MPIDR system regiser and return the affx bits
+  @brief   This API reads MPIDR system regiser and return the Affinity bits
            1. Caller       -  Test Suite, VAL
            2. Prerequisite -  None
   @param   None
-  @return  32-bit Affinity value
+  @return  Affinity Bits of MPIDR
 **/
 uint64_t
 val_pe_get_mpid()
@@ -102,10 +102,8 @@ val_pe_get_mpid()
   #else
     data = val_pe_reg_read(MPIDR_EL1);
   #endif
-  //
-  //return the affx bits
-  //
-  data = (((data >> 32) & 0xFF) << 24) | (data & 0xFFFFFF);
+  /* Return the Affinity bits */
+  data = data & MPIDR_AFF_MASK;
   return data;
 
 }


### PR DESCRIPTION
Added the fix in avs_pe_infra.c - val_pe_get_mpid.

Signed-off-by: Rajat Goyal <rajat.goyal@arm.com>