### PR TITLE
test 704: align output on SMMU v2

### DIFF
--- a/test_pool/io_virt/test_i004.c
+++ b/test_pool/io_virt/test_i004.c
@@ -51,7 +51,7 @@ payload()
 
   while (num_smmu--) {
       if (val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu) == 2) {
-          val_print(AVS_PRINT_WARN, "\n       Not valid for SMMU v2           ", 0);
+          val_print(AVS_PRINT_WARN, "\n       Not valid for SMMU v2             ", 0);
           val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
           return;
       }


### PR DESCRIPTION
Was:
```
 703 : SMMU Compatibility Check          : Result:  PASS
 704 : If PCIe, Check Stall model
       Not valid for SMMU v2           : Result:  -SKIPPED- 1
 705 : SMMUv2 unique intr per ctxt bank  : Result:  PASS
```