### PR TITLE
GIC : Fixed GICR Base Calculation, Peripheral : Fixed test_m001

### DIFF
--- a/platform/pal_uefi/include/pal_uefi.h
+++ b/platform/pal_uefi/include/pal_uefi.h
@@ -82,7 +82,8 @@ typedef struct {
 typedef enum {
   ENTRY_TYPE_CPUIF = 0x1000,
   ENTRY_TYPE_GICD,
-  ENTRY_TYPE_GICRD,
+  ENTRY_TYPE_GICC_GICRD,
+  ENTRY_TYPE_GICR_GICRD,
   ENTRY_TYPE_GICITS
 }GIC_INFO_TYPE_e;
 
@@ -101,6 +102,7 @@ typedef struct {
   UINT32 type;
   UINT64 base;
   UINT32 its_id;  /* This its_id is only used in case of ITS Type entry */
+  UINT32 length;  /* This length is only used in case of Re-Distributor Range Address length */
 }GIC_INFO_ENTRY;
 
 /**

--- a/platform/pal_uefi/src_gic_its/sbsa_gic_its.h
+++ b/platform/pal_uefi/src_gic_its/sbsa_gic_its.h
@@ -204,7 +204,8 @@ ArmGicItsConfiguration (
 
 UINT64
 GetCurrentCpuRDBase (
-  UINT64    mGicRedistributorBase
+  UINT64    mGicRedistributorBase,
+  UINT32    length
   );
 
 EFIAPI

--- a/test_pool/peripherals/test_m001.c
+++ b/test_pool/peripherals/test_m001.c
@@ -58,8 +58,6 @@ payload()
 
   val_pe_install_esr(EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS, esr);
   val_pe_install_esr(EXCEPT_AARCH64_SERROR, esr);
-  val_pe_install_esr(EXCEPT_AARCH64_IRQ, esr);
-  val_pe_install_esr(EXCEPT_AARCH64_FIQ, esr);
 
   /* If we don't find a single un-populated address, mark this test as skipped */
   val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));

--- a/uefi_app/SbsaAvsMain.c
+++ b/uefi_app/SbsaAvsMain.c
@@ -422,16 +422,6 @@ ShellAppMainsbsa (
   if (Status)
     return Status;
 
-  /*
-   * Configure Gic Redistributor and ITS to support
-   * Generation of LPIs.
-  */
-  Status = configureGicIts();
-  if (Status) {
-    Print(L" GIC ITS Initialization Failed.\n");
-    Print(L" LPI Interrupt related test may not pass.\n");
-  }
-
   createTimerInfoTable();
   createWatchdogInfoTable();
   createPcieVirtInfoTable();
@@ -474,6 +464,12 @@ ShellAppMainsbsa (
 
   Print(L"\n      *** Starting IO Virtualization tests ***  \n");
   Status |= val_smmu_execute_tests(g_sbsa_level, val_pe_get_num());
+
+  /*
+   * Configure Gic Redistributor and ITS to support
+   * Generation of LPIs.
+  */
+  configureGicIts();
 
   Print(L"\n      *** Starting PCIe Exerciser tests ***  \n");
   Status |= val_exerciser_execute_tests(g_sbsa_level);

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -122,7 +122,8 @@ typedef struct {
 typedef enum {
   ENTRY_TYPE_CPUIF = 0x1000,
   ENTRY_TYPE_GICD,
-  ENTRY_TYPE_GICRD,
+  ENTRY_TYPE_GICC_GICRD,
+  ENTRY_TYPE_GICR_GICRD,
   ENTRY_TYPE_GICITS
 }GIC_INFO_TYPE_e;
 
@@ -141,6 +142,7 @@ typedef struct {
   uint32_t type;
   uint64_t base;
   uint32_t its_id;  /* This its_id is only used in case of ITS Type entry */
+  uint32_t length;  /* This length is only used in case of Re-Distributor Range Address length */
 }GIC_INFO_ENTRY;
 
 /**


### PR DESCRIPTION
Include the following updates.
- GIC
    - Fixed GICR base address calculation based on the available configuration. 
    - Added support for reading GICR Base from GICC structure & GICR structure based on the configuration.
    - Added extra checks for failure case.
- Peripheral
    - Removed IRQ/FIQ esr from the test.