### PR TITLE
PCIe, Io-Virt Test Fixes and Enhancements

### DIFF
--- a/test_pool/io_virt/test_i001.c
+++ b/test_pool/io_virt/test_i001.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2020 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,22 +46,22 @@ payload()
       rev = val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu);
       if (rev == 2) {
           data = val_smmu_read_cfg(SMMUv2_IDR2, num_smmu);
-          if (data & BIT14) {
-              val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
-          } else {
+          if (!(data & BIT14)) {
               val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
+              return;
           }
       }
 
       if (rev == 3) {
           data = val_smmu_read_cfg(SMMUv3_IDR5, num_smmu);
-          if (data & BIT6) {
-              val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
-          } else {
+          if (!(data & BIT6)) {
               val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
+              return;
           }
       }
   }
+
+  val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
 
 }
 

--- a/test_pool/io_virt/test_i004.c
+++ b/test_pool/io_virt/test_i004.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2020 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -59,10 +59,11 @@ payload()
       data = val_smmu_read_cfg(SMMUv3_IDR0, num_smmu);
       if (((data >> 24) & 0x3) == 0x2) {
           val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
-      } else {
-          val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
+          return;
       }
   }
+
+  val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
 
 }
 

--- a/test_pool/io_virt/test_i005.c
+++ b/test_pool/io_virt/test_i005.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2020 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,10 +47,11 @@ payload()
 
       if(!val_iovirt_check_unique_ctx_intid(num_smmu)) {
           val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 1));
-      } else {
-          val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 0));
+          return;
       }
   }
+
+  val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 0));
 }
 
 uint32_t

--- a/test_pool/pcie/test_p030.c
+++ b/test_pool/pcie/test_p030.c
@@ -52,6 +52,7 @@ payload(void)
   uint32_t tbl_index;
   uint32_t bar_data;
   uint32_t test_fails;
+  uint32_t test_skip = 1;
   uint64_t bar_base;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
@@ -108,6 +109,9 @@ payload(void)
       /* Set test status as FAIL, update to PASS in exception handler */
       val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 02));
 
+      /* If test runs for atleast an endpoint */
+      test_skip = 0;
+
       /*
        * Read memory mapped BAR to cause unsupported request
        * detected bit set in Device Status Register of the pcie
@@ -139,7 +143,9 @@ exception_return:
        bar_data = 0;
   }
 
-  if (test_fails)
+  if (test_skip == 1)
+      val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+  else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, test_fails));
   else
       val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));

--- a/test_pool/pcie/test_p031.c
+++ b/test_pool/pcie/test_p031.c
@@ -34,6 +34,7 @@ payload(void)
   uint32_t tbl_index;
   uint32_t reg_value;
   uint32_t test_fails;
+  uint32_t test_skip = 1;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
@@ -52,6 +53,9 @@ payload(void)
       /* Extract BIST register value */
       reg_value = VAL_EXTRACT_BITS(reg_value, BIST_REG_START, BIST_REG_END);
 
+      /* If test runs for atleast an endpoint */
+      test_skip = 0;
+
       /*
        * If BIST Capable bit[7] is clear Completion Code[0:3] and Start Bist[6]
        * must be hardwired to 0b
@@ -65,7 +69,9 @@ payload(void)
       }
   }
 
-  if (test_fails)
+  if (test_skip == 1)
+      val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+  else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, test_fails));
   else
       val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));

--- a/test_pool/pcie/test_p032.c
+++ b/test_pool/pcie/test_p032.c
@@ -35,6 +35,7 @@ payload(void)
   uint32_t reg_value;
   uint32_t cap_ptr_value;
   uint32_t test_fails;
+  uint32_t test_skip = 1;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
@@ -53,6 +54,9 @@ payload(void)
       /* Extract Capabilities Pointer register value */
       cap_ptr_value = (reg_value >> TYPE01_CPR_SHIFT) & TYPE01_CPR_MASK;
 
+      /* If test runs for atleast an endpoint */
+      test_skip = 0;
+
       /* Check Capabilities Pointer is not NULL and is between 40h and FCh */
       if (!((cap_ptr_value != 0x00) && ((cap_ptr_value >= 0x40) && (cap_ptr_value <= 0xFC))))
       {
@@ -62,7 +66,9 @@ payload(void)
       }
   }
 
-  if (test_fails)
+  if (test_skip == 1)
+      val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+  else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, test_fails));
   else
       val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));

--- a/test_pool/pcie/test_p033.c
+++ b/test_pool/pcie/test_p033.c
@@ -35,6 +35,7 @@ payload(void)
   uint32_t reg_value;
   uint32_t max_payload_value;
   uint32_t test_fails;
+  uint32_t test_skip = 1;
   uint32_t cap_base;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
@@ -57,6 +58,9 @@ payload(void)
       /* Extract Max payload Size Supported value */
       max_payload_value = (reg_value >> DCAPR_MPSS_SHIFT) & DCAPR_MPSS_MASK;
 
+      /* If test runs for atleast an endpoint */
+      test_skip = 0;
+
       /* Valid payload size between 000b (129-bytes) to 101b (4096 bytes) */
       if (!((max_payload_value >= 0x00) && (max_payload_value <= 0x05)))
       {
@@ -66,7 +70,9 @@ payload(void)
       }
   }
 
-  if (test_fails)
+  if (test_skip == 1)
+      val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+  else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, test_fails));
   else
       val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));

--- a/test_pool/pcie/test_p034.c
+++ b/test_pool/pcie/test_p034.c
@@ -39,6 +39,7 @@ payload(void)
   uint32_t bar_index;
   uint32_t  dp_type;
   uint32_t test_fails;
+  uint32_t test_skip = 1;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
@@ -80,6 +81,9 @@ payload(void)
               if (reg_value == 0)
                   continue;
 
+              /* If test runs for atleast an endpoint */
+              test_skip = 0;
+
               /* Check type[1:2] should be 32-bit or 64-bit */
               addr_type = (reg_value >> BAR_MDT_SHIFT) & BAR_MDT_MASK;
               if ((addr_type != BITS_32) && (addr_type != BITS_64))
@@ -103,7 +107,10 @@ payload(void)
            }
        }
   }
-  if (test_fails)
+
+  if (test_skip == 1)
+      val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+  else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, test_fails));
   else
       val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));

--- a/test_pool/pcie/test_p035.c
+++ b/test_pool/pcie/test_p035.c
@@ -75,6 +75,7 @@ payload(void)
   uint32_t cap_base;
   uint32_t flr_cap;
   uint32_t test_fails;
+  uint32_t test_skip = 1;
   addr_t config_space_addr;
   void *func_config_space;
   pcie_device_bdf_table *bdf_tbl_ptr;
@@ -131,6 +132,9 @@ payload(void)
           /* Wait for 100 ms */
           val_time_delay_ms(100 * ONE_MILLISECOND);
 
+          /* If test runs for atleast an endpoint */
+          test_skip = 0;
+
           /* Vendor Id should not be 0xFF after max FLR period */
           val_pcie_read_cfg(bdf, 0, &reg_value);
           if ((reg_value & TYPE01_VIDR_MASK) == TYPE01_VIDR_MASK)
@@ -150,7 +154,9 @@ payload(void)
       }
   }
 
-  if (test_fails)
+  if (test_skip == 1)
+      val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+  else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, test_fails));
   else
       val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));

--- a/test_pool/pcie/test_p036.c
+++ b/test_pool/pcie/test_p036.c
@@ -39,6 +39,7 @@ payload(void)
   uint32_t cap_base;
   uint32_t ari_frwd_support;
   uint32_t test_fails;
+  uint32_t test_skip = 1;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
@@ -68,6 +69,9 @@ payload(void)
           val_pcie_read_cfg(rp_bdf, cap_base + DCAP2R_OFFSET, &reg_value);
           ari_frwd_support = (reg_value >> DCAP2R_AFS_SHIFT) & DCAP2R_AFS_MASK;
 
+          /* If test runs for atleast an endpoint */
+          test_skip = 0;
+
           /* If root port not support ARI forwarding, fail the test */
           if (!ari_frwd_support)
               test_fails++;
@@ -75,7 +79,9 @@ payload(void)
       }
   }
 
-  if (test_fails)
+  if (test_skip == 1)
+      val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+  else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, test_fails));
   else
       val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));

--- a/test_pool/pcie/test_p037.c
+++ b/test_pool/pcie/test_p037.c
@@ -40,6 +40,7 @@ payload(void)
   uint32_t ep_obff_support;
   uint32_t rp_obff_support;
   uint32_t test_fails;
+  uint32_t test_skip = 1;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
@@ -69,6 +70,9 @@ payload(void)
           val_pcie_read_cfg(rp_bdf, cap_base + DCAP2R_OFFSET, &reg_value);
           rp_obff_support = (reg_value >> DCAP2R_OBFF_SHIFT) & DCAP2R_OBFF_MASK;
 
+          /* If test runs for atleast an endpoint */
+          test_skip = 0;
+
           /* As per SBSA spec iRP must have same value as of iEP */
           if (ep_obff_support != rp_obff_support)
            {
@@ -81,7 +85,9 @@ payload(void)
       }
   }
 
-  if (test_fails)
+  if (test_skip == 1)
+      val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+  else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, test_fails));
   else
       val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));

--- a/test_pool/pcie/test_p038.c
+++ b/test_pool/pcie/test_p038.c
@@ -35,10 +35,12 @@ payload(void)
   uint32_t tbl_index;
   uint32_t reg_value;
   uint32_t dp_type;
+  uint32_t iep_rp_found;
   uint32_t cap_base;
   uint32_t ctrs_value;
   uint32_t ctds_value;
   uint32_t test_fails;
+  uint32_t test_skip = 1;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
@@ -46,6 +48,7 @@ payload(void)
 
   tbl_index = 0;
   test_fails = 0;
+  iep_rp_found = 0;
 
   /* Check for all the function present in bdf table */
   while (tbl_index < bdf_tbl_ptr->num_entries)
@@ -56,6 +59,8 @@ payload(void)
       /* Check entry is iRP endpoint */
       if (dp_type == iEP_RP)
       {
+          iep_rp_found = 1;
+
           /* If rootport invovled in transaction forwarding, move to next */
           if (val_pcie_get_rp_transaction_frwd_support(bdf))
              continue;
@@ -66,9 +71,10 @@ payload(void)
           ctrs_value = (reg_value >> DCAP2R_CTRS_SHIFT) & DCAP2R_CTRS_MASK;
 
           /* Read rootport Completion Timeout Disable supported bit value */
-          val_pcie_find_capability(bdf, PCIE_CAP, CID_PCIECS, &cap_base);
-          val_pcie_read_cfg(bdf, cap_base + DCAP2R_OFFSET, &reg_value);
           ctds_value = (reg_value >> DCAP2R_CTDS_SHIFT) & DCAP2R_CTDS_MASK;
+
+          /* If test runs for atleast an endpoint */
+          test_skip = 0;
 
           /* CTRS and CTDS bit is handwired to 0, if transaction forwarding not support */
           if ((ctrs_value != 0) || (ctds_value !=0))
@@ -81,7 +87,15 @@ payload(void)
      }
   }
 
-  if (test_fails)
+  /* Skip the test if no iEP_RP found */
+  if (iep_rp_found == 0) {
+      val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+      return;
+  }
+
+  if (test_skip == 1)
+      val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+  else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, test_fails));
   else
       val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));

--- a/test_pool/pcie/test_p039.c
+++ b/test_pool/pcie/test_p039.c
@@ -44,6 +44,7 @@ payload(void)
   uint32_t rp_requester_cap;
   uint32_t ep_requester_cap;
   uint32_t test_fails;
+  uint32_t test_skip = 1;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
@@ -76,6 +77,9 @@ payload(void)
 
           rp_requester_cap = val_pcie_get_atomicop_requester_capable(rp_bdf);
 
+          /* If test runs for atleast an endpoint */
+          test_skip = 0;
+
           /* if iEP is atomicop completer capable, RP should be routing or requester capable */
           if ((atomicop_32_cap || atomicop_64_cap || atomicop_128_cap) &&
              ((rp_routing_cap == 0) && (rp_requester_cap == 0)))
@@ -96,7 +100,9 @@ payload(void)
      }
   }
 
-  if (test_fails)
+  if (test_skip == 1)
+      val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+  else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, test_fails));
   else
       val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));

--- a/test_pool/pcie/test_p040.c
+++ b/test_pool/pcie/test_p040.c
@@ -36,6 +36,7 @@ payload(void)
   uint32_t dp_type;
   uint32_t cap_base;
   uint32_t test_fails;
+  uint32_t test_skip = 1;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
@@ -52,6 +53,9 @@ payload(void)
       /* Check entry is rootport */
       if ((dp_type == RP) || (dp_type == iEP_RP))
       {
+          /* If test runs for atleast an endpoint */
+          test_skip = 0;
+
           /* If ATS capability support for RP, test fails */
           if (val_pcie_find_capability(bdf, PCIE_ECAP, ECID_ATS, &cap_base) == PCIE_SUCCESS)
               test_fails++;
@@ -62,7 +66,9 @@ payload(void)
       }
   }
 
-  if (test_fails)
+  if (test_skip == 1)
+      val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+  else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, test_fails));
   else
       val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));

--- a/test_pool/pcie/test_p041.c
+++ b/test_pool/pcie/test_p041.c
@@ -36,6 +36,7 @@ payload(void)
   uint32_t dp_type;
   uint32_t cap_base;
   uint32_t test_fails;
+  uint32_t test_skip = 1;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
@@ -56,6 +57,9 @@ payload(void)
       /* Check entry is endpoint or rciep */
       if ((dp_type == iEP_EP) || (dp_type == RCiEP))
       {
+         /* If test runs for atleast an endpoint */
+         test_skip = 0;
+
          /* If MSI or MSI-X not supported, test fails */
          if ((val_pcie_find_capability(bdf, PCIE_CAP, CID_MSI, &cap_base) == PCIE_CAP_NOT_FOUND) &&
              (val_pcie_find_capability(bdf, PCIE_CAP, CID_MSIX, &cap_base) == PCIE_CAP_NOT_FOUND))
@@ -63,7 +67,9 @@ payload(void)
       }
   }
 
-  if (test_fails)
+  if (test_skip == 1)
+      val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+  else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, test_fails));
   else
       val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));

--- a/test_pool/pcie/test_p042.c
+++ b/test_pool/pcie/test_p042.c
@@ -36,6 +36,7 @@ payload(void)
   uint32_t dp_type;
   uint32_t cap_base;
   uint32_t test_fails;
+  uint32_t test_skip = 1;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
@@ -52,13 +53,18 @@ payload(void)
       /* Check entry is onchip peripherals */
       if ((dp_type == iEP_EP) || (dp_type == RCiEP) || (dp_type == iEP_RP))
       {
-          /* If Power Management capability not supported, test fails */
+         /* If test runs for atleast an endpoint */
+         test_skip = 0;
+
+         /* If Power Management capability not supported, test fails */
          if (val_pcie_find_capability(bdf, PCIE_CAP, CID_PMC, &cap_base) == PCIE_CAP_NOT_FOUND)
               test_fails++;
       }
   }
 
-  if (test_fails)
+  if (test_skip == 1)
+      val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+  else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, test_fails));
   else
       val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));

--- a/test_pool/pcie/test_p043.c
+++ b/test_pool/pcie/test_p043.c
@@ -42,6 +42,7 @@ payload(void)
   uint32_t sec_bus;
   uint32_t sub_bus;
   uint32_t test_fails;
+  uint32_t test_skip = 1;
   uint32_t reg_value;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
@@ -76,6 +77,9 @@ payload(void)
           if (sec_bus != sub_bus)
               continue;
 
+          /* If test runs for atleast an endpoint */
+          test_skip = 0;
+
           /* Configuration Requests specifying Device Numbers (1-31) must be terminated by the
            * Downstream Port or the Root Port with an Unsupported Request Completion Status
            */
@@ -97,7 +101,9 @@ payload(void)
       }
   }
 
-  if (test_fails)
+  if (test_skip == 1)
+      val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+  else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, test_fails));
   else
       val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));

--- a/test_pool/pcie/test_p044.c
+++ b/test_pool/pcie/test_p044.c
@@ -92,6 +92,7 @@ payload(void)
   uint32_t pe_index;
   uint32_t tbl_index;
   uint32_t fail_cnt;
+  uint32_t test_skip = 1;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   fail_cnt = 0;
@@ -109,16 +110,22 @@ payload(void)
       bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
       dp_type = val_pcie_device_port_type(bdf);
       if (dp_type == EP || dp_type == iEP_EP ||
-               dp_type == UP || dp_type == DP)
+               dp_type == UP || dp_type == DP) {
+          /* If test runs for atleast an endpoint */
+          test_skip = 0;
+
           if (func_ecam_is_rp_ecam(bdf))
           {
               val_print(AVS_PRINT_ERR, "\n        bdf: 0x%x ", bdf);
               val_print(AVS_PRINT_ERR, "dp_type: 0x%x ", dp_type);
               fail_cnt++;
           }
+      }
   }
 
-  if (fail_cnt)
+  if (test_skip == 1)
+      val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+  else if (fail_cnt)
       val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, fail_cnt));
   else
       val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));

--- a/test_pool/pcie/test_p045.c
+++ b/test_pool/pcie/test_p045.c
@@ -40,6 +40,7 @@ payload(void)
   uint32_t reg_value;
   uint16_t vendor_id;
   uint32_t device_id;
+  uint32_t test_skip = 1;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   tbl_index = 0;
@@ -59,6 +60,9 @@ payload(void)
           dp_type = val_pcie_device_port_type(bdf);
           if (dp_type == RP || dp_type == iEP_RP)
           {
+              /* If test runs for atleast an endpoint */
+              test_skip = 0;
+
               if (ecam_base == val_pcie_get_ecam_base(bdf))
               {
                   val_pcie_read_cfg(bdf, TYPE01_VIDR, &reg_value);
@@ -76,7 +80,10 @@ payload(void)
       ecam_index++;
   }
 
-  val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
+  if (test_skip == 1)
+      val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+  else
+      val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
 }
 
 uint32_t

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -26,6 +26,8 @@
   typedef char          char8_t;
   typedef long long int addr_t;
 #else
+  typedef INT8   int8_t;
+  typedef INT32  int32_t;
   typedef CHAR8  char8_t;
   typedef CHAR16 char16_t;
   typedef UINT8  uint8_t;

--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -836,7 +836,7 @@ val_pcie_increment_bdf(uint32_t bdf)
   uint32_t bus;
   uint32_t dev;
   uint32_t func;
-  uint32_t ecam_cnt;
+  int32_t ecam_cnt;
   uint32_t ecam_index = 0;
 
   seg = PCIE_EXTRACT_BDF_SEG(bdf);
@@ -1002,11 +1002,15 @@ val_pcie_find_capability(uint32_t bdf, uint32_t cid_type, uint32_t cid, uint32_t
 
   uint32_t reg_value;
   uint32_t next_cap_offset;
+  uint32_t ret;
 
   if (cid_type == PCIE_CAP) {
 
       /* Serach in PCIe configuration space */
-      val_pcie_read_cfg(bdf, TYPE01_CPR, &reg_value);
+      ret = val_pcie_read_cfg(bdf, TYPE01_CPR, &reg_value);
+      if (ret == PCIE_NO_MAPPING || reg_value == PCIE_UNKNOWN_RESPONSE)
+          return ret;
+
       next_cap_offset = (reg_value & TYPE01_CPR_MASK);
       while (next_cap_offset)
       {


### PR DESCRIPTION
PCIe : Test Updates

- Added Skip logic in test to skip the test when test is not being done for any of the endpoint.
- Comparison of unsigned expression < 0 is always false.


Io-Virt : Test Fixes
- Io-Virt tests updates to handle false pass/fail