### PR TITLE
Tests 301 and 302 : Fix -skip not working issue.

### DIFF
--- a/test_pool/timer_wd/test_w001.c
+++ b/test_pool/timer_wd/test_w001.c
@@ -88,9 +88,10 @@ w001_entry(uint32_t num_pe)
 
   num_pe = 1;  //This Timer test is run on single processor
 
-  val_initialize_test(TEST_NUM, TEST_DESC, num_pe, g_sbsa_level);
-
-  val_run_test_payload(TEST_NUM, num_pe, payload, 0);
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe, g_sbsa_level);
+  /* This check is when user is forcing us to skip this test */
+  if (status != AVS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_pe, payload, 0);
 
   /* get the result from all PE and check for failure */
   error_flag = val_check_for_error(TEST_NUM, num_pe);

--- a/test_pool/timer_wd/test_w002.c
+++ b/test_pool/timer_wd/test_w002.c
@@ -111,9 +111,10 @@ w002_entry(uint32_t num_pe)
 
   num_pe = 1;  //This Timer test is run on single processor
 
-  val_initialize_test(TEST_NUM, TEST_DESC, num_pe, g_sbsa_level);
-
-  val_run_test_payload(TEST_NUM, num_pe, payload, 0);
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe, g_sbsa_level);
+  /* This check is when user is forcing us to skip this test */
+  if (status != AVS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_pe, payload, 0);
 
   /* get the result from all PE and check for failure */
   error_flag = val_check_for_error(TEST_NUM, num_pe);


### PR DESCRIPTION
" -skip 301,302" doesn't work. It shows "USER OVERRIDE  - Skip Test"  message, but still runs the tests. 

301 : Check NS Watchdog Accessibility
       USER OVERRIDE  - Skip Test        : Result:  PASS
 302 : Check Watchdog WS0 interrupt
       USER OVERRIDE  - Skip Test        : Result:  PASS