### PR TITLE
PCIe test enhancements and bug fixes

### DIFF
--- a/platform/pal_baremetal/FVP/src/platform_cfg_fvp.c
+++ b/platform/pal_baremetal/FVP/src/platform_cfg_fvp.c
@@ -245,6 +245,9 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[3].dev           = PLATFORM_PCIE_DEV3_DEV_NUM,
     .device[3].function      = PLATFORM_PCIE_DEV3_FUNC_NUM,
     .device[3].seg           = PLATFORM_PCIE_DEV3_SEG_NUM,
+    /* IRQ list of interrupt pin INTC# */
+    .device[3].irq_map.legacy_irq_map[2].irq_count = 1,
+    .device[3].irq_map.legacy_irq_map[2].irq_list[0] = 200,
 
     .device[4].class_code    = PLATFORM_PCIE_DEV4_CLASSCODE,
     .device[4].vendor_id     = PLATFORM_PCIE_DEV4_VENDOR_ID,
@@ -277,6 +280,9 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[7].dev           = PLATFORM_PCIE_DEV7_DEV_NUM,
     .device[7].function      = PLATFORM_PCIE_DEV7_FUNC_NUM,
     .device[7].seg           = PLATFORM_PCIE_DEV7_SEG_NUM,
+    /* IRQ list of interrupt pin INTC# */
+    .device[7].irq_map.legacy_irq_map[2].irq_count = 1,
+    .device[7].irq_map.legacy_irq_map[2].irq_list[0] = 200,
 
     .device[8].class_code    = PLATFORM_PCIE_DEV8_CLASSCODE,
     .device[8].vendor_id     = PLATFORM_PCIE_DEV8_VENDOR_ID,
@@ -285,6 +291,9 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[8].dev           = PLATFORM_PCIE_DEV8_DEV_NUM,
     .device[8].function      = PLATFORM_PCIE_DEV8_FUNC_NUM,
     .device[8].seg           = PLATFORM_PCIE_DEV8_SEG_NUM,
+    /* IRQ list of interrupt pin INTC# */
+    .device[8].irq_map.legacy_irq_map[2].irq_count = 1,
+    .device[8].irq_map.legacy_irq_map[2].irq_list[0] = 200,
 
     .device[9].class_code    = PLATFORM_PCIE_DEV9_CLASSCODE,
     .device[9].vendor_id     = PLATFORM_PCIE_DEV9_VENDOR_ID,
@@ -333,6 +342,9 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[14].dev           = PLATFORM_PCIE_DEV14_DEV_NUM,
     .device[14].function      = PLATFORM_PCIE_DEV14_FUNC_NUM,
     .device[14].seg           = PLATFORM_PCIE_DEV14_SEG_NUM,
+    /* IRQ list of interrupt pin INTA# */
+    .device[14].irq_map.legacy_irq_map[0].irq_count = 1,
+    .device[14].irq_map.legacy_irq_map[0].irq_list[0] = 500,
 
     .device[15].class_code    = PLATFORM_PCIE_DEV15_CLASSCODE,
     .device[15].vendor_id     = PLATFORM_PCIE_DEV15_VENDOR_ID,

--- a/platform/pal_baremetal/include/pal_common_support.h
+++ b/platform/pal_baremetal/include/pal_common_support.h
@@ -266,6 +266,18 @@ typedef struct {
   @brief PCIe Info Table
 **/
 
+#define LEGACY_PCI_IRQ_CNT 4  // Legacy PCI IRQ A, B, C. and D
+#define MAX_IRQ_CNT 0xFFFF    // This value is arbitrary and may have to be adjusted
+
+typedef struct {
+  uint32_t  irq_list[MAX_IRQ_CNT];
+  uint32_t  irq_count;
+} PERIFERAL_IRQ_LIST;
+
+typedef struct {
+  PERIFERAL_IRQ_LIST  legacy_irq_map[LEGACY_PCI_IRQ_CNT];
+} PERIPHERAL_IRQ_MAP;
+
 typedef struct {
   uint64_t   ecam_base;     ///< ECAM Base address
   uint32_t   segment_num;   ///< Segment number of this ECAM
@@ -286,6 +298,7 @@ typedef struct {
   uint32_t   dev;
   uint32_t   function;
   uint32_t   seg;
+  PERIPHERAL_IRQ_MAP irq_map;
 } PCIE_READ_BLOCK;
 
 typedef struct {
@@ -384,18 +397,6 @@ typedef struct PERIPHERAL_VECTOR_LIST_STRUCT
 }PERIPHERAL_VECTOR_LIST;
 
 uint32_t pal_get_msi_vectors (uint32_t seg, uint32_t bus, uint32_t dev, uint32_t fn, PERIPHERAL_VECTOR_LIST **mvector);
-
-#define LEGACY_PCI_IRQ_CNT 4  // Legacy PCI IRQ A, B, C. and D
-#define MAX_IRQ_CNT 0xFFFF    // This value is arbitrary and may have to be adjusted
-
-typedef struct {
-  uint32_t  irq_list[MAX_IRQ_CNT];
-  uint32_t  irq_count;
-} PERIFERAL_IRQ_LIST;
-
-typedef struct {
-  PERIFERAL_IRQ_LIST  legacy_irq_map[LEGACY_PCI_IRQ_CNT];
-} PERIPHERAL_IRQ_MAP;
 
 /**
   @brief  Instance of SMMU INFO block

--- a/platform/pal_baremetal/src/pal_pcie.c
+++ b/platform/pal_baremetal/src/pal_pcie.c
@@ -25,6 +25,8 @@ extern PCIE_READ_TABLE platform_pcie_device_hierarchy;
 extern PERIPHERAL_INFO_TABLE  *g_peripheral_info_table;
 extern PLATFORM_PCIE_PERIPHERAL_INFO_TABLE platform_pcie_peripheral_cfg;
 
+void *pal_memcpy(void *dest_buffer, void *src_buffer, uint32_t len);
+
 uint64_t
 pal_pcie_get_mcfg_ecam()
 {
@@ -615,6 +617,24 @@ pal_get_msi_vectors(uint32_t Seg, uint32_t Bus, uint32_t Dev, uint32_t Fn, PERIP
 uint32_t
 pal_pcie_get_legacy_irq_map(uint32_t Seg, uint32_t Bus, uint32_t Dev, uint32_t Fn, PERIPHERAL_IRQ_MAP *IrqMap)
 {
+  uint32_t i;
+
+  for(i = 0; i < platform_pcie_device_hierarchy.num_entries; i++)
+  {
+     if(Seg  == platform_pcie_device_hierarchy.device[i].seg &&
+        Bus  == platform_pcie_device_hierarchy.device[i].bus &&
+        Dev  == platform_pcie_device_hierarchy.device[i].dev &&
+        Fn == platform_pcie_device_hierarchy.device[i].function)
+        {
+            pal_memcpy(IrqMap, &platform_pcie_device_hierarchy.device[i].irq_map,
+                       sizeof(platform_pcie_device_hierarchy.device[i].irq_map));
+            return 0;
+        }
+  }
+
+  print(AVS_PRINT_ERR, "No PCI devices found in the system\n");
+  return PCIE_NO_MAPPING;
+
   return 1;
 }
 

--- a/test_pool/exerciser/test_e006.c
+++ b/test_pool/exerciser/test_e006.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2021, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,22 +25,24 @@
 #define TEST_NUM   (AVS_EXERCISER_TEST_NUM_BASE + 6)
 #define TEST_DESC  "Generate PCIe legacy interrupts   "
 
-#define LEGACY_INTR_PIN_COUNT 1
-
 static uint32_t instance;
 static uint32_t e_intr_line;
+static uint32_t test_fail = 0;
 static volatile uint32_t e_intr_pending;
 
 static void intr_handler(void)
 {
-    /* Call exerciser specific function to handle the interrupt */
-    val_exerciser_ops(CLEAR_INTR, e_intr_line, instance);
+    if (e_intr_pending == 0)
+    {
+        val_print(AVS_PRINT_ERR, "\n  Multiple interrupts received", 0);
+        test_fail++;
+        return;
+    }
 
     /* Clear the interrupt pending state */
     e_intr_pending = 0;
 
     val_print(AVS_PRINT_INFO, " \n  Received legacy interrupt %d", e_intr_line);
-    val_gic_end_of_interrupt(e_intr_line);
 
 }
 
@@ -48,22 +50,23 @@ static
 void
 payload (void)
 {
-
   uint32_t pe_index;
   uint32_t e_bdf;
   uint32_t ret_val;
   uint32_t timeout;
   uint32_t e_intr_pin;
   uint32_t status;
+  uint32_t count;
+  uint32_t test_skip = 1;
   PERIPHERAL_IRQ_MAP *e_intr_map;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
 
-/* Allocate memory for interrupt mappings */
+  /* Allocate memory for interrupt mappings */
   e_intr_map = val_memory_alloc(sizeof(PERIPHERAL_IRQ_MAP));
   if (!e_intr_map) {
     val_print (AVS_PRINT_ERR, "\n       Memory allocation error", 00);
-    val_set_status(pe_index, RESULT_FAIL (g_sbsa_level, TEST_NUM, 02));
+    val_set_status(pe_index, RESULT_FAIL (g_sbsa_level, TEST_NUM, 01));
     return;
   }
 
@@ -72,58 +75,99 @@ payload (void)
 
   while (instance-- != 0) {
 
-      /* if init fail moves to next exerciser */
-      if (val_exerciser_init(instance))
-          continue;
+    /* if init fail moves to next exerciser */
+    if (val_exerciser_init(instance))
+        continue;
 
     /* Get the exerciser BDF */
     e_bdf = val_exerciser_get_bdf(instance);
 
+    /* Check if the PCI interrupt request pins is connected INTA#-through-INTD */
     val_pcie_read_cfg(e_bdf, PCIE_INTERRUPT_LINE, &e_intr_pin);
-    val_print (AVS_PRINT_DEBUG, "  e_intr_pin %x", e_intr_pin);
-
-    if (((e_intr_pin >> 8) == 0) || ((e_intr_pin >> 8) > 4))
+    e_intr_pin = (e_intr_pin >> PCIE_INTERRUPT_PIN_SHIFT) & PCIE_INTERRUPT_PIN_MASK;
+    if ((e_intr_pin == 0) || (e_intr_pin > 4))
         continue;
 
+    /* Get the legacy IRQ map */
     status = val_pci_get_legacy_irq_map(e_bdf, e_intr_map);
     if(!status) {
 
-        e_intr_pending = 1;
-        e_intr_line = e_intr_map->legacy_irq_map[0].irq_list[0];
+        /* Get the number of IRQ for the specified INTx# */
+        count = e_intr_map->legacy_irq_map[e_intr_pin - 1].irq_count;
+        while (count--)
+        {
+            test_skip = 0;
 
-        /* Register an interrupt handler to verify legacy interrupt functionality */
-        ret_val = val_gic_install_isr(e_intr_line, intr_handler);
-        if (ret_val)
-            goto test_fail;
+            /* Register an interrupt handler to verify legacy interrupt functionality
+             * for each of the IRQ present.
+             */
+            e_intr_line = e_intr_map->legacy_irq_map[e_intr_pin - 1].irq_list[count];
 
-        /* Trigger the legacy interrupt */
-        val_exerciser_ops(GENERATE_L_INTR, e_intr_line, instance);
+            /* Clear any pending interrupts */
+            val_exerciser_ops(CLEAR_INTR, e_intr_line, instance);
+            val_gic_end_of_interrupt(e_intr_line);
 
-        /* PE busy polls to check the completion of interrupt service routine */
-        timeout = TIMEOUT_LARGE;
-        while ((--timeout > 0) && e_intr_pending);
+            ret_val = val_gic_install_isr(e_intr_line, intr_handler);
+            if (ret_val)
+            {
+                val_print (AVS_PRINT_ERR,"\n       Installing ISR failed for IRQ: %x", e_intr_line);
+                val_set_status(pe_index, RESULT_FAIL (g_sbsa_level, TEST_NUM, 02));
+                return;
+            }
 
-        if (timeout == 0) {
+            e_intr_pending = 1;
+
+            /* Trigger the legacy interrupt */
+            val_exerciser_ops(GENERATE_L_INTR, e_intr_line, instance);
+
+            /* PE busy polls to check the completion of interrupt service routine */
+            timeout = TIMEOUT_LARGE;
+            while ((--timeout > 0) && e_intr_pending);
+
+            if (timeout == 0) {
+                val_gic_free_irq(e_intr_line, 0);
+                val_print(AVS_PRINT_ERR, "\n       Interrupt trigger failed for bdf 0x%lx", e_bdf);
+                test_fail++;
+                continue;
+            }
+
+            /* Check if interrupt status bit is set in Status register */
+            if (!val_pcie_check_interrupt_status(e_bdf))
+            {
+                val_print(AVS_PRINT_ERR, "\n       No outstanding interrupt for bdf 0x%x", e_bdf);
+                test_fail++;
+                continue;
+            }
+
+            /* Deassert the interupt line */
+            val_exerciser_ops(CLEAR_INTR, e_intr_line, instance);
+
+            /* Return the interrupt */
+            val_gic_end_of_interrupt(e_intr_line);
+
+            /* Check if interrupt status bit is cleared in Status register */
+            if (val_pcie_check_interrupt_status(e_bdf))
+            {
+                val_print(AVS_PRINT_ERR, "\n       Outstanding interrupt for bdf 0x%x", e_bdf);
+                test_fail++;
+                continue;
+            }
+
             val_gic_free_irq(e_intr_line, 0);
-            val_print(AVS_PRINT_ERR, "\n       Interrupt trigger failed for bdf %lx   ", e_bdf);
-            goto test_fail;
         }
-
-        /* Return the interrupt */
-        val_gic_free_irq(e_intr_line, 0);
-
    } else {
-        val_print (AVS_PRINT_ERR, "\n       Legacy interrupt mapping Read error", status);
-        goto test_fail;
+        val_print (AVS_PRINT_ERR, "\n       Legacy interrupt mapping Read error for bdf: 0x%x", e_bdf);
+        test_fail++;
    }
  }
 
-  val_memory_free(e_intr_map);
-  val_set_status (pe_index, RESULT_PASS (g_sbsa_level, TEST_NUM, 01));
-  return;
+  if (test_fail)
+      val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 03));
+  else if (test_skip)
+      val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+  else
+      val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
 
-test_fail:
-  val_set_status(pe_index, RESULT_FAIL (g_sbsa_level, TEST_NUM, 02));
   val_memory_free(e_intr_map);
   return;
 

--- a/test_pool/exerciser/test_e008.c
+++ b/test_pool/exerciser/test_e008.c
@@ -155,12 +155,24 @@ exception_return:
           val_pcie_clear_urd(erp_bdf);
       } else
       {
-          val_print(AVS_PRINT_ERR, "\n      BDF 0x%x BME functionality failure", erp_bdf);
+          val_print(AVS_PRINT_ERR, "\n      Root Port BDF 0x%x BME functionality failure", erp_bdf);
           fail_cnt++;
       }
 
       /* Restore Rootport Bus Master Enable */
       val_pcie_enable_bme(erp_bdf);
+
+      /* Check if UR detected bit is set in the Exerciser */
+      if (val_pcie_is_urd(e_bdf))
+      {
+          /* Clear urd bit in Device Status Register */
+          val_pcie_clear_urd(e_bdf);
+      } else
+      {
+          val_print(AVS_PRINT_ERR, "\n      Exerciser BDF 0x%x BME functionality failure", e_bdf);
+          fail_cnt++;
+      }
+
 
   }
 

--- a/test_pool/exerciser/test_e011.c
+++ b/test_pool/exerciser/test_e011.c
@@ -86,6 +86,7 @@ payload(void)
   uint32_t test_data_blk_size = page_size * TEST_DATA_NUM_PAGES;
   uint64_t *pgt_base_array;
   uint64_t translated_addr;
+  uint32_t test_skip = 1;
 
   /* Initialize DMA master and memory descriptors */
   val_memory_set(&master, sizeof(master), 0);
@@ -207,6 +208,8 @@ payload(void)
         dram_buf_out_iova = dram_buf_in_iova + (test_data_blk_size / 2);
     }
 
+    test_skip = 0;
+
     /* Send an ATS Translation Request for the VA */
     if (val_exerciser_ops(ATS_TXN_REQ, (uint64_t)dram_buf_in_virt + instance * test_data_blk_size, instance)) {
         val_print(AVS_PRINT_ERR, "\n       ATS Translation Req Failed exerciser %4x", instance);
@@ -260,7 +263,11 @@ payload(void)
     clear_dram_buf(dram_buf_in_virt, test_data_blk_size);
   }
 
-  val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
+  if (test_skip)
+    val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+  else
+    val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
+
   goto test_clean;
 
 test_fail:

--- a/test_pool/pcie/test_p008.c
+++ b/test_pool/pcie/test_p008.c
@@ -123,6 +123,7 @@ payload (void)
   uint64_t current_dev_bdf;
   uint64_t next_dev_bdf;
   uint32_t count_next;
+  uint32_t test_skip = 1;
 
   if(!count) {
      val_set_status (index, RESULT_SKIP (g_sbsa_level, TEST_NUM, 3));
@@ -155,6 +156,7 @@ payload (void)
               next_dev_bdf = val_peripheral_get_info (ANY_BDF, count_next - 1);
               /* Read MSI(X) vectors */
               if (val_get_msi_vectors (next_dev_bdf, &next_dev_mvec)) {
+                test_skip = 0;
                 /* Compare two lists of MSI(X) vectors */
                 if(check_list_duplicates (current_dev_mvec, next_dev_mvec)) {
                   val_print (AVS_STATUS_ERR, "\n       Allocated MSIs are not unique", 0);
@@ -178,8 +180,11 @@ payload (void)
     count--;
   }
 
-  if (!status) {
-    val_set_status (index, RESULT_PASS (g_sbsa_level, TEST_NUM, 01));
+  if (test_skip) {
+    val_print(AVS_PRINT_ERR, "\n       No MSI vectors found ", 0);;
+    val_set_status (index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+  } else  if (!status) {
+    val_set_status (index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
   }
 }
 

--- a/test_pool/pcie/test_p009.c
+++ b/test_pool/pcie/test_p009.c
@@ -79,6 +79,7 @@ payload (void)
   uint8_t status;
   PERIPHERAL_VECTOR_LIST *dev_mvec, *mvec;
   uint64_t dev_bdf;
+  uint32_t test_skip = 1;
 
   if(!count) {
      val_set_status (index, RESULT_SKIP (g_sbsa_level, TEST_NUM, 2));
@@ -100,6 +101,7 @@ payload (void)
         val_print (AVS_PRINT_INFO, "       Checking PCI device with BDF %4X\n", dev_bdf);
         /* Read MSI(X) vectors */
         if (val_get_msi_vectors (dev_bdf, &dev_mvec)) {
+          test_skip = 0;
           mvec = dev_mvec;
           while(mvec) {
               if(mvec->vector.vector_irq_base < LPI_BASE) {
@@ -116,8 +118,11 @@ payload (void)
     count--;
   }
 
-  if (!status) {
-    val_set_status (index, RESULT_PASS (g_sbsa_level, TEST_NUM, 0));
+  if (test_skip) {
+    val_print(AVS_PRINT_ERR, "\n       No MSI vectors found ", 0);
+    val_set_status (index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 0));
+  } else if (!status) {
+    val_set_status (index, RESULT_PASS(g_sbsa_level, TEST_NUM, 0));
   }
 }
 

--- a/val/include/sbsa_avs_pcie.h
+++ b/val/include/sbsa_avs_pcie.h
@@ -41,7 +41,8 @@
 
 #define PCIE_INTERRUPT_LINE  0x3c
 #define PCIE_INTERRUPT_PIN   0x3d
-
+#define PCIE_INTERRUPT_PIN_SHIFT 0x8
+#define PCIE_INTERRUPT_PIN_MASK  0xFF
 #define PCIE_TYPE_ROOT_PORT  0x04 /* Root Port */
 #define PCIE_TYPE_DOWNSTREAM 0x06 /* Downstream Port */
 #define PCIE_TYPE_ENDPOINT   0x0  /* Express Endpoint */
@@ -201,6 +202,9 @@ val_pcie_is_cache_present(uint32_t bdf);
 
 uint32_t
 val_pcie_data_link_layer_status(uint32_t bdf);
+
+uint32_t
+val_pcie_check_interrupt_status(uint32_t bdf);
 
 uint32_t
 p001_entry(uint32_t num_pe);

--- a/val/include/sbsa_avs_pcie_spec.h
+++ b/val/include/sbsa_avs_pcie_spec.h
@@ -69,6 +69,8 @@
 #define CR_ID_MASK     0x1
 
 /* Status Register */
+#define SR_IS_SHIFT    19
+#define SR_IS_MASK     0x1
 #define SR_STA_SHIFT   27
 #define SR_STA_MASK    0x1
 
@@ -113,10 +115,11 @@
 #define BAR_BASE_MASK   0xfffffff
 
 /*BAR offset */
-#define BAR0_OFFSET        0x10
-#define BAR_MAX_OFFSET     0x24
-#define BAR_64_BIT         1
-#define BAR_32_BIT         0
+#define BAR0_OFFSET               0x10
+#define BAR_TYPE_0_MAX_OFFSET     0x24
+#define BAR_TYPE_1_MAX_OFFSET     0x14
+#define BAR_64_BIT                0x1
+#define BAR_32_BIT                0x0
 #define BAR_REG(bar_reg_value) ((bar_reg_value >> 2) & 0x1)
 
 #define TYPE0_MAX_BARS  6

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -170,6 +170,7 @@ void val_pcie_disable_bme(uint32_t bdf);
 void val_pcie_enable_bme(uint32_t bdf);
 void val_pcie_disable_msa(uint32_t bdf);
 void val_pcie_enable_msa(uint32_t bdf);
+uint32_t val_pcie_is_msa_enabled(uint32_t bdf);
 void val_pcie_clear_urd(uint32_t bdf);
 uint32_t val_pcie_is_urd(uint32_t bdf);
 void val_pcie_disable_eru(uint32_t bdf);

--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -1245,6 +1245,28 @@ val_pcie_enable_msa(uint32_t bdf)
 }
 
 /**
+  @brief  Reads the BAR memory space access in the command register.
+
+  @param  bdf   - Segment/Bus/Dev/Func in the format of PCIE_CREATE_BDF
+  @return 0 - Success
+          1 - Failure
+**/
+uint32_t
+val_pcie_is_msa_enabled(uint32_t bdf)
+{
+
+  uint32_t reg_value;
+
+  /* Enable MSE bit in Command Register to enable BAR memory space accesses */
+  val_pcie_read_cfg(bdf, TYPE01_CR, &reg_value);
+  reg_value &= (1 << CR_MSE_SHIFT);
+  if (reg_value)
+      return 0;
+  else
+      return 1;
+}
+
+/**
   @brief  Clears unsupported request detected bit in Device Status Register
 
   @param  bdf   - Segment/Bus/Dev/Func in the format of PCIE_CREATE_BDF
@@ -1967,3 +1989,23 @@ val_pcie_data_link_layer_status(uint32_t bdf)
 
    return PCIE_DLL_LINK_ACTIVE_NOT_SUPPORTED;
 }
+
+/**
+  @brief  Returns whether a PCIe Function has detected an Interrupt request
+
+  @param  bdf        - Segment/Bus/Dev/Func in the format of PCIE_CREATE_BDF
+  @return Returns 1 - if the Function has received an Interrupt Request or
+                  0 - if it does not detect Interrupt request
+**/
+uint32_t
+val_pcie_check_interrupt_status(uint32_t bdf)
+{
+
+  uint32_t reg_value;
+
+  val_pcie_read_cfg(bdf, TYPE01_CR, &reg_value);
+  reg_value = (reg_value >> SR_IS_SHIFT) & SR_IS_MASK;
+
+  return reg_value;
+}
+


### PR DESCRIPTION
PCIe: MSI: Test to skip if no msi vectors found
- Initially, the test was passing if no MSI vectors were found.
  It has been modified to skip if no MSI vectors are found.

PCIe: Test 405 runs for all PCIe devices
- Modified to use PCIe table instead peripheral table to get
  the PCIe device BDF.

PCIe: Using Bus number register to perform checks
- Bus number register is the only register in the list of
  mandatory registers that have continuous 24 bit read/write
  fields. No 32 bit read/write register is available.
- Removed 32 bit write check.

PCIe: Skip test 811 if ATS is not supported
- Exerciser Test-811 is passing instead of skipping when
  the exerciser functions don't support ATS.

Exerciser: Updated legacy interrupt test 806
- Obtain the interrupt numbers from platform cfg for
  bare-metal for the mentioned INTx# pin
- Check the interrupt status bit in the status register
  after generating the interrupt and after clearing the interrupt
- Check if multiple interrupts are received

PCIe: Check UR bit of exerciser with BME disabled
- After BME is disabled in root port, memory read request
  from exerciser should set the UR bit in both exercisers
  and its root port's device status register.

Signed-off-by: Gowtham Siddarth <gowtham.siddarth@arm.com>
Change-Id: I4466593ad8fd9671f2b466ef165ad9d9cac77ff1