### PR TITLE
test 301: align output in Debug mode

### DIFF
--- a/test_pool/timer_wd/test_w001.c
+++ b/test_pool/timer_wd/test_w001.c
@@ -34,7 +34,7 @@ payload()
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
   uint32_t data, ns_wdg = 0;
 
-  val_print(AVS_PRINT_DEBUG, "\n       Found %d watchdogs in ACPI table ", wd_num);
+  val_print(AVS_PRINT_DEBUG, "\n       Found %d watchdogs in ACPI table   ", wd_num);
 
   if (wd_num == 0) {
       val_print(AVS_PRINT_WARN, "\n       No Watchdogs reported          %d  ", wd_num);


### PR DESCRIPTION
Was:
```
 301 : Check NS Watchdog Accessibility
       Found 1 watchdogs in ACPI table : Result:  PASS
 302 : Check Watchdog WS0 interrupt
       WS0 Interrupt id  48
       Setting Trigger type as 1
       Received WS0 interrupt            : Result:  PASS
```
Is:
```
 301 : Check NS Watchdog Accessibility
       Found 1 watchdogs in ACPI table   : Result:  PASS
 302 : Check Watchdog WS0 interrupt
       WS0 Interrupt id  48
       Setting Trigger type as 1
       Received WS0 interrupt            : Result:  PASS
```