### PR TITLE
Fix for the exception issue caused by RootPort Memory Access tests (448 and 449)

### DIFF
--- a/test_pool/pcie/test_p048.c
+++ b/test_pool/pcie/test_p048.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2020, 2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2022 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,10 +53,10 @@ payload(void)
   uint32_t pe_index;
   uint32_t tbl_index;
   uint32_t read_value, old_value, value;
+  uint32_t status;
   uint32_t test_skip = 1;
   uint64_t mem_base;
   uint64_t mem_lim, new_mem_lim;
-  uint32_t status;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   tbl_index = 0;
@@ -92,8 +92,7 @@ payload(void)
       bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
       dp_type = val_pcie_device_port_type(bdf);
 
-      if ((dp_type == RP) || (dp_type == iEP_RP))
-      {
+      if ((dp_type == RP) || (dp_type == iEP_RP)) {
         /* Part 1:
          * Check When Address is within the Range of Non-Prefetchable
          * Memory Range.
@@ -124,18 +123,27 @@ payload(void)
         *(volatile uint32_t *)(mem_base + MEM_OFFSET_10) = KNOWN_DATA;
         read_value = (*(volatile uint32_t *)(mem_base + MEM_OFFSET_10));
 
-        /*Accessing out of range of limit should return 0xFFFFFFFF*/
+        //
+        // Accessing out of range of limit should return 0xFFFFFFFF
+        //
         if ((mem_lim >> MEM_SHIFT) > (mem_base >> MEM_SHIFT))
         {
-           new_mem_lim = mem_base + MEM_OFF_100000;
-           mem_base = mem_base | (mem_base  >> 16);
-           val_pcie_write_cfg(bdf, TYPE1_NP_MEM, mem_base);
+           //
+           // Reduce the size of memory windows by 1MB
+           //
+           new_mem_lim = mem_lim + 1 - MEM_OFF_100000;
+           val_pcie_write_cfg(bdf, TYPE1_NP_MEM, ((new_mem_lim & MEM_LIM_MASK) | (mem_base  >> 16)));
            val_pcie_read_cfg(bdf, TYPE1_NP_MEM, &read_value);
 
+           //
+           //Accessing out of new memory windows
+           //
            value = (*(volatile uint32_t *)(new_mem_lim + MEM_OFFSET_10));
 
-           /*Write back original value */
-           val_pcie_write_cfg(bdf, TYPE1_NP_MEM, ((mem_lim & MEM_LIM_MASK) | (mem_base  >> 16)));
+           //
+           // Write back original size of memory windows 
+           //
+           val_pcie_write_cfg(bdf, TYPE1_NP_MEM, ((mem_lim & MEM_LIM_MASK) | (mem_base  >> MEM_BASE_SHIFT)));
 
            if (value != PCIE_UNKNOWN_RESPONSE)
            {


### PR DESCRIPTION
The problem with current RootPort Memory Access tests (448 and 449)
is that it changes the memory window (memory limit) without
considering the end-point device behind the root port. In other words,
the new memory window doesn't cover the region that is being used by
the end-point device. That caused system to run into exception. In the
worst case, the system may enter a weird state to cause fake failures
with some other test cases (e.g. Timer Wakeup tests (501, 502, 503)) or 
cause some devices non-functional.

Therefore, the fix is to only slightly reduce the size of memory
windows by 1MB instead of giving only 1MB memory windows to not
affect the end-point device behind the tested root port.

By the way, we can later work on a better solution to check the
end-point device's BAR and then change the end-point device's BAR
for need and determine the size of memory windows. However, at this
moment, since no platform can pass these two test cases, let's use
this simple solution for the short term.

Signed-off-by: Sunny Wang <sunny.wang@arm.com>