### PR TITLE
Fix for Gic, PE Breakpoints, increased Mem Table size

### DIFF
--- a/platform/pal_uefi/include/pal_uefi.h
+++ b/platform/pal_uefi/include/pal_uefi.h
@@ -361,6 +361,7 @@ UINT32 pal_pcie_max_pasid_bits(UINT32 bdf);
 #define MEM_MAP_SUCCESS  0x0
 #define MEM_MAP_NO_MEM   0x1
 #define MEM_MAP_FAILURE  0x2
+#define MEM_INFO_TBL_MAX_ENTRY  500 /* Maximum entries to be added in Mem info table*/
 
 typedef enum {
   MEMORY_TYPE_DEVICE = 0x1000,

--- a/platform/pal_uefi/src/pal_peripherals.c
+++ b/platform/pal_uefi/src/pal_peripherals.c
@@ -268,7 +268,10 @@ pal_memory_create_info_table(MEMORY_INFO_TABLE *memoryInfoTable)
       memoryInfoTable->info[i].virt_addr = MemoryMapPtr->VirtualStart;
       memoryInfoTable->info[i].size      = (MemoryMapPtr->NumberOfPages * EFI_PAGE_SIZE);
       i++;
-
+      if (i >= MEM_INFO_TBL_MAX_ENTRY) {
+        sbsa_print(AVS_PRINT_DEBUG, L"Memory Info tbl limit exceeded, Skipping remaining\n", 0);
+        break;
+      }
       MemoryMapPtr = (EFI_MEMORY_DESCRIPTOR*)((UINTN)MemoryMapPtr + DescriptorSize);
     }
     memoryInfoTable->info[i].type      = MEMORY_TYPE_LAST_ENTRY;

--- a/test_pool/gic/test_g003.c
+++ b/test_pool/gic/test_g003.c
@@ -33,16 +33,18 @@ payload()
 
   data = val_gic_get_info(GIC_INFO_VERSION);
   if (data < 3) {
-     val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+     val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 1));
      return;
   }
 
   data = val_gic_get_info(GIC_INFO_SEC_STATES);
 
-  if (data != 0)
-      val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
+  if (data != 0) {
+      val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 1));
+      return;
+  }
 
-  val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
+  val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 1));
 }
 
 uint32_t

--- a/test_pool/pe/test_c014.c
+++ b/test_pool/pe/test_c014.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,19 +25,26 @@ static
 void payload()
 {
   uint64_t data = 0;
+  int32_t  breakpointcount;
+  uint32_t context_aware_breakpoints = 0;
   uint32_t pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
 
   data = val_pe_reg_read(ID_AA64DFR0_EL1);
 
-  if (((data >> 12) & 0xF) < 5) { //bits 15:12 for Number of breakpoints - 1
-      val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
+  /* bits 15:12 for Number of breakpoints - 1 */
+  breakpointcount = VAL_EXTRACT_BITS(data, 12, 15) + 1;
+
+  if (breakpointcount < 6) {
+      val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 1));
       return;
   }
 
-  if (((data >> 28) > 0))  //bits 31:28 for Number of context aware breakpoints - 1
-      val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
+  /*bits [31:28] Number of breakpoints that are context-aware, minus 1*/
+  context_aware_breakpoints = VAL_EXTRACT_BITS(data, 28, 31) + 1;
+  if (context_aware_breakpoints > 1)
+      val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 1));
   else
-      val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 02));
+      val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 2));
 
 
   return;
@@ -50,7 +57,6 @@ void payload()
 uint32_t
 c014_entry(uint32_t num_pe)
 {
-
   uint32_t status = AVS_STATUS_FAIL;
 
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe, g_sbsa_level);

--- a/uefi_app/SbsaAvs.h
+++ b/uefi_app/SbsaAvs.h
@@ -32,7 +32,7 @@
   #define GIC_INFO_TBL_SZ        8192 /*Supports maximum 256 redistributors, 256 ITS blocks & 4 distributors*/
   #define TIMER_INFO_TBL_SZ      1024 /*Supports maximum 2 system timers*/
   #define WD_INFO_TBL_SZ         512  /*Supports maximum 20 Watchdogs*/
-  #define MEM_INFO_TBL_SZ        4096 /*Supports maximum 110 memory regions*/
+  #define MEM_INFO_TBL_SZ        32768/*Supports maximum 800 memory regions*/
   #define IOVIRT_INFO_TBL_SZ     32768/*Supports maximum 240 nodes of a typical iort table*/
   #define PERIPHERAL_INFO_TBL_SZ 1024 /*Supports maximum 20 PCIe EPs (USB and SATA controllers only) */
   #define PCIE_INFO_TBL_SZ       512  /*Supports maximum 20 RC's*/

--- a/uefi_app/SbsaAvsMain.c
+++ b/uefi_app/SbsaAvsMain.c
@@ -34,7 +34,8 @@ UINT32  g_sbsa_level;
 UINT32  g_enable_pcie_tests;
 UINT32  g_print_level;
 UINT32  g_execute_nist;
-UINT32  g_skip_test_num[3] = {10000, 10000, 10000};
+UINT32  g_skip_test_num[MAX_TEST_SKIP_NUM] = { 10000, 10000, 10000, 10000, 10000,
+                                               10000, 10000, 10000, 10000 };
 UINT32  g_sbsa_tests_total;
 UINT32  g_sbsa_tests_pass;
 UINT32  g_sbsa_tests_fail;

--- a/val/include/sbsa_avs_cfg.h
+++ b/val/include/sbsa_avs_cfg.h
@@ -18,7 +18,7 @@
 #ifndef __SBSA_AVS_CFG_H__
 #define __SBSA_AVS_CFG_H__
 
-#define MAX_TEST_SKIP_NUM  3
+#define MAX_TEST_SKIP_NUM  9
 
 extern uint32_t g_sbsa_level;
 extern uint32_t g_print_level;

--- a/val/src/avs_peripherals.c
+++ b/val/src/avs_peripherals.c
@@ -48,7 +48,6 @@ val_peripheral_execute_tests(uint32_t level, uint32_t num_pe)
   status = d001_entry(num_pe);
   status |= d002_entry(num_pe);
   status |= d003_entry(num_pe);
-  status |= m001_entry(num_pe);
 
   if (status == AVS_STATUS_FAIL) {
       val_print(AVS_PRINT_ERR, "\n    One or more Peripheral tests have failed...\n", status);


### PR DESCRIPTION
Added return after the failure case in GIC
Fix for PE breakpoint check similar to BSA
Fix for limiting memory info table entry in pal_peripheral.c
Increased Skip test num from 3 to 9