### PR TITLE
Github #242 Moved timeout in multiples of system counter frequency

### DIFF
--- a/test_pool/power_wakeup/test_u001.c
+++ b/test_pool/power_wakeup/test_u001.c
@@ -38,6 +38,7 @@ static uint32_t intid;
 uint64_t timer_num;
 static uint32_t g_wd_int_received;
 static uint32_t g_failsafe_int_received;
+extern uint32_t g_wakeup_timeout;
 
 static
 void
@@ -121,7 +122,7 @@ static
 void
 wakeup_set_failsafe(void)
 {
-  uint64_t timer_expire_val = val_get_counter_frequency() * 2;
+  uint64_t timer_expire_val = val_get_counter_frequency() * (g_wakeup_timeout + 1);
 
   intid = val_timer_get_info(TIMER_INFO_PHY_EL1_INTID, 0);
   val_gic_install_isr(intid, isr_failsafe);
@@ -140,7 +141,7 @@ static
 void
 payload1(void)
 {
-  uint64_t timer_expire_val = TIMEOUT_SMALL;
+  uint64_t timer_expire_val = val_get_counter_frequency() * g_wakeup_timeout;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
   val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
@@ -156,7 +157,7 @@ static
 void
 payload2(void)
 {
-  uint64_t timer_expire_val = TIMEOUT_SMALL;
+  uint64_t timer_expire_val = val_get_counter_frequency() * g_wakeup_timeout;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
   val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM2, 01));
@@ -173,7 +174,7 @@ static
 void
 payload3(void)
 {
-  uint64_t timer_expire_val = TIMEOUT_SMALL;
+  uint64_t timer_expire_val = val_get_counter_frequency() * g_wakeup_timeout;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
   val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM3, 01));
@@ -191,7 +192,7 @@ void
 payload4(void)
 {
   uint32_t status, ns_wdg = 0;
-  uint64_t timer_expire_val = 1;
+  uint64_t timer_expire_val = 1 * g_wakeup_timeout;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
   timer_num = val_wd_get_info(0, WD_INFO_COUNT);
@@ -249,7 +250,7 @@ void
 payload5(void)
 {
   uint64_t cnt_base_n;
-  uint64_t timer_expire_val = TIMEOUT_SMALL;
+  uint64_t timer_expire_val = val_get_counter_frequency() * g_wakeup_timeout;
   uint32_t status, ns_timer = 0;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 

--- a/test_pool/timer_wd/test_t001.c
+++ b/test_pool/timer_wd/test_t001.c
@@ -32,6 +32,7 @@ payload(void)
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
   counter_freq = val_timer_get_info(TIMER_INFO_CNTFREQ, 0);
+  val_print(AVS_PRINT_DEBUG, "\n      Counter frequency is %x      ", counter_freq);
 
   if (counter_freq > 10*1000*1000) {
       val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));

--- a/test_pool/timer_wd/test_w002.c
+++ b/test_pool/timer_wd/test_w002.c
@@ -63,7 +63,7 @@ payload(void)
           continue;    //Skip Secure watchdog
 
       ns_wdg++;
-      timeout = val_timer_get_info(TIMER_INFO_CNTFREQ, 0) * 2;
+      timeout = val_get_counter_frequency() * 2;
       val_set_status(index, RESULT_PENDING(g_sbsa_level, TEST_NUM));     // Set the initial result to pending
 
       int_id       = val_wd_get_info(wd_num, WD_INFO_GSIV);

--- a/uefi_app/SbsaAvsMain.c
+++ b/uefi_app/SbsaAvsMain.c
@@ -45,6 +45,7 @@ UINT32  g_sbsa_tests_fail;
 UINT64  g_stack_pointer;
 UINT64  g_exception_ret_addr;
 UINT64  g_ret_addr;
+UINT32  g_wakeup_timeout;
 SHELL_FILE_HANDLE g_sbsa_log_file_handle;
 
 STATIC VOID FlushImage (VOID)
@@ -273,6 +274,8 @@ HelpMsg (
          "-nist   Enable the NIST Statistical test suite\n"
          "-p      Enable/disable PCIe SBSA 6.0 (RCiEP) compliance tests\n"
          "        1 - enables PCIe tests, 0 - disables PCIe tests\n"
+         "-timeout  Set timeout multiple for wakeup tests\n"
+         "        1 - min value  5 - max value\n"
   );
 }
 
@@ -286,6 +289,7 @@ STATIC CONST SHELL_PARAM_ITEM ParamList[] = {
   {L"-nist" , TypeFlag},     // -nist # Binary Flag to enable the execution of NIST STS
   {L"-p"    , TypeValue},    // -p    # Enable/disable PCIe SBSA 6.0 (RCiEP) compliance tests.
   {L"-mmio" , TypeFlag},     // -mmio # Enable pal_mmio prints
+  {L"-timeout" , TypeValue}, // -timeout # Set timeout multiple for wakeup tests
   {NULL     , TypeMax}
   };
 
@@ -369,6 +373,17 @@ ShellAppMainsbsa (
       g_print_level = G_PRINT_LEVEL;
     }
   }
+
+  // Options with Values
+  CmdLineArg  = ShellCommandLineGetValue (ParamPackage, L"-timeout");
+  if (CmdLineArg == NULL) {
+    g_wakeup_timeout = 1;
+  } else {
+    g_wakeup_timeout = StrDecimalToUintn(CmdLineArg);
+    Print(L"Wakeup timeout multiple %d.\n", g_wakeup_timeout);
+    if (g_wakeup_timeout > 5)
+        g_wakeup_timeout = 5;
+    }
 
     // Options with Values
   CmdLineArg  = ShellCommandLineGetValue (ParamPackage, L"-f");

--- a/val/src/avs_wd.c
+++ b/val/src/avs_wd.c
@@ -172,9 +172,7 @@ val_wd_set_ws0(uint32_t index, uint32_t timeout)
   data = VAL_EXTRACT_BITS(val_mmio_read(ctrl_base + WD_IIDR_OFFSET), 16, 19);
 
   /* Option to override system counter frequency value */
-  counter_freq = pal_timer_get_counter_frequency();
-  if (counter_freq == 0)
-      counter_freq = val_timer_get_info(TIMER_INFO_CNTFREQ, 0);
+  counter_freq = val_get_counter_frequency();
 
   /* Check if the timeout value exceeds */
   if (data == 0)


### PR DESCRIPTION
* Moved timeout in multiples of system counter frequency for power and wakeup tests
* In case the default value is not sufficient in some system, added timeout variable to increased timeout value in multiples of system counter. 