### PR TITLE
test 303 'check watchdog revision' is SBSA level 5 and above

### DIFF
--- a/test_pool/timer_wd/test_w003.c
+++ b/test_pool/timer_wd/test_w003.c
@@ -33,11 +33,6 @@ payload()
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
   uint32_t data, ns_wdg = 0;
 
-  if (g_sbsa_level < 5) {
-      val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
-      return;
-  }
-
   val_print(AVS_PRINT_DEBUG, "\n       Found %d watchdogs in ACPI table ", wd_num);
 
   if (wd_num == 0) {

--- a/val/src/avs_wd.c
+++ b/val/src/avs_wd.c
@@ -46,7 +46,10 @@ val_wd_execute_tests(uint32_t level, uint32_t num_pe)
 
   status = w001_entry(num_pe);
   status |= w002_entry(num_pe);
-  status |= w003_entry(num_pe);
+
+  if (level > 4) {
+      status |= w003_entry(num_pe);
+  }
 
   if (status != 0)
     val_print(AVS_PRINT_TEST, "\n      ***One or more tests have failed... *** \n", 0);


### PR DESCRIPTION
Instead of marking test as skipped on lower level it would be better to not run it at all.

Will close issue #140 