### PR TITLE
PCIe Exerciser tests are SBSA level 4+

### DIFF
--- a/uefi_app/SbsaAvsMain.c
+++ b/uefi_app/SbsaAvsMain.c
@@ -480,11 +480,13 @@ ShellAppMainsbsa (
   /*
    * Configure Gic Redistributor and ITS to support
    * Generation of LPIs.
-  */
+   */
   configureGicIts();
 
-  Print(L"\n      *** Starting PCIe Exerciser tests ***  \n");
-  Status |= val_exerciser_execute_tests(g_sbsa_level);
+  if (g_sbsa_level > 3) { 
+    Print(L"\n      *** Starting PCIe Exerciser tests ***  \n");
+    Status |= val_exerciser_execute_tests(g_sbsa_level);
+  }
 
   #ifdef ENABLE_NIST
   if (g_execute_nist == TRUE) {

--- a/val/src/avs_exerciser.c
+++ b/val/src/avs_exerciser.c
@@ -219,11 +219,6 @@ val_exerciser_execute_tests(uint32_t level)
   uint32_t status, i;
   uint32_t num_instances;
 
-  if (level == 3) {
-    val_print(AVS_PRINT_WARN, "Exerciser Sbsa compliance is only from Level %d \n", 4);
-    return AVS_STATUS_SKIP;
-  }
-
   for (i = 0; i < MAX_TEST_SKIP_NUM; i++){
       if (g_skip_test_num[i] == AVS_EXERCISER_TEST_NUM_BASE) {
           val_print(AVS_PRINT_TEST, "\n USER Override - Skipping three Exerciser tests \n", 0);


### PR DESCRIPTION
So no need to inform about them on lower levels.