### PR TITLE
PCIe: P and NP memory access check updates for test 448 and 449

### DIFF
--- a/test_pool/pcie/test_p048.c
+++ b/test_pool/pcie/test_p048.c
@@ -52,7 +52,7 @@ payload(void)
   uint32_t dp_type;
   uint32_t pe_index;
   uint32_t tbl_index;
-  uint32_t read_value;
+  uint32_t read_value, old_value;
   uint32_t test_skip = 1;
   uint64_t mem_base;
   uint64_t mem_lim;
@@ -108,10 +108,11 @@ payload(void)
         /* If test runs for atleast an endpoint */
         test_skip = 0;
 
-        /* Write known value to an address which is in range
+        /* Read and write known value to an address which is in range
          * Base + 0x10 will always be in the range.
          * Read the same
         */
+        old_value = (*(volatile uint32_t *)(mem_base + MEM_OFFSET_10));
         *(volatile uint32_t *)(mem_base + MEM_OFFSET_10) = KNOWN_DATA;
         read_value = (*(volatile uint32_t *)(mem_base + MEM_OFFSET_10));
 
@@ -125,7 +126,7 @@ exception_return:
           return;
         }
 
-        if ((read_value == PCIE_UNKNOWN_RESPONSE) || val_pcie_is_urd(bdf)) {
+        if ((old_value != read_value && read_value == PCIE_UNKNOWN_RESPONSE) || val_pcie_is_urd(bdf)) {
           val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 02));
           val_pcie_clear_urd(bdf);
           return;

--- a/test_pool/pcie/test_p049.c
+++ b/test_pool/pcie/test_p049.c
@@ -52,7 +52,7 @@ payload(void)
   uint32_t dp_type;
   uint32_t pe_index;
   uint32_t tbl_index;
-  uint32_t read_value;
+  uint32_t read_value, old_value;
   uint32_t test_skip = 1;
   uint64_t mem_base = 0, mem_base_upper = 0;
   uint64_t mem_lim = 0, mem_lim_upper = 0;
@@ -119,10 +119,11 @@ payload(void)
         /* If test runs for atleast an endpoint */
         test_skip = 0;
 
-        /* Write known value to an address which is in range
+        /* Read and write known value to an address which is in range
          * Base + 0x10 will always be in the range.
          * Read the same
         */
+        old_value = (*(volatile addr_t *)(mem_base + MEM_OFFSET_10));
         *(volatile addr_t *)(mem_base + MEM_OFFSET_10) = KNOWN_DATA;
         read_value = (*(volatile addr_t *)(mem_base + MEM_OFFSET_10));
 
@@ -136,7 +137,7 @@ exception_return:
           return;
         }
 
-        if ((read_value == PCIE_UNKNOWN_RESPONSE) || val_pcie_is_urd(bdf)) {
+        if ((old_value != read_value && read_value == PCIE_UNKNOWN_RESPONSE) || val_pcie_is_urd(bdf)) {
           val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 02));
           val_pcie_clear_urd(bdf);
           return;


### PR DESCRIPTION
The code to check if read value is valid or not need to compare
with the old value, not just based on all F's

Signed-off-by: Gowtham Siddarth <gowtham.siddarth@arm.com>