### PR TITLE
SMMU hang issue fix and WD test 504 updates

### DIFF
--- a/val/include/sbsa_avs_pe.h
+++ b/val/include/sbsa_avs_pe.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2022, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -292,6 +292,8 @@ uint64_t AA64ReadFar2(void);
 uint64_t ArmRdvl(void);
 
 void ArmCallWFI(void);
+
+void ArmExecuteMemoryBarrier(void);
 
 void SpeProgramUnderProfiling(uint64_t interval, uint64_t address);
 

--- a/val/src/AArch64/PeTestSupport.S
+++ b/val/src/AArch64/PeTestSupport.S
@@ -1,5 +1,5 @@
 #/** @file
-# Copyright (c) 2016-2019, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2016-2019, 2022 Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,7 @@
 GCC_ASM_EXPORT (ArmCallWFI)
 GCC_ASM_EXPORT (SpeProgramUnderProfiling)
 GCC_ASM_EXPORT (DisableSpe)
+GCC_ASM_EXPORT (ArmExecuteMemoryBarrier)
 
 ASM_PFX(ArmCallWFI):
   wfi
@@ -63,4 +64,8 @@ ASM_PFX(DisableSpe):
   //msr   pmblimitr_el1,x0
   isb
 
+  ret
+
+ASM_PFX(ArmExecuteMemoryBarrier):
+  dmb sy
   ret

--- a/val/sys_arch_src/smmu_v3/smmu_v3.c
+++ b/val/sys_arch_src/smmu_v3/smmu_v3.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2020-2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2022, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -99,6 +99,7 @@ static int smmu_cmdq_write_cmd(smmu_dev_t *smmu, uint64_t *cmd)
     for (i = 0; i < CMDQ_DWORDS_PER_ENT; ++i)
         cmd_dst[i] = cmd[i];
     queue.prod = smmu_cmdq_inc_prod(&queue);
+    ArmExecuteMemoryBarrier();
     val_mmio_write((uint64_t)cmdq->prod_reg, queue.prod);
 
     return ret;
@@ -130,6 +131,7 @@ static void smmu_cmdq_poll_until_consumed(smmu_dev_t *smmu)
         if (smmu_queue_empty(&queue))
             break;
         queue.cons = val_mmio_read((uint64_t)cmdq->cons_reg);
+        timeout--;
     }
 
     if (!timeout) {

--- a/val/sys_arch_src/smmu_v3/smmu_v3.h
+++ b/val/sys_arch_src/smmu_v3/smmu_v3.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2020, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,7 @@
 #include "../include/sbsa_avs_iovirt.h"
 #include "../include/sbsa_avs_pgt.h"
 #include "smmu_reg.h"
+#include "../include/sbsa_avs_pe.h"
 
 static uint64_t inline get_max(uint64_t x, uint64_t y)
 {


### PR DESCRIPTION
- SMMU init code updated with timeout and memory barrier.
- Test 501 updated to treat PE wakeup from any interrupt as success

Signed-off-by: Amrathesh <amrathesh@arm.com>