### PR TITLE
Fix for WD test and wakeup tests status field incorrect update

### DIFF
--- a/platform/pal_baremetal/src/pal_misc.c
+++ b/platform/pal_baremetal/src/pal_misc.c
@@ -120,10 +120,10 @@ pal_mmio_read(uint64_t addr)
 void
 pal_mmio_write8(uint64_t addr, uint8_t data)
 {
-  *(volatile uint8_t *)addr = data;
   if (g_print_mmio || (g_curr_module & g_enable_module))
       print(AVS_PRINT_INFO, " pal_mmio_write8 Address = %llx  Data = %lx \n", addr, data);
 
+  *(volatile uint8_t *)addr = data;
 }
 
 /**
@@ -138,10 +138,10 @@ pal_mmio_write8(uint64_t addr, uint8_t data)
 void
 pal_mmio_write16(uint64_t addr, uint16_t data)
 {
-  *(volatile uint16_t *)addr = data;
   if (g_print_mmio || (g_curr_module & g_enable_module))
       print(AVS_PRINT_INFO, " pal_mmio_write16 Address = %llx  Data = %lx \n", addr, data);
 
+  *(volatile uint16_t *)addr = data;
 }
 
 /**
@@ -156,10 +156,10 @@ pal_mmio_write16(uint64_t addr, uint16_t data)
 void
 pal_mmio_write64(uint64_t addr, uint64_t data)
 {
-  *(volatile uint64_t *)addr = data;
   if (g_print_mmio || (g_curr_module & g_enable_module))
       print(AVS_PRINT_INFO, " pal_mmio_write64 Address = %llx  Data = %llx \n", addr, data);
 
+  *(volatile uint64_t *)addr = data;
 }
 
 /**
@@ -180,10 +180,10 @@ pal_mmio_write(uint64_t addr, uint32_t data)
       addr = addr & ~(0x3);  //make sure addr is aligned to 4 bytes
   }
 
-    *(volatile uint32_t *)addr = data;
   if (g_print_mmio || (g_curr_module & g_enable_module))
       print(AVS_PRINT_INFO, " pal_mmio_write Address = %8x  Data = %x \n", addr, data);
 
+    *(volatile uint32_t *)addr = data;
 }
 
 /**

--- a/platform/pal_uefi/src/pal_misc.c
+++ b/platform/pal_uefi/src/pal_misc.c
@@ -39,10 +39,11 @@ UINT8   *gSharedMemory;
 VOID
 pal_mmio_write8(UINT64 addr, UINT8 data)
 {
-  *(volatile UINT8 *)addr = data;
+
   if (g_print_mmio || (g_curr_module & g_enable_module))
       sbsa_print(AVS_PRINT_INFO, L" pal_mmio_write8 Address = %llx  Data = %lx \n", addr, data);
 
+  *(volatile UINT8 *)addr = data;
 }
 
 /**
@@ -57,10 +58,11 @@ pal_mmio_write8(UINT64 addr, UINT8 data)
 VOID
 pal_mmio_write16(UINT64 addr, UINT16 data)
 {
-  *(volatile UINT16 *)addr = data;
+
   if (g_print_mmio || (g_curr_module & g_enable_module))
       sbsa_print(AVS_PRINT_INFO, L" pal_mmio_write16 Address = %llx  Data = %lx \n", addr, data);
 
+  *(volatile UINT16 *)addr = data;
 }
 
 /**
@@ -75,10 +77,11 @@ pal_mmio_write16(UINT64 addr, UINT16 data)
 VOID
 pal_mmio_write64(UINT64 addr, UINT64 data)
 {
-  *(volatile UINT64 *)addr = data;
+
   if (g_print_mmio || (g_curr_module & g_enable_module))
       sbsa_print(AVS_PRINT_INFO, L" pal_mmio_write64 Address = %llx  Data = %lx \n", addr, data);
 
+  *(volatile UINT64 *)addr = data;
 }
 
 /**
@@ -178,9 +181,10 @@ pal_mmio_read(UINT64 addr)
 VOID
 pal_mmio_write(UINT64 addr, UINT32 data)
 {
-  *(volatile UINT32 *)addr = data;
   if (g_print_mmio || (g_curr_module & g_enable_module))
     sbsa_print(AVS_PRINT_INFO, L" pal_mmio_write Address = %llx  Data = %x \n", addr, data);
+
+  *(volatile UINT32 *)addr = data;
 }
 
 /**

--- a/platform/pal_uefi/src/pal_timer_wd.c
+++ b/platform/pal_uefi/src/pal_timer_wd.c
@@ -107,7 +107,7 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
       GtEntry->type = TIMER_TYPE_SYS_TIMER;
       GtEntry->block_cntl_base = Entry->CntCtlBase;
       GtEntry->timer_count     = Entry->GTBlockTimerCount;
-      sbsa_print(AVS_PRINT_DEBUG, L" CNTCTLBase = %x \n", GtEntry->block_cntl_base);
+      sbsa_print(AVS_PRINT_DEBUG, L" CNTCTLBase = %llx \n", GtEntry->block_cntl_base);
       GtBlockTimer = (EFI_ACPI_6_1_GTDT_GT_BLOCK_TIMER_STRUCTURE *)(((UINT8 *)Entry) + Entry->GTBlockTimerOffset);
       for (i = 0; i < GtEntry->timer_count; i++) {
         sbsa_print(AVS_PRINT_INFO, L" Found timer entry \n");
@@ -118,7 +118,7 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
         GtEntry->virt_gsiv[i]    = GtBlockTimer->GTxVirtualTimerGSIV;
         GtEntry->flags[i]        = GtBlockTimer->GTxPhysicalTimerFlags | (GtBlockTimer->GTxVirtualTimerFlags << 8) | (GtBlockTimer->GTxCommonFlags << 16);
         sbsa_print(AVS_PRINT_DEBUG,
-                   L" CNTBaseN = %x for sys counter = %d\n", GtEntry->GtCntBase[i], i);
+                   L" CNTBaseN = %llx for sys counter = %d\n", GtEntry->GtCntBase[i], i);
         GtBlockTimer++;
         TimerTable->header.num_platform_timer++;
       }
@@ -206,7 +206,7 @@ pal_wd_create_info_table(WD_INFO_TABLE *WdTable)
       WdEntry->wd_flags        = Entry->WatchdogTimerFlags;
       WdTable->header.num_wd++;
       sbsa_print(AVS_PRINT_DEBUG,
-                 L" Watchdog base = 0x%x INTID = 0x%x \n", WdEntry->wd_ctrl_base,
+                 L" Watchdog base = 0x%llx INTID = 0x%x \n", WdEntry->wd_ctrl_base,
                  WdEntry->wd_gsiv);
       WdEntry++;
     }

--- a/test_pool/power_wakeup/test_u001.c
+++ b/test_pool/power_wakeup/test_u001.c
@@ -207,7 +207,7 @@ payload4()
           wakeup_set_failsafe();
           status = val_wd_set_ws0(timer_num, timer_expire_val);
           if (status) {
-              val_print(AVS_PRINT_ERR, "\n       Setting watchdof timeout failed", 0);
+              val_print(AVS_PRINT_ERR, "\n       Setting watchdog timeout failed", 0);
               val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM4, 02));
               return;
           }

--- a/test_pool/timer_wd/test_t008.c
+++ b/test_pool/timer_wd/test_t008.c
@@ -47,7 +47,7 @@ payload()
 {
 
   volatile uint32_t timeout;
-  uint32_t timer_expire_val = 1000;
+  uint32_t timer_expire_val = TIMEOUT_MEDIUM;
   uint32_t status, ns_timer = 0;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
   uint64_t timer_num = val_timer_get_info(TIMER_INFO_NUM_PLATFORM_TIMERS, 0);
@@ -93,7 +93,7 @@ payload()
       while ((--timeout > 0) && (IS_RESULT_PENDING(val_get_status(index))));
 
       if (timeout == 0){
-          val_print(AVS_PRINT_ERR, "\n       Sys timer interrupt not received on %d   ", intid);
+           val_print(AVS_PRINT_ERR, "\n       Sys timer interrupt not received on %d   ", intid);
           val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
           return;
       }

--- a/test_pool/timer_wd/test_w001.c
+++ b/test_pool/timer_wd/test_w001.c
@@ -50,9 +50,9 @@ payload()
 
       ns_wdg++;
       refresh_base = val_wd_get_info(wd_num, WD_INFO_REFRESH_BASE);
-      val_print(AVS_PRINT_INFO, "\n       Watchdog Refresh base is %x ", refresh_base);
+      val_print(AVS_PRINT_INFO, "\n       Watchdog Refresh base is %llx ", refresh_base);
       ctrl_base    = val_wd_get_info(wd_num, WD_INFO_CTRL_BASE);
-      val_print(AVS_PRINT_INFO, "\n       Watchdog CTRL base is  %x      ", ctrl_base);
+      val_print(AVS_PRINT_INFO, "\n       Watchdog CTRL base is  %llx      ", ctrl_base);
 
       data = val_mmio_read(ctrl_base);
       //Control register bits 31:4 are reserved 0

--- a/test_pool/timer_wd/test_w002.c
+++ b/test_pool/timer_wd/test_w002.c
@@ -79,7 +79,7 @@ payload()
 
       status = val_wd_set_ws0(wd_num, timer_expire_ticks);
       if (status) {
-          val_print(AVS_PRINT_ERR, "\n       Setting watchdof timeout failed", 0);
+          val_print(AVS_PRINT_ERR, "\n       Setting watchdog timeout failed", 0);
           val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 02));
           return;
       }

--- a/test_pool/timer_wd/test_w003.c
+++ b/test_pool/timer_wd/test_w003.c
@@ -54,7 +54,7 @@ payload()
 
       ns_wdg++;
       ctrl_base    = val_wd_get_info(wd_num, WD_INFO_CTRL_BASE);
-      val_print(AVS_PRINT_INFO, "\n      Watchdog CTRL base is  %x      ", ctrl_base);
+      val_print(AVS_PRINT_INFO, "\n      Watchdog CTRL base is  %llx      ", ctrl_base);
 
       /* W_IIDR.Architecture Revision [19:16] = 0x1 for Watchdog Rev 1 */
       data = VAL_EXTRACT_BITS(val_mmio_read(ctrl_base + WD_IIDR_OFFSET), 16, 19);

--- a/val/src/avs_wd.c
+++ b/val/src/avs_wd.c
@@ -160,7 +160,7 @@ val_wd_set_ws0(uint32_t index, uint32_t timeout)
   uint64_t counter_freq;
   uint32_t wor_l;
   uint32_t wor_h = 0;
-  uint32_t ctrl_base;
+  uint64_t ctrl_base;
   uint32_t data;
 
   if (timeout == 0) {


### PR DESCRIPTION
WD: Watchdog ctrl base is incorrectly accessed as 32 bit which was leading to crash in some systems.
Status Field: Due to UART print delay after enabling timeout in wakeup test the status field was not correctly updated in some systems.