### PR TITLE
Remove pcie/test_p004.o from test_pool/Makefile

### DIFF
--- a/test_pool/Makefile
+++ b/test_pool/Makefile
@@ -26,7 +26,7 @@ TEST_POOL = $(ACS_DIR)/
 obj-m += sbsa_acs_test.o
 sbsa_acs_test-objs += $(TEST_POOL)/pcie/test_p001.o \
     $(TEST_POOL)/pcie/test_p002.o \
-    $(TEST_POOL)/pcie/test_p003.o $(TEST_POOL)/pcie/test_p004.o \
+    $(TEST_POOL)/pcie/test_p003.o \
     $(TEST_POOL)/pcie/test_p005.o $(TEST_POOL)/pcie/test_p006.o \
     $(TEST_POOL)/pcie/test_p007.o $(TEST_POOL)/pcie/test_p008.o \
     $(TEST_POOL)/pcie/test_p009.o $(TEST_POOL)/pcie/test_p010.o \


### PR DESCRIPTION
test_pool/pcie/test_p004.c was deleted in commit
7775a1729811ec695253cc4ae8d0350eeecb0671 - also remove it from
test_pool/Makefile.

Signed-off-by: Rebecca Cran <rebecca@nuviainc.com>