### PR TITLE
PCIe: Using val_pcie_function_header_type() to extract header type

### DIFF
--- a/test_pool/pcie/test_p034.c
+++ b/test_pool/pcie/test_p034.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -57,11 +57,8 @@ payload(void)
       /* Check for RCiEP and iEP */
       if (dp_type == RCiEP || dp_type == iEP_EP)
       {
-          /* Read 32-bits from CacheLine Size regsiter offset */
-          val_pcie_read_cfg(bdf, TYPE01_CLSR, &reg_value);
-
           /* Extract Hdr Type */
-          hdr_type = (reg_value >> TYPE01_HTR_SHIFT) & TYPE01_HTR_MASK;
+          hdr_type = val_pcie_function_header_type(bdf);
           val_print(AVS_PRINT_INFO, "\n        HDR TYPE 0x%x ", hdr_type);
 
           max_bar = 0;

--- a/val/include/sbsa_avs_pcie_spec.h
+++ b/val/include/sbsa_avs_pcie_spec.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019-2020, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2021, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -96,7 +96,7 @@
 
 /* Header type reg shifts and masks */
 #define HTR_HL_SHIFT   0x0
-#define HTR_HL_MASK    0x3f
+#define HTR_HL_MASK    0x7f
 #define HTR_MFD_SHIFT  7
 #define HTR_MFD_MASK   0x1
 


### PR DESCRIPTION
- test_c034 extracts header type register for a bdf and
  ignores to discard the multifunction support bit. The
  test has been modified to use existing val_pcie_function_header_type()
  function.

Signed-off-by: Gowtham Siddarth <gowtham.siddarth@arm.com>