### PR TITLE
WD test 303 changes

### DIFF
--- a/test_pool/timer_wd/test_w003.c
+++ b/test_pool/timer_wd/test_w003.c
@@ -67,9 +67,9 @@ payload()
           }
       }
 
-      if (g_sbsa_level == 6) {
+      if (g_sbsa_level > 5) {
           if (data != 1) {
-              val_print(AVS_PRINT_ERR, "\n       Recommended Watchdog Rev 1 Not Found", 0);
+              val_print(AVS_PRINT_ERR, "\n       Watchdog Rev 1 Not Found", 0);
               val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 02));
               return;
           }


### PR DESCRIPTION
- corrected failure error message
- test was made mandatory for level 6 and above.

Signed-off-by: Amrathesh <amrathesh@arm.com>