### PR TITLE
Do not run test 303 below SBSA level 5

### DIFF
--- a/val/src/avs_wd.c
+++ b/val/src/avs_wd.c
@@ -46,7 +46,8 @@ val_wd_execute_tests(uint32_t level, uint32_t num_pe)
   g_curr_module = 1 << WD_MODULE;
   status = w001_entry(num_pe);
   status |= w002_entry(num_pe);
-  status |= w003_entry(num_pe);
+  if (level > 4)
+	status |= w003_entry(num_pe);
 
   if (status != 0)
     val_print(AVS_PRINT_TEST, "\n      ***One or more tests have failed... *** \n", 0);


### PR DESCRIPTION
Test skips itself if run below level 5:

*** Starting Watchdog tests ***
301 : Check NS Watchdog Accessibility   : Result:  PASS
302 : Check Watchdog WS0 interrupt      : Result:  PASS
303 : Check NS Watchdog Revision        : Result:  -SKIPPED- 1

So why run it at all?