### PR TITLE
EDKII: Migration to edk2-stable202008

### DIFF
--- a/docs/Arm_SBSA_NIST_User_Guide.md
+++ b/docs/Arm_SBSA_NIST_User_Guide.md
@@ -32,20 +32,20 @@ To start the ACS build with NIST STS, perform the following steps:
 ```
     UefiRuntimeLib|MdePkg/Library/UefiRuntimeLib/UefiRuntimeLib.inf
     !ifdef $(ENABLE_NIST)
-        SbsaNistLib|AppPkg/Applications/sbsa-acs/test_pool/nist_sts/SbsaNistLib.inf
-        SbsaValNistLib|AppPkg/Applications/sbsa-acs/val/SbsaValNistLib.inf
-        SbsaPalNistLib|AppPkg/Applications/sbsa-acs/platform/pal_uefi/SbsaPalNistLib.inf
+        SbsaNistLib|ShellPkg/Application/sbsa-acs/test_pool/nist_sts/SbsaNistLib.inf
+        SbsaValNistLib|ShellPkg/Application/sbsa-acs/val/SbsaValNistLib.inf
+        SbsaPalNistLib|ShellPkg/Application/sbsa-acs/platform/pal_uefi/SbsaPalNistLib.inf
     !else
-        SbsaValLib|AppPkg/Applications/sbsa-acs/val/SbsaValLib.inf
-        SbsaPalLib|AppPkg/Applications/sbsa-acs/platform/pal_uefi/SbsaPalLib.inf
+        SbsaValLib|ShellPkg/Application/sbsa-acs/val/SbsaValLib.inf
+        SbsaPalLib|ShellPkg/Application/sbsa-acs/platform/pal_uefi/SbsaPalLib.inf
     !endif
 ```
 2.  Add the following in the [components] section of ShellPkg/ShellPkg.dsc
 ```
     !ifdef $(ENABLE_NIST)
-        AppPkg/Applications/sbsa-acs/uefi_app/SbsaAvsNist.inf
+        ShellPkg/Application/sbsa-acs/uefi_app/SbsaAvsNist.inf
     !else
-        AppPkg/Applications/sbsa-acs/uefi_app/SbsaAvs.inf
+        ShellPkg/Application/sbsa-acs/uefi_app/SbsaAvs.inf
     !endif
 ```
 3.  Modify CC Flags in the [BuildOptions] section of ShellPkg/ShellPkg.dsc
@@ -84,12 +84,12 @@ To start the ACS build with NIST STS, perform the following steps:
 To build the SBSA test suite with NIST STS, execute the following commands:
 ***Linux build environment***
 ```
-source AppPkg/Applications/sbsa-acs/tools/scripts/avsbuild.sh NIST
+source ShellPkg/Application/sbsa-acs/tools/scripts/avsbuild.sh NIST
 ```
 
 ***Windows build environment***
 ```
-build -a AARCH64 -t GCC49 -p ShellPkg/ShellPkg.dsc -m AppPkg/Applications/sbsa-acs/uefi_app/SbsaAvs.inf -D ENABLE_NIST
+build -a AARCH64 -t GCC49 -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/sbsa-acs/uefi_app/SbsaAvs.inf -D ENABLE_NIST
 ```
 
 **Directory structure of SBSA ACS**

--- a/platform/pal_uefi/SbsaPalLib.inf
+++ b/platform/pal_uefi/SbsaPalLib.inf
@@ -48,7 +48,6 @@
   ShellPkg/ShellPkg.dec
   EmbeddedPkg/EmbeddedPkg.dec
   MdeModulePkg/MdeModulePkg.dec
-  EdkCompatibilityPkg/EdkCompatibilityPkg.dec
 
 [LibraryClasses]
   IoLib

--- a/platform/pal_uefi/SbsaPalNistLib.inf
+++ b/platform/pal_uefi/SbsaPalNistLib.inf
@@ -50,7 +50,6 @@
   ShellPkg/ShellPkg.dec
   EmbeddedPkg/EmbeddedPkg.dec
   MdeModulePkg/MdeModulePkg.dec
-  EdkCompatibilityPkg/EdkCompatibilityPkg.dec
 
 [LibraryClasses]
   LibC

--- a/platform/pal_uefi/src/pal_acpi.c
+++ b/platform/pal_uefi/src/pal_acpi.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2020 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +21,7 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/ShellLib.h>
 
-#include "Foundation/Efi/Guid/Acpi/Acpi.h"
+#include "Include/Guid/Acpi.h"
 #include <Protocol/AcpiTable.h>
 #include "Include/IndustryStandard/Acpi61.h"
 

--- a/test_pool/nist_sts/SbsaNistLib.inf
+++ b/test_pool/nist_sts/SbsaNistLib.inf
@@ -53,7 +53,6 @@
   ShellPkg/ShellPkg.dec
   EmbeddedPkg/EmbeddedPkg.dec
   MdeModulePkg/MdeModulePkg.dec
-  EdkCompatibilityPkg/EdkCompatibilityPkg.dec
   SecurityPkg/SecurityPkg.dec
 
 [LibraryClasses]

--- a/tools/scripts/avsbuild.sh
+++ b/tools/scripts/avsbuild.sh
@@ -18,8 +18,8 @@ function build_with_NIST()
         fi
     fi
 
-    if [ ! -d "AppPkg/Applications/sbsa-acs/test_pool/nist_sts/sts-2.1.2/" ]; then
-        /usr/bin/unzip sts-2_1_2.zip -d AppPkg/Applications/sbsa-acs/test_pool/nist_sts/.
+    if [ ! -d "ShellPkg/Application/sbsa-acs/test_pool/nist_sts/sts-2.1.2/" ]; then
+        /usr/bin/unzip sts-2_1_2.zip -d ShellPkg/Application/sbsa-acs/test_pool/nist_sts/.
 	status=$?
         if [ $status -ne 0 ]; then
             echo "unzip failed for NIST. Building sbsa without NIST"
@@ -27,7 +27,7 @@ function build_with_NIST()
         fi
     fi
 
-    cd AppPkg/Applications/sbsa-acs/test_pool/nist_sts/sts-2.1.2/
+    cd ShellPkg/Application/sbsa-acs/test_pool/nist_sts/sts-2.1.2/
     if ! patch -R -p1 -s -f --dry-run < ../../../patches/nist_sbsa_sts.diff; then
         patch -p1 < ../../../patches/nist_sbsa_sts.diff
         status=$?
@@ -38,7 +38,7 @@ function build_with_NIST()
     fi
     cd -
 
-    build -a AARCH64 -t GCC49 -p ShellPkg/ShellPkg.dsc -m AppPkg/Applications/sbsa-acs/uefi_app/SbsaAvsNist.inf -D ENABLE_NIST
+    build -a AARCH64 -t GCC49 -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/sbsa-acs/uefi_app/SbsaAvsNist.inf -D ENABLE_NIST
     status=$?
     if [ $status -ne 0 ]; then
         echo "Build failed for NIST. Building sbsa without NIST"
@@ -55,6 +55,6 @@ if [ "$1" == "NIST" ]; then
 fi
 
 if [ $NISTStatus -ne 0 ]; then
-    build -a AARCH64 -t GCC49 -p ShellPkg/ShellPkg.dsc -m AppPkg/Applications/sbsa-acs/uefi_app/SbsaAvs.inf
+    build -a AARCH64 -t GCC49 -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/sbsa-acs/uefi_app/SbsaAvs.inf
 fi
 

--- a/tools/scripts/avssetup.sh
+++ b/tools/scripts/avssetup.sh
@@ -10,5 +10,5 @@ echo -e "AVS_PATH is set to -> \e[93m $AVS_PATH\e[0m"
 export EDK2_PATH=$2
 echo -e "EDK2_PATH is set to -> \e[93m$EDK2_PATH\e[0m"
 
-ln -s  $AVS_PATH/ $EDK2_PATH/AppPkg/Applications/sbsa-acs
+ln -s  $AVS_PATH/ $EDK2_PATH/ShellPkg/Application/sbsa-acs
 

--- a/uefi_app/SbsaAvs.inf
+++ b/uefi_app/SbsaAvs.inf
@@ -173,7 +173,6 @@
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
   ShellPkg/ShellPkg.dec
-  EdkCompatibilityPkg/EdkCompatibilityPkg.dec
 
 [LibraryClasses]
   SbsaValLib

--- a/uefi_app/SbsaAvsNist.inf
+++ b/uefi_app/SbsaAvsNist.inf
@@ -174,7 +174,6 @@
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
   ShellPkg/ShellPkg.dec
-  EdkCompatibilityPkg/EdkCompatibilityPkg.dec
 
 [LibraryClasses]
   SbsaNistLib


### PR DESCRIPTION
SBSA changes required to build ACS on the latest EDK II
firmware tagged edk2-stable202008.

Signed-off-by: Gowtham Siddarth <gowtham.siddarth@arm.com>