### PR TITLE
PCIe: Removed linux API reference from PCIe test

### DIFF
--- a/test_pool/pcie/test_p008.c
+++ b/test_pool/pcie/test_p008.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,7 @@
 #include "val/include/val_interface.h"
 
 #include "val/include/sbsa_avs_pcie.h"
+#include "val/include/sbsa_avs_memory.h"
 
 #define TEST_NUM   (AVS_PCIE_TEST_NUM_BASE + 8)
 #define TEST_DESC  "Check MSI(X) vectors uniqueness   "
@@ -104,7 +105,7 @@ clean_msi_list (PERIPHERAL_VECTOR_LIST *list)
   current_node = list;
   while (current_node != NULL) {
     next_node = current_node->next;
-    kfree (current_node);
+    val_memory_free (current_node);
     current_node = next_node;
   }
 }

--- a/test_pool/pcie/test_p009.c
+++ b/test_pool/pcie/test_p009.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@
 #include "val/include/val_interface.h"
 
 #include "val/include/sbsa_avs_pcie.h"
+#include "val/include/sbsa_avs_memory.h"
 
 #define TEST_NUM   (AVS_PCIE_TEST_NUM_BASE + 9)
 #define TEST_DESC  "Check all MSI(X) vectors are LPIs "
@@ -63,7 +64,7 @@ clean_msi_list (PERIPHERAL_VECTOR_LIST *list)
   current_node = list;
   while (current_node != NULL) {
     next_node = current_node->next;
-    kfree (current_node);
+    val_memory_free (current_node);
     current_node = next_node;
   }
 }

--- a/test_pool/pcie/test_p012.c
+++ b/test_pool/pcie/test_p012.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,7 @@
 #include "val/include/val_interface.h"
 
 #include "val/include/sbsa_avs_pcie.h"
+#include "val/include/sbsa_avs_memory.h"
 
 #define TEST_NUM   (AVS_PCIE_TEST_NUM_BASE + 12)
 #define TEST_DESC  "PCI legacy interrupt SPI ID unique"
@@ -53,7 +54,7 @@ payload (void)
      return;
   }
 
-  irq_map = kzalloc(sizeof(PERIPHERAL_IRQ_MAP), GFP_KERNEL);
+  irq_map = val_memory_alloc(sizeof(PERIPHERAL_IRQ_MAP));
   if (!irq_map) {
     val_print (AVS_PRINT_ERR, "\n       Memory allocation error", 0);
     val_set_status (index, RESULT_FAIL (g_sbsa_level, TEST_NUM, 01));
@@ -124,7 +125,7 @@ payload (void)
     }
   }
 
-  kfree (irq_map);
+  val_memory_free (irq_map);
 
   if (!status) {
     val_set_status (index, RESULT_PASS (g_sbsa_level, TEST_NUM, 01));

--- a/test_pool/pcie/test_p014.c
+++ b/test_pool/pcie/test_p014.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,8 +34,7 @@ payload(void)
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
   uint32_t target_dev_index;
   uint32_t status = 0;
-  addr_t   dma_addr = 0;
-  void *buffer;
+  void     *buffer;
   uint32_t attr, sh;
   int ret;
 
@@ -53,7 +52,7 @@ payload(void)
       target_dev_index--; //index is zero based
       if(val_dma_get_info(DMA_HOST_COHERENT, target_dev_index))
       {
-          dma_addr = val_dma_mem_alloc(&buffer, 512, target_dev_index, DMA_COHERENT);
+          val_dma_mem_alloc(&buffer, 512, target_dev_index, DMA_COHERENT);
           ret = val_dma_mem_get_attrs(buffer, &attr, &sh);
           if(ret)
           {
@@ -69,7 +68,7 @@ payload(void)
           }
       }
       else {
-          dma_addr = val_dma_mem_alloc(&buffer, 512, target_dev_index, DMA_NOT_COHERENT);
+          val_dma_mem_alloc(&buffer, 512, target_dev_index, DMA_NOT_COHERENT);
           ret = val_dma_mem_get_attrs(buffer, &attr, &sh);
           if(ret)
           {


### PR DESCRIPTION
- Replaced kzalloc and free linux function calls with
  val_memory_alloc and val_memory_free functions.
- Remove unused variable dma_addr in test_p014.

Signed-off-by: Gowtham Siddarth <gowtham.siddarth@arm.com>