### PR TITLE
improve printing table on SMMU v2 systems

### DIFF
--- a/val/src/avs_peripherals.c
+++ b/val/src/avs_peripherals.c
@@ -207,7 +207,7 @@ val_peripheral_create_info_table(uint64_t *peripheral_info_table)
 
   pal_peripheral_create_info_table(g_peripheral_info_table);
 
-  val_print(AVS_PRINT_TEST, " Peripheral: Num of USB controllers   :    %d \n",
+  val_print(AVS_PRINT_TEST, "\n Peripheral: Num of USB controllers   :    %d \n",
     val_peripheral_get_info(NUM_USB, 0));
   val_print(AVS_PRINT_TEST, " Peripheral: Num of SATA controllers  :    %d \n",
     val_peripheral_get_info(NUM_SATA, 0));


### PR DESCRIPTION
Was:

 SMMU_INFO: Number of SMMU CTRL       :    1

      val_smmu_init: only SMMUv3.x supported, skipping smmu 0
      smmu_set_state: smmu unsupported      Peripheral: Num of USB controllers
 :    2
 Peripheral: Num of SATA controllers  :    4

Is:

 SMMU_INFO: Number of SMMU CTRL       :    1

      val_smmu_init: only SMMUv3.x supported, skipping smmu 0
      smmu_set_state: smmu unsupported
 Peripheral: Num of USB controllers   :    2
 Peripheral: Num of SATA controllers  :    4
 Peripheral: Num of UART controllers  :    1