### PR TITLE
pal_uefi: Fix enum conversion

### DIFF
--- a/platform/pal_uefi/src/pal_gic.c
+++ b/platform/pal_uefi/src/pal_gic.c
@@ -223,7 +223,7 @@ pal_gic_set_intr_trigger(UINT32 int_id, INTR_TRIGGER_INFO_TYPE_e trigger_type)
   Status = gInterrupt2->SetTriggerType (
                    gInterrupt2,
                    int_id,
-                   trigger_type
+                   (EFI_HARDWARE_INTERRUPT2_TRIGGER_TYPE)trigger_type
                    );
 
   if (EFI_ERROR(Status))


### PR DESCRIPTION
clang complains about enum type mismatches:

pal_uefi/src/pal_gic.c:224:20: error: implicit conversion from enumeration type
'INTR_TRIGGER_INFO_TYPE_e' to different enumeration type 'EFI_HARDWARE_INTERRUPT2_TRIGGER_TYPE'

Signed-off-by: Khem Raj <raj.khem@gmail.com>