### PR TITLE
Show expected/present values for PCIe tests

### DIFF
--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -1532,6 +1532,8 @@ uint32_t val_pcie_bitfield_check(uint32_t bdf, uint64_t *bitfield_entry)
   {
       val_print(AVS_PRINT_ERR, "\n       BDF 0x%x : ", bdf);
       val_print(AVS_PRINT_ERR, bf_entry->err_str1, 0);
+      val_print(AVS_PRINT_ERR, ": 0x%x", bf_value);
+      val_print(AVS_PRINT_ERR, " instead of 0x%x", bf_entry->cfg_value);
       if (!val_strncmp(bf_entry->err_str1, "WARNING", WARN_STR_LEN))
           return 0;
       return 1;
@@ -1586,6 +1588,8 @@ uint32_t val_pcie_bitfield_check(uint32_t bdf, uint64_t *bitfield_entry)
   {
       val_print(AVS_PRINT_ERR, "\n       BDF 0x%x : ", bdf);
       val_print(AVS_PRINT_ERR, bf_entry->err_str2, 0);
+      val_print(AVS_PRINT_ERR, ": 0x%x", reg_overwrite_value);
+      val_print(AVS_PRINT_ERR, " instead of 0x%x", reg_value);
       if (!val_strncmp(bf_entry->err_str2, "WARNING", WARN_STR_LEN))
           return 0;
       return 1;


### PR DESCRIPTION
It could be helpful to see which values are present and which are expected in PCIe tests.

```
 424 : Check Device capabilites reg rules
       BDF 0x100 : ETFS value mismatch: 0x0 instead of 0x1
       BDF 0x300 : ETFS value mismatch: 0x0 instead of 0x1
       BDF 0x100 : ETFS value mismatch: 0x0 instead of 0x1
       BDF 0x300 : ETFS value mismatch: 0x0 instead of 0x1
       Failed on PE -    0 for Level=  3 : Result:  --FAIL-- 4 
 425 : Check Device Control register rule
       BDF 0x100 : WARNING PFE attribute mismatch: 0x200 instead of 0x0
       BDF 0x100 : WARNING APPE attribute mismatch: 0x400 instead of 0x0
       BDF 0x300 : WARNING PFE attribute mismatch: 0x200 instead of 0x0
       BDF 0x300 : WARNING APPE attribute mismatch: 0x400 instead of 0x0
       BDF 0x100 : WARNING PFE attribute mismatch: 0x200 instead of 0x0
       BDF 0x100 : WARNING APPE attribute mismatch: 0x400 instead of 0x0
       BDF 0x300 : WARNING PFE attribute mismatch: 0x200 instead of 0x0
       BDF 0x300 : WARNING APPE attribute mismatch: 0x400 instead of 0x0: Result
:  PASS 
```

Does it make sense?