### PR TITLE
PCIe: Fix for issues #232 and #238

### DIFF
--- a/test_pool/pcie/test_p030.c
+++ b/test_pool/pcie/test_p030.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019-2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2022, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -122,33 +122,26 @@ payload(void)
 
       /*
        * Read memory mapped BAR to cause unsupported request
-       * detected bit set in Device Status Register of the pcie
-       * Function. Based on platform configuration, this may
+       * response. Based on platform configuration, this may
        * even cause an sync/async exception.
        */
       bar_data = (*(volatile addr_t *)bar_base);
 
 exception_return:
       /*
-       * Check if unsupported request detected bit isn't set
-       * and if either of UR response or abort isn't received.
+       * Check if either of UR response or abort isn't received.
        */
-      if ((val_pcie_is_urd(bdf)) &&
-          (IS_TEST_PASS(val_get_status(pe_index)) || (bar_data == PCIE_UNKNOWN_RESPONSE)))
+      if (!(IS_TEST_PASS(val_get_status(pe_index)) || (bar_data == PCIE_UNKNOWN_RESPONSE)))
       {
-          /* Clear urd bit in Device Status Register */
-          val_pcie_clear_urd(bdf);
-       } else
-       {
-           val_print(AVS_PRINT_ERR, "\n      BDF %x MSE functionality failure", bdf);
-           test_fails++;
-       }
+          val_print(AVS_PRINT_ERR, "\n      BDF %x MSE functionality failure", bdf);
+          test_fails++;
+      }
 
-       /* Enable memory space access to decode BAR addresses */
-       val_pcie_enable_msa(bdf);
+      /* Enable memory space access to decode BAR addresses */
+      val_pcie_enable_msa(bdf);
 
-       /* Reset the loop variables */
-       bar_data = 0;
+      /* Reset the loop variables */
+      bar_data = 0;
   }
 
   if (test_skip == 1)

--- a/test_pool/pcie/test_p043.c
+++ b/test_pool/pcie/test_p043.c
@@ -19,6 +19,7 @@
 #include "val/include/val_interface.h"
 
 #include "val/include/sbsa_avs_pcie.h"
+#include "val/include/sbsa_avs_pcie_spec.h"
 #include "val/include/sbsa_avs_pe.h"
 #include "val/include/sbsa_avs_memory.h"
 
@@ -70,9 +71,10 @@ payload(void)
           val_pcie_read_cfg(bdf, TYPE1_PBN, &reg_value);
           sec_bus = ((reg_value >> SECBN_SHIFT) & SECBN_MASK);
           sub_bus = ((reg_value >> SUBBN_SHIFT) & SUBBN_MASK);
+          status = val_pcie_data_link_layer_status(bdf);
 
           /* Skip the port, if switch is present below it or no device present*/
-          if ((sec_bus != sub_bus) || (sec_bus == 0))
+          if ((sec_bus != sub_bus) || (status != PCIE_DLL_LINK_STATUS_ACTIVE))
               continue;
 
           /* If test runs for atleast an endpoint */

--- a/val/include/sbsa_avs_pcie_spec.h
+++ b/val/include/sbsa_avs_pcie_spec.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019-2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2022, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -212,7 +212,7 @@
 #define LCAPR_DLLLARC_MASK  0x100000
 
 /* Link Status register shifts and masks */
-#define LSTAT_DLLLA_SHIFT   13
+#define LSTAT_DLLLA_SHIFT   29
 #define LSTAT_DLLLA_MASK    0x20000000
 
 /* Device Capabilities register */

--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -1867,6 +1867,7 @@ val_pcie_get_rootport(uint32_t bdf, uint32_t *rp_bdf)
 {
 
   uint32_t index;
+  uint32_t seg_num;
   uint32_t sec_bus;
   uint32_t sub_bus;
   uint32_t reg_value;
@@ -1902,13 +1903,15 @@ val_pcie_get_rootport(uint32_t bdf, uint32_t *rp_bdf)
        * bus number falls within that range.
        */
       val_pcie_read_cfg(*rp_bdf, TYPE1_PBN, &reg_value);
+      seg_num = PCIE_EXTRACT_BDF_SEG(*rp_bdf);
       sec_bus = ((reg_value >> SECBN_SHIFT) & SECBN_MASK);
       sub_bus = ((reg_value >> SUBBN_SHIFT) & SUBBN_MASK);
       dp_type = val_pcie_device_port_type(*rp_bdf);
 
       if (((dp_type == RP) || (dp_type == iEP_RP)) &&
           (sec_bus <= PCIE_EXTRACT_BDF_BUS(bdf)) &&
-          (sub_bus >= PCIE_EXTRACT_BDF_BUS(bdf)))
+          (sub_bus >= PCIE_EXTRACT_BDF_BUS(bdf)) &&
+          (seg_num == PCIE_EXTRACT_BDF_SEG(bdf)))
           return 0;
   }
 


### PR DESCRIPTION
- Test p030.c
  When MSE is disabled, Root is required to treat this request as
  a UR completion. PCIe forbids root ports from logging UR in
  device status for outbound requests.

- Test p043.c
  The secondary and primary bus values of RP will not be 0
  as it will be set during enumeration. Whether a device is
  present below a RP can be verified by checking the
  Data Link Layer Link Active of RP

- Adding seg_num check for RP derivation.

Co-Authored-by: Gowtham Siddarth <gowtham.siddarth@arm.com>
Co-authored-by: Chetan Rathore <chetan.rathore@arm.com>

Signed-off-by: Sujana M <sujana.m@arm.com>