### PR TITLE
PCIe: Changing the return value for val_pcie_multifunction_support

### DIFF
--- a/test_pool/pcie/test_p019.c
+++ b/test_pool/pcie/test_p019.c
@@ -27,10 +27,15 @@ static void payload(void)
     uint32_t index;
     uint32_t count;
     uint32_t valid_cnt;
-    uint8_t data;
+    uint8_t  data;
     uint16_t acs_data;
     uint32_t pcie_type;
     uint64_t dev_bdf;
+    uint32_t test_fail = 0;
+    uint32_t test_skip = 1;
+    uint32_t p2p_rqst_fail = 0;
+    uint32_t p2p_cmplt_fail = 0;
+    uint32_t p2p_trns_fail = 0;
 
     index = val_pe_get_index_mpid(val_pe_get_mpid());
 
@@ -60,32 +65,42 @@ static void payload(void)
                 continue;
 
             valid_cnt++;
+            test_skip = 0;
             val_pcie_read_ext_cap_word(dev_bdf, PCI_EXT_CAPID_ACS, PCI_CAPID_ACS, &acs_data);
             if (!acs_data) {
-                val_print(AVS_PRINT_WARN, "\n       ACS feature not supported", 0);
-                return;
+                val_print(AVS_PRINT_WARN, "\n       ACS feature not supported for bdf %x", dev_bdf);
+                test_fail++;
+                continue;
             }
             /* Extract ACS P2P request redirect bit */
             data = VAL_EXTRACT_BITS(acs_data, 2, 2);
             if (!data) {
-                val_print(AVS_PRINT_WARN, "\n       P2P request redirect not supported", 0);
+                val_print(AVS_PRINT_WARN, "\n       P2P request redirect not supported for bdf %x", dev_bdf);
+                p2p_rqst_fail++;
             }
             /* Extract ACS P2P completion redirect bit */
             data = VAL_EXTRACT_BITS(acs_data, 3, 3);
             if (!data) {
-                val_print(AVS_PRINT_WARN, "\n       P2P completion redirect not supported", 0);
+                val_print(AVS_PRINT_WARN, "\n       P2P completion redirect not supported for bdf %x", dev_bdf);
+                p2p_cmplt_fail++;
             }
             /* Extract ACS direct translated P2P bit */
             data = VAL_EXTRACT_BITS(acs_data, 6, 6);
             if (!data) {
-                val_print(AVS_PRINT_WARN, "\n       Direct translated P2P not supported", 0);
+                val_print(AVS_PRINT_WARN, "\n       Direct translated P2P not supported for bdf %x", dev_bdf);
+                p2p_trns_fail++;
             }
         } else {
             continue;
         }
     }
 
-    val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 3));
+    if (test_skip)
+        val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 0));
+    else if (test_fail || p2p_rqst_fail || p2p_cmplt_fail || p2p_trns_fail)
+        val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 1));
+    else
+        val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, valid_cnt));
 }
 
 uint32_t p019_entry(uint32_t num_pe)

--- a/test_pool/pcie/test_p057.c
+++ b/test_pool/pcie/test_p057.c
@@ -57,7 +57,7 @@ payload(void)
       if ((dp_type == RCiEP) || (dp_type == iEP_EP))
       {
           /* Check if the EP Supports Multifunction */
-          if(!val_pcie_multifunction_support(bdf))
+          if(val_pcie_multifunction_support(bdf))
               continue;
 
           /* Check If Endpoint supports P2P with other Functions. */

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -273,7 +273,6 @@ void pal_pcie_read_ext_cap_word(uint32_t seg, uint32_t bus, uint32_t dev, uint32
 uint32_t pal_pcie_get_pcie_type(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t fn);
 uint32_t pal_pcie_p2p_support(void);
 uint32_t pal_pcie_dev_p2p_support(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t fn);
-uint32_t pal_pcie_multifunction_support(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t fn);
 uint32_t pal_pcie_is_cache_present(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t fn);
 
 void pal_pcie_io_write_cfg(uint32_t bdf, uint32_t offset, uint32_t data);

--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -830,7 +830,7 @@ val_pcie_dev_p2p_support(uint32_t bdf)
   @brief   This API checks the PCIe device multifunction support
            1. Caller       -  Test Suite
   @param   bdf      - PCIe BUS/Device/Function
-  @return  0 - Multifunction not supported 1 - Multifunction supported
+  @return  1 - Multifunction not supported 0 - Multifunction supported
 **/
 uint32_t
 val_pcie_multifunction_support(uint32_t bdf)
@@ -839,7 +839,7 @@ val_pcie_multifunction_support(uint32_t bdf)
   val_pcie_read_cfg(bdf, TYPE01_CLSR, &reg_data);
   reg_data = ((reg_data >> TYPE01_HTR_SHIFT) & TYPE01_HTR_MASK);
 
-  return ((reg_data >> HTR_MFD_SHIFT) & HTR_MFD_MASK);
+  return !((reg_data >> HTR_MFD_SHIFT) & HTR_MFD_MASK);
 }
 
 /**


### PR DESCRIPTION
- The return value was changed for newly developed PCIe
  test 57 but was not changed in the existing test 19.
  Changing back to original value to be in consistent with
  other function.
- Added logic in test_p019 to check for rest of the PCIe
  devices eventhough some fails.
- Removed C99 standard code ;;

Signed-off-by: Gowtham Siddarth <gowtham.siddarth@arm.com>
Change-Id: I5c9c39e07c6da40ea8b411e034ee464c4ea9a119