### PR TITLE
Fix test 501 (Wake from EL0 PHY Timer Interrupt)

### DIFF
--- a/test_pool/power_wakeup/test_u001.c
+++ b/test_pool/power_wakeup/test_u001.c
@@ -144,6 +144,7 @@ payload1()
   val_gic_install_isr(intid, isr1);
   val_timer_set_phy_el1(timer_expire_val);
   val_power_enter_semantic(SBSA_POWER_SEM_B);
+  wakeup_clear_failsafe();
   return;
 }
 


### PR DESCRIPTION
The payload1 function ("Wake from EL0 PHY Timer Interrupt) in
power_wakeup/test_u001.c was missing a call to wakeup_clear_failsafe.
So the interrupt was coming in and isr1 was being called, but the test
hung.

Signed-off-by: Rebecca Cran <rebecca@nuviainc.com>