### PR TITLE
WDOG: Added counter frequency multiplier to wd timeout

### DIFF
--- a/test_pool/power_wakeup/test_u001.c
+++ b/test_pool/power_wakeup/test_u001.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019, 2021 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -117,7 +117,7 @@ isr5()
 void
 wakeup_set_failsafe()
 {
-  uint64_t timer_expire_val = TIMEOUT_LARGE;
+  uint64_t timer_expire_val = TIMEOUT_LARGE * 10;
 
   intid = val_timer_get_info(TIMER_INFO_PHY_EL1_INTID, 0);
   val_gic_install_isr(intid, isr_failsafe);
@@ -186,7 +186,7 @@ void
 payload4()
 {
   uint32_t status, ns_wdg = 0;
-  uint64_t timer_expire_val = TIMEOUT_SMALL;
+  uint64_t timer_expire_val = 1;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
   timer_num = val_wd_get_info(0, WD_INFO_COUNT);

--- a/test_pool/timer_wd/test_w002.c
+++ b/test_pool/timer_wd/test_w002.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018,2020 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2020-2021 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,7 +45,7 @@ payload()
 {
 
   uint32_t timeout, ns_wdg = 0;
-  uint64_t timer_expire_ticks = 1000;
+  uint64_t timer_expire_ticks = 1;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
   wd_num = val_wd_get_info(0, WD_INFO_COUNT);
 
@@ -63,7 +63,7 @@ payload()
           continue;    //Skip Secure watchdog
 
       ns_wdg++;
-      timeout = TIMEOUT_LARGE;
+      timeout = val_timer_get_info(TIMER_INFO_CNTFREQ, 0) * 2;
       val_set_status(index, RESULT_PENDING(g_sbsa_level, TEST_NUM));     // Set the initial result to pending
 
       int_id       = val_wd_get_info(wd_num, WD_INFO_GSIV);

--- a/val/src/avs_wd.c
+++ b/val/src/avs_wd.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2020, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2021, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -157,13 +157,16 @@ val_wd_disable(uint32_t index)
 void
 val_wd_set_ws0(uint32_t index, uint32_t timeout)
 {
+  uint32_t counter_freq;
 
   if (timeout == 0) {
       val_wd_disable(index);
       return;
   }
 
-  val_mmio_write((g_wd_info_table->wd_info[index].wd_ctrl_base + 8), timeout);
+  counter_freq = val_timer_get_info(TIMER_INFO_CNTFREQ, 0);
+
+  val_mmio_write((g_wd_info_table->wd_info[index].wd_ctrl_base + 8), counter_freq * timeout);
   val_wd_enable(index);
 
 }


### PR DESCRIPTION
Added counter frequency multiplier to timeout value in
val_wd_set_ws0(),since without this change, the timeout
value written by the testcase into watchdog device was
too small causing system reset even before watchdog refresh.

Signed-off-by: Gowtham Siddarth <gowtham.siddarth@arm.com>
Change-Id: If7a979855a47d6a8ad680b5a87edf92d7d88fed2