### PR TITLE
Bug Fix for test_c022, test_p004

### DIFF
--- a/test_pool/pcie/test_p004.c
+++ b/test_pool/pcie/test_p004.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2020 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2020-2021 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,70 +31,129 @@ void
 payload(void)
 {
   uint32_t count = 0;
-  uint64_t base;
   uint32_t data;
   uint32_t bdf;
   uint32_t bar_reg_value;
+  uint64_t bar_upper_bits;
   uint32_t bar_value;
-  uint32_t bar_size;
+  uint32_t bar_value_1;
+  uint64_t bar_size;
   char    *baseptr;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
   uint32_t test_skip = 1;
   uint32_t test_fail = 0;
+  uint64_t offset;
+  uint64_t base;
 
   count = val_peripheral_get_info(NUM_SATA, 0);
 
   while (count--) {
-      base = val_peripheral_get_info(SATA_BASE1, count);
+next_bdf:
       bdf = val_peripheral_get_info(SATA_BDF, count);
+      offset = BAR0_OFFSET;
 
-      val_pcie_read_cfg(bdf, TYPE01_BAR, &bar_value);
-      val_print(AVS_PRINT_DEBUG, "\n The BAR value of bdf %x", bdf);
-      val_print(AVS_PRINT_DEBUG, " is %x ", bar_value);
+      while(offset <= BAR_MAX_OFFSET) {
+          val_pcie_read_cfg(bdf, offset, &bar_value);
+          val_print(AVS_PRINT_DEBUG, "\n The BAR value of bdf %x", bdf);
+          val_print(AVS_PRINT_DEBUG, " is %x ", bar_value);
+          base = 0;
 
-      /* Determine the BAR size */
-      val_pcie_write_cfg(bdf, TYPE01_BAR, 0xFFFFFFF0);
-      val_pcie_read_cfg(bdf, TYPE01_BAR, &bar_reg_value);
-      bar_reg_value = bar_reg_value & 0xFFFFFFF0;
-      bar_size = ~bar_reg_value + 1;
-      val_print(AVS_PRINT_DEBUG, "\n BAR size is %x", bar_size);
+          if (bar_value == 0)
+          {
+              /** This BAR is not implemented **/
+              count--;
+              goto next_bdf;
+          }
 
-      /* Restore the original BAR value */
-      val_pcie_write_cfg(bdf, TYPE01_BAR, bar_value);
+          /* Skip for IO address space */
+          if (bar_value & 0x1) {
+              count--;
+              goto next_bdf;
+          }
 
-      /* Check if bar supports the remap size */
-      if (1024 > bar_size) {
-          val_print(AVS_PRINT_ERR, "Bar size less than remap requested size", 0);
-          continue;
-      }
+          if (BAR_REG(bar_value) == BAR_64_BIT)
+          {
+              val_print(AVS_PRINT_INFO, "The BAR supports 64-bit address decoding capability \n", 0);
+              val_pcie_read_cfg(bdf, offset+4, &bar_value_1);
+              base = bar_value_1;
 
-      test_skip = 0;
+              /* BAR supports 64-bit address therefore, write all 1's
+               * to BARn and BARn+1 and identify the size requested
+               */
+              val_pcie_write_cfg(bdf, offset, 0xFFFFFFF0);
+              val_pcie_write_cfg(bdf, offset + 4, 0xFFFFFFFF);
+              val_pcie_read_cfg(bdf, offset, &bar_reg_value);
+              bar_size = bar_reg_value & 0xFFFFFFF0;
+              val_pcie_read_cfg(bdf, offset + 4, &bar_reg_value);
+              bar_upper_bits = bar_reg_value;
+              bar_size = bar_size | (bar_upper_bits << 32 );
+              bar_size = ~bar_size + 1;
 
-      /* Map SATA Controller BARs to a NORMAL memory attribute. check unaligned access */
-      baseptr = (char *)val_memory_ioremap((void *)base, 1024, NORMAL_NC);
+              /* Restore the original BAR value */
+              val_pcie_write_cfg(bdf, offset + 4, bar_value_1);
+              val_pcie_write_cfg(bdf, offset, bar_value);
+              base = (base << 32) | bar_value;
+          }
 
-      /* Check for unaligned access */
-      *(uint32_t *)(baseptr) = DATA;
-      data = *(char *)(baseptr+3);
+          else {
+              val_print(AVS_PRINT_INFO, "The BAR supports 32-bit address decoding capability\n", 0);
 
-      val_memory_unmap(baseptr);
+              /* BAR supports 32-bit address. Write all 1's
+               * to BARn and identify the size requested
+               */
+              val_pcie_write_cfg(bdf, offset, 0xFFFFFFF0);
+              val_pcie_read_cfg(bdf, offset, &bar_reg_value);
+              bar_reg_value = bar_reg_value & 0xFFFFFFF0;
+              bar_size = ~bar_reg_value + 1;
 
-      if (data != (DATA >> 24)) {
-          val_print(AVS_PRINT_ERR, "Unaligned data mismatch", 0);
-          test_fail++;
-      }
+              /* Restore the original BAR value */
+              val_pcie_write_cfg(bdf, offset, bar_value);
+              base = bar_value;
+          }
 
-      /* Map SATA Controller BARs to a DEVICE memory attribute and check transaction */
-      baseptr = (char *)val_memory_ioremap((void *)base, 1024, DEVICE_nGnRnE);
+          val_print(AVS_PRINT_DEBUG, "\n BAR size is %x", bar_size);
 
-      *(uint32_t *)(baseptr) = DATA;
-      data = *(uint32_t *)(baseptr);
+          /* Check if bar supports the remap size */
+          if (1024 > bar_size) {
+              val_print(AVS_PRINT_ERR, "Bar size less than remap requested size", 0);
+              goto next_bar;
+          }
 
-      val_memory_unmap(baseptr);
+          test_skip = 0;
 
-      if (data != DATA) {
-          val_print(AVS_PRINT_ERR, "Data value mismatch", 0);
-          test_fail++;
+          /* Map SATA Controller BARs to a NORMAL memory attribute. check unaligned access */
+          baseptr = (char *)val_memory_ioremap((void *)base, 1024, NORMAL_NC);
+
+          /* Check for unaligned access */
+          *(uint32_t *)(baseptr) = DATA;
+          data = *(char *)(baseptr+3);
+
+          val_memory_unmap(baseptr);
+
+          if (data != (DATA >> 24)) {
+              val_print(AVS_PRINT_ERR, "Unaligned data mismatch", 0);
+              test_fail++;
+          }
+
+          /* Map SATA Controller BARs to a DEVICE memory attribute and check transaction */
+          baseptr = (char *)val_memory_ioremap((void *)base, 1024, DEVICE_nGnRnE);
+
+          *(uint32_t *)(baseptr) = DATA;
+          data = *(uint32_t *)(baseptr);
+
+          val_memory_unmap(baseptr);
+
+          if (data != DATA) {
+              val_print(AVS_PRINT_ERR, "Data value mismatch", 0);
+              test_fail++;
+          }
+
+next_bar:
+          if (BAR_REG(bar_reg_value) == BAR_32_BIT)
+              offset=offset+4;
+
+          if (BAR_REG(bar_reg_value) == BAR_64_BIT)
+              offset=offset+8;
       }
   }
 

--- a/test_pool/pe/test_c022.c
+++ b/test_pool/pe/test_c022.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2020 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2020-2021 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,10 +26,10 @@ static void check_pointer_signing_algorithm(uint32_t index, uint64_t data)
     /* Read ID_AA64ISAR1_EL1[7:4] for pointer signing using standard algorithm
      * defined by Arm architecture
      */
-    if (VAL_EXTRACT_BITS(data, 4, 7) == 0x1)
-        val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
-    else
+    if (VAL_EXTRACT_BITS(data, 4, 7) == 0)
         val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
+    else
+        val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
 }
 static void payload()
 {
@@ -43,8 +43,8 @@ static void payload()
     } else if (g_sbsa_level < 5) {
 
         /* Pointer signing is optional, Check if Pointer signing is implemented */
-        if ((VAL_EXTRACT_BITS(data, 4, 7) != 0x1) && (VAL_EXTRACT_BITS(data, 8, 11) != 0x1) &&
-            (VAL_EXTRACT_BITS(data, 24, 27) != 0x1) && (VAL_EXTRACT_BITS(data, 28, 31) != 0x1)) {
+        if ((VAL_EXTRACT_BITS(data, 4, 7) == 0) && (VAL_EXTRACT_BITS(data, 8, 11) == 0) &&
+            (VAL_EXTRACT_BITS(data, 24, 27) == 0) && (VAL_EXTRACT_BITS(data, 28, 31) == 0)) {
             /* Pointer signing not implemented, Skip the test */
             val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
             return;

--- a/val/include/sbsa_avs_pcie_spec.h
+++ b/val/include/sbsa_avs_pcie_spec.h
@@ -112,6 +112,13 @@
 #define BAR_MT_MASK     0x1
 #define BAR_BASE_MASK   0xfffffff
 
+/*BAR offset */
+#define BAR0_OFFSET        0x10
+#define BAR_MAX_OFFSET     0x24
+#define BAR_64_BIT         1
+#define BAR_32_BIT         0
+#define BAR_REG(bar_reg_value) ((bar_reg_value >> 2) & 0x1)
+
 #define TYPE0_MAX_BARS  6
 #define TYPE1_MAX_BARS  2
 


### PR DESCRIPTION
test_c022 : Updated Pointer Signing test

 - All PEs must implement pointer signing indicated
   by ID_AA64ISAR1_EL1.APA having a non-zero value.

PCIe: Test only if the BAR is memory address space mapped

- test_p004 should perform the tests only if the BAR is
  memory address space mapped and not IO address space mapped.
  This is determined by reading bit 0 of BAR.