### PR TITLE
PCIe: Fixes and updates

### DIFF
--- a/baremetal_app/SbsaAvsMain.c
+++ b/baremetal_app/SbsaAvsMain.c
@@ -134,7 +134,7 @@ createPeripheralInfoTable(
                                         (1 * sizeof(PERIPHERAL_INFO_BLOCK)));
   val_peripheral_create_info_table(PeripheralInfoTable);
 
-  MemoryInfoTable = val_memory_alloc(sizeof(MEMORY_INFO_TABLE) + (4 * sizeof(MEM_INFO_BLOCK)));
+  MemoryInfoTable = val_memory_alloc(sizeof(MEMORY_INFO_TABLE) + (PLATFORM_OVERRIDE_MEMORY_ENTRY_COUNT * sizeof(MEM_INFO_BLOCK)));
   val_memory_create_info_table(MemoryInfoTable);
 }
 

--- a/platform/pal_baremetal/FVP/include/platform_override_fvp.h
+++ b/platform/pal_baremetal/FVP/include/platform_override_fvp.h
@@ -158,7 +158,8 @@
 
 /* Offset from the memory range to be accesed
  * Modify this macro w.r.t to the requirement */
-#define MEM_OFFSET   0x10
+#define MEM_OFFSET_SMALL   0x10
+#define MEM_OFFSET_MEDIUM  0x1000
 
 /* Platform config parameters for ECAM_0 */
 #define PLATFORM_OVERRIDE_PCIE_ECAM_BASE_ADDR_0   0x60000000

--- a/platform/pal_baremetal/src/pal_misc.c
+++ b/platform/pal_baremetal/src/pal_misc.c
@@ -494,6 +494,20 @@ pal_mem_free_pages(void *PageBase, uint32_t NumPages)
 }
 
 /**
+  @brief  Allocates memory with the given alignement.
+
+  @param  Alignment   Specifies the alignment.
+  @param  Size        Requested memory allocation size.
+
+  @return Pointer to the allocated memory with requested alignment.
+**/
+void
+*pal_aligned_alloc( uint32_t alignment, uint32_t size )
+{
+  return (void *)memalign(alignment, size);
+}
+
+/**
   @brief   Checks if System information is passed using Baremetal (BM)
            This api is also used to check if GIC/Interrupt Init ACS Code
            is used or not. In case of BM, ACS Code is used for INIT

--- a/platform/pal_baremetal/src/pal_pcie.c
+++ b/platform/pal_baremetal/src/pal_pcie.c
@@ -814,12 +814,19 @@ uint32_t pal_pcie_check_device_list(void)
           This offset is platform-specific. It needs to
           be modified according to the requirement.
 
-  @param  None
+  @param  memory offset
   @return memory offset
 **/
 uint32_t
-pal_pcie_mem_get_offset(void)
+pal_pcie_mem_get_offset(uint32_t type)
 {
 
-  return MEM_OFFSET;
+  switch (type) {
+      case MEM_OFFSET_SMALL:
+         return MEM_OFFSET_SMALL;
+      case MEM_OFFSET_MEDIUM:
+         return MEM_OFFSET_MEDIUM;
+      default:
+         return MEM_OFFSET_SMALL;
+  }
 }

--- a/platform/pal_baremetal/src/pal_pcie_enumeration.c
+++ b/platform/pal_baremetal/src/pal_pcie_enumeration.c
@@ -216,22 +216,23 @@ void pal_pcie_program_bar_reg(uint32_t bus, uint32_t dev, uint32_t func)
             **/
             if ((p_bar64_size == 0) && ((g_64_bus == bus)))
             {
-                if (g_np_bar_size < bar_size)
-                    g_bar32_np_start = g_bar32_np_start + bar_size;
+                if (g_bar64_size < bar_size)
+                    g_bar64_p_start = g_bar64_p_start + bar_size;
                 else
-                    g_bar32_np_start = g_bar32_np_start + g_np_bar_size;
+                    g_bar64_p_start = g_bar64_p_start + g_bar64_size;
             }
-
-            else if ((g_np_bar_size < bar_size) && (p_bar64_size != 0))
-                g_bar32_np_start = g_bar32_np_start + bar_size;
+            else if ((g_bar64_size < bar_size) && (p_bar64_size != 0))
+                g_bar64_p_start = g_bar64_p_start + bar_size;
 
             else
-                g_bar32_np_start = g_bar32_np_start + p_bar64_size;
+                g_bar64_p_start = g_bar64_p_start + p_bar64_size;
 
             pal_pci_cfg_write(bus, dev, func, offset, g_bar64_p_start);
-            print(AVS_PRINT_INFO, "Value written to BAR register is %x\n", g_bar64_p_start);
+            pal_pci_cfg_write(bus, dev, func, offset + 4, g_bar64_p_start >> 32);
+
+            print(AVS_PRINT_INFO, "Value written to BAR register is %llx\n", g_bar64_p_start);
             p_bar64_size = bar_size;
-            g_np_bar_size = bar_size;
+            g_bar64_size = bar_size;
             g_64_bus = bus;
             offset = offset + 8;
 
@@ -575,7 +576,7 @@ pal_pcie_get_base(uint32_t bdf, uint32_t bar_index)
      bar_value = bar_value | (bar_upper_bits << 32 );
   }
 
-  print(AVS_PRINT_INFO, "value read from BAR %x\n", bar_value);
+  print(AVS_PRINT_INFO, "value read from BAR 0x%llx\n", bar_value);
 
   return bar_value;
 

--- a/platform/pal_uefi/include/pal_uefi.h
+++ b/platform/pal_uefi/include/pal_uefi.h
@@ -23,6 +23,8 @@ extern UINT32 g_print_level;
 extern UINT32 g_print_mmio;
 extern UINT32 g_curr_module;
 extern UINT32 g_enable_module;
+extern UINT32 g_pcie_p2p;
+extern UINT32 g_pcie_cache_present;
 
 #define AVS_PRINT_ERR   5      /* Only Errors. use this to de-clutter the terminal and focus only on specifics */
 #define AVS_PRINT_WARN  4      /* Only warnings & errors. use this to de-clutter the terminal and focus only on specifics */
@@ -36,7 +38,7 @@ extern UINT32 g_enable_module;
 #define PCIE_UNKNOWN_RESPONSE   0xFFFFFFFF  /* Function not found or UR response from completer */
 
 #define NOT_IMPLEMENTED         0x4B1D  /* Feature or API by default unimplemented */
-#define MEM_OFFSET              0x10    /* Memory Offset from BAR base value that can be accesed*/
+#define MEM_OFFSET_SMALL        0x10    /* Memory Offset from BAR base value that can be accesed*/
 
 #define TYPE0_MAX_BARS  6
 #define TYPE1_MAX_BARS  2

--- a/platform/pal_uefi/include/platform_override.h
+++ b/platform/pal_uefi/include/platform_override.h
@@ -55,3 +55,5 @@
 #define PLATFORM_OVERRIDE_SMMU_BASE        0x0 //0x2B400000
 #define PLATFORM_OVERRIDE_SMMU_ARCH_MAJOR  3
 
+extern UINT32 g_pcie_p2p;
+extern UINT32 g_pcie_cache_present;

--- a/platform/pal_uefi/src/pal_misc.c
+++ b/platform/pal_uefi/src/pal_misc.c
@@ -610,6 +610,35 @@ pal_mem_alloc_pages (
 }
 
 /**
+  @brief  Allocates memory with the given alignement.
+
+  @param  Alignment   Specifies the alignment.
+  @param  Size        Requested memory allocation size.
+
+  @return Pointer to the allocated memory with requested alignment.
+**/
+VOID *
+pal_aligned_alloc( UINT32 alignment, UINT32 size)
+{
+  VOID *Mem = NULL;
+  VOID *Aligned_Ptr = NULL;
+
+  /* Generate mask for the Alignment parameter*/
+  UINT64 Mask = ~(UINT64)(alignment - 1);
+
+  /* Allocate memory with extra bytes, so we can return an aligned address*/
+  Mem = (VOID *)pal_mem_alloc(size + alignment);
+
+  if( Mem == NULL)
+    return 0;
+
+  /* Add the alignment to allocated memory address and align it to target alignment*/
+  Aligned_Ptr = (VOID *)(((UINT64) Mem + alignment-1) & Mask);
+
+  return Aligned_Ptr;
+}
+
+/**
   @brief Free number of pages in the memory as requested.
 
   @param PageBase Address from where we need to free

--- a/platform/pal_uefi/src/pal_pcie.c
+++ b/platform/pal_uefi/src/pal_pcie.c
@@ -226,8 +226,10 @@ pal_pcie_p2p_support()
    * PCIe support for peer to peer
    * transactions is platform implementation specific
    */
-
-  return NOT_IMPLEMENTED;
+  if (g_pcie_p2p)
+      return 0;
+  else
+      return NOT_IMPLEMENTED;
 }
 
 /**
@@ -329,7 +331,10 @@ pal_pcie_is_cache_present (
   UINT32 Fn
   )
 {
-  return NOT_IMPLEMENTED;
+  if (g_pcie_cache_present)
+      return 1;
+  else
+      return NOT_IMPLEMENTED;
 }
 
 /**
@@ -378,12 +383,12 @@ pal_pcie_check_device_list(void)
           accessed from the BAR base and is within
           BAR limit value
 
-  @param  None
+  @param  memory offset
   @return memory offset
 **/
 UINT32
-pal_pcie_mem_get_offset(void)
+pal_pcie_mem_get_offset(UINT32 type)
 {
 
-  return MEM_OFFSET;
+  return MEM_OFFSET_SMALL;
 }

--- a/test_pool/exerciser/test_e006.c
+++ b/test_pool/exerciser/test_e006.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2022, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,6 +29,7 @@ static uint32_t instance;
 static uint32_t e_intr_line;
 static uint32_t test_fail = 0;
 static volatile uint32_t e_intr_pending;
+uint32_t e_bdf;
 
 static void intr_handler(void)
 {
@@ -38,6 +39,21 @@ static void intr_handler(void)
         test_fail++;
         return;
     }
+
+    /* Check if interrupt status bit is set in Status register */
+
+    if (!val_pcie_check_interrupt_status(e_bdf))
+    {
+        val_print(AVS_PRINT_ERR, "\n       No outstanding interrupt for bdf 0x%x", e_bdf);
+        test_fail++;
+        return;
+    }
+
+    /* Deassert the interupt line */
+    val_exerciser_ops(CLEAR_INTR, e_intr_line, instance);
+
+    /* Return the interrupt */
+    val_gic_end_of_interrupt(e_intr_line);
 
     /* Clear the interrupt pending state */
     e_intr_pending = 0;
@@ -51,7 +67,6 @@ void
 payload (void)
 {
   uint32_t pe_index;
-  uint32_t e_bdf;
   uint32_t ret_val;
   uint32_t timeout;
   uint32_t e_intr_pin;
@@ -130,20 +145,6 @@ payload (void)
                 test_fail++;
                 continue;
             }
-
-            /* Check if interrupt status bit is set in Status register */
-            if (!val_pcie_check_interrupt_status(e_bdf))
-            {
-                val_print(AVS_PRINT_ERR, "\n       No outstanding interrupt for bdf 0x%x", e_bdf);
-                test_fail++;
-                continue;
-            }
-
-            /* Deassert the interupt line */
-            val_exerciser_ops(CLEAR_INTR, e_intr_line, instance);
-
-            /* Return the interrupt */
-            val_gic_end_of_interrupt(e_intr_line);
 
             /* Check if interrupt status bit is cleared in Status register */
             if (val_pcie_check_interrupt_status(e_bdf))

--- a/test_pool/exerciser/test_e008.c
+++ b/test_pool/exerciser/test_e008.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019-2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2022, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,6 +63,7 @@ payload(void)
   uint32_t smmu_index;
   uint32_t dma_len;
   uint32_t status;
+  uint32_t reg_value;
   void *dram_buf_virt;
   void *dram_buf_phys;
   void *dram_buf_iova;
@@ -164,12 +165,10 @@ exception_return:
       /* Restore Rootport Bus Master Enable */
       val_pcie_enable_bme(erp_bdf);
 
-      /* Check if UR detected bit is set in the Exerciser */
-      if (val_pcie_is_urd(e_bdf))
-      {
-          /* Clear urd bit in Device Status Register */
-          val_pcie_clear_urd(e_bdf);
-      } else
+
+      /* Check if Received Master Abort bit is set in the Exerciser */
+      val_pcie_read_cfg(e_bdf, COMMAND_REG_OFFSET, &reg_value);
+      if (!((reg_value & MASTER_ABORT_MASK) >> MASTER_ABORT_SHIFT))
       {
           val_print(AVS_PRINT_ERR, "\n      Exerciser BDF 0x%x BME functionality failure", e_bdf);
           fail_cnt++;

--- a/test_pool/exerciser/test_e011.c
+++ b/test_pool/exerciser/test_e011.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2022, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -76,6 +76,7 @@ payload(void)
   uint64_t dram_buf_out_phys;
   uint64_t dram_buf_in_iova;
   uint64_t dram_buf_out_iova;
+  uint64_t m_vir_addr;
   uint32_t num_exercisers, num_smmus;
   uint32_t device_id, its_id;
   uint32_t page_size = val_memory_page_size();
@@ -224,7 +225,8 @@ payload(void)
     }
 
     /* Get ATS Translation Response */
-    if (val_exerciser_get_param(ATS_RES_ATTRIBUTES, &translated_addr, NULL, instance)) {
+    m_vir_addr = (uint64_t)dram_buf_in_virt + instance * test_data_blk_size;
+    if (val_exerciser_get_param(ATS_RES_ATTRIBUTES, &translated_addr, &m_vir_addr, instance)) {
         val_print(AVS_PRINT_ERR, "\n       ATS Response failure %4x", instance);
         goto test_fail;
     }

--- a/test_pool/pcie/test_p049.c
+++ b/test_pool/pcie/test_p049.c
@@ -57,8 +57,9 @@ payload(void)
   uint32_t status;
   uint32_t test_skip = 1;
   uint32_t mem_offset = 0;
-  uint64_t mem_base = 0, mem_base_upper = 0;
+  uint64_t mem_base = 0, mem_base_upper = 0, ori_mem_base = 0;
   uint64_t mem_lim = 0, mem_lim_upper = 0, new_mem_lim;
+  uint64_t updated_mem_base = 0, updated_mem_lim = 0;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   tbl_index = 0;
@@ -96,10 +97,7 @@ payload(void)
       dp_type = val_pcie_device_port_type(bdf);
 
       if ((dp_type == RP) || (dp_type == iEP_RP)) {
-        /* Part 1:
-         * Check When Address is within the Range of Prefetchable
-         * Memory Range.
-        */
+
         /* Clearing UR in Device Status Register */
         val_pcie_clear_urd(bdf);
 
@@ -136,7 +134,7 @@ payload(void)
          * Base + offset should always be in the range.
          * Read the same
         */
-        mem_offset = val_pcie_mem_get_offset();
+        mem_offset = val_pcie_mem_get_offset(MEM_OFFSET_MEDIUM);
 
         if ((mem_base + mem_offset) > mem_lim)
         {
@@ -162,38 +160,60 @@ payload(void)
          * If the limit exceeds 1MB then modify the range to be 1MB
          * and access out of the limit set
          **/
+        ori_mem_base = mem_base;
+
         if ((mem_lim >> MEM_SHIFT) > (mem_base >> MEM_SHIFT))
         {
-           new_mem_lim  = mem_base + MEM_OFF_100000;
+           new_mem_lim  = mem_base + MEM_OFFSET_LARGE;
            val_pcie_read_cfg(bdf, TYPE1_P_MEM, &new_value);
 
           if ((new_value & P_MEM_PAC_MASK) == 0x1)
                val_pcie_write_cfg(bdf, TYPE1_P_MEM_LU, (mem_base >> 32));
 
            mem_base = ((uint32_t)mem_base) | ((uint32_t)mem_base >> 16);
-           val_print(AVS_PRINT_INFO, " mem_base new is 0x%lx", mem_base);
+           val_print(AVS_PRINT_INFO, " mem_base new is 0x%llx", mem_base);
            val_pcie_write_cfg(bdf, TYPE1_P_MEM, mem_base);
 
-           value = (*(volatile uint32_t *)(new_mem_lim + MEM_OFFSET_10));
+           val_pcie_read_cfg(bdf, TYPE1_P_MEM, &read_value);
+           updated_mem_base = (read_value & MEM_BA_MASK) << MEM_BA_SHIFT;
+           updated_mem_lim = (read_value & MEM_LIM_MASK) | MEM_LIM_LOWER_BITS;
+
+           /* If 64 Bit Prefetchable Address */
+           if ((read_value & P_MEM_PAC_MASK) == 0x1) {
+             val_pcie_read_cfg(bdf, TYPE1_P_MEM_BU, &read_value);
+             mem_base_upper = read_value;
+             val_pcie_read_cfg(bdf, TYPE1_P_MEM_LU, &read_value);
+             mem_lim_upper = read_value;
+           }
+
+           updated_mem_base |= (mem_base_upper << P_MEM_BU_SHIFT);
+           updated_mem_lim |= (mem_lim_upper << P_MEM_LU_SHIFT);
+
+           value = (*(volatile uint32_t *)(new_mem_lim + MEM_OFFSET_SMALL));
            if (value != PCIE_UNKNOWN_RESPONSE)
            {
                val_print(AVS_PRINT_ERR, "\n Memory range for bdf 0x%x", bdf);
-               val_print(AVS_PRINT_ERR, " is 0x%x", new_value);
-               val_print(AVS_PRINT_ERR, "\n Out of range addr %x ", (new_mem_lim + MEM_OFFSET_10));
+               val_print(AVS_PRINT_ERR, " is 0x%llx", updated_mem_base);
+               val_print(AVS_PRINT_ERR, " 0x%llx", updated_mem_lim);
+               val_print(AVS_PRINT_ERR, "\n Out of range addr 0x%llx ", (new_mem_lim + MEM_OFFSET_SMALL));
                val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 03));
            }
         }
 
 exception_return:
         /*Write back original value */
-        val_pcie_write_cfg(bdf, TYPE1_P_MEM, ((mem_lim & MEM_LIM_MASK) | (mem_base  >> 16)));
-        val_pcie_write_cfg(bdf, TYPE1_P_MEM_LU, (mem_lim >> 32));
+        if ((mem_lim >> MEM_SHIFT) > (ori_mem_base >> MEM_SHIFT))
+        {
+            val_pcie_write_cfg(bdf, TYPE1_P_MEM,
+                                              ((mem_lim & MEM_LIM_MASK) | (ori_mem_base  >> 16)));
+            val_pcie_write_cfg(bdf, TYPE1_P_MEM_LU, (mem_lim >> 32));
+        }
 
         /* Memory Space might have constraint on RW/RO behaviour
          * So not checking for Read-Write Data mismatch.
         */
         if (IS_TEST_FAIL(val_get_status(pe_index))) {
-          val_print(AVS_PRINT_ERR, "\n       Failed. Exception on Memory Access For Bdf : 0x%x", bdf);
+          val_print(AVS_PRINT_ERR, "\n       Failed exception on Memory Access For Bdf : 0x%x", bdf);
           val_pcie_clear_urd(bdf);
           return;
         }

--- a/uefi_app/SbsaAvsMain.c
+++ b/uefi_app/SbsaAvsMain.c
@@ -29,6 +29,8 @@
 
 #include "SbsaAvs.h"
 
+UINT32 g_pcie_p2p;
+UINT32 g_pcie_cache_present;
 
 UINT32  g_sbsa_level;
 UINT32  g_enable_pcie_tests;
@@ -274,6 +276,8 @@ HelpMsg (
          "-nist   Enable the NIST Statistical test suite\n"
          "-p      Enable/disable PCIe SBSA 6.0 (RCiEP) compliance tests\n"
          "        1 - enables PCIe tests, 0 - disables PCIe tests\n"
+         "-p2p    Pass this flag to indicate that PCIe Hierarchy Supports Peer-to-Peer\n"
+         "-cache  Pass this flag to indicate that if the test system supports PCIe address translation cache\n"
          "-timeout  Set timeout multiple for wakeup tests\n"
          "        1 - min value  5 - max value\n"
   );
@@ -289,6 +293,8 @@ STATIC CONST SHELL_PARAM_ITEM ParamList[] = {
   {L"-nist" , TypeFlag},     // -nist # Binary Flag to enable the execution of NIST STS
   {L"-p"    , TypeValue},    // -p    # Enable/disable PCIe SBSA 6.0 (RCiEP) compliance tests.
   {L"-mmio" , TypeFlag},     // -mmio # Enable pal_mmio prints
+  {L"-p2p", TypeFlag},       // -p2p  # Peer-to-Peer is supported
+  {L"-cache", TypeFlag},     // -cache# PCIe address translation cache is supported
   {L"-timeout" , TypeValue}, // -timeout # Set timeout multiple for wakeup tests
   {NULL     , TypeMax}
   };
@@ -416,6 +422,18 @@ ShellAppMainsbsa (
     g_print_mmio = TRUE;
   } else {
     g_print_mmio = FALSE;
+  }
+
+  if (ShellCommandLineGetFlag (ParamPackage, L"-p2p")) {
+    g_pcie_p2p = TRUE;
+  } else {
+    g_pcie_p2p = FALSE;
+  }
+
+  if (ShellCommandLineGetFlag (ParamPackage, L"-cache")) {
+    g_pcie_cache_present = TRUE;
+  } else {
+    g_pcie_cache_present = FALSE;
   }
 
   // Options with Values

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -307,7 +307,7 @@ uint32_t pal_pcie_is_onchip_peripheral(uint32_t bdf);
 void pal_pcie_io_write_cfg(uint32_t bdf, uint32_t offset, uint32_t data);
 uint32_t pal_pcie_check_device_list(void);
 uint32_t pal_pcie_check_device_valid(uint32_t bdf);
-uint32_t pal_pcie_mem_get_offset(void);
+uint32_t pal_pcie_mem_get_offset(uint32_t type);
 
 /**
   @brief  Instance of SMMU INFO block
@@ -620,6 +620,7 @@ uint16_t pal_mmio_read16(uint64_t addr);
 uint32_t pal_mem_page_size(void);
 void    *pal_mem_alloc_pages(uint32_t num_pages);
 void     pal_mem_free_pages(void *page_base, uint32_t num_pages);
+void *pal_aligned_alloc(uint32_t alignment, uint32_t size);
 
 uint32_t pal_mmio_read(uint64_t addr);
 uint64_t pal_mmio_read64(uint64_t addr);

--- a/val/include/sbsa_avs_exerciser.h
+++ b/val/include/sbsa_avs_exerciser.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2022, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +24,9 @@
 
 /* PCIe Config space Offset */
 #define COMMAND_REG_OFFSET 0x04
+
+#define MASTER_ABORT_MASK  0x20000000
+#define MASTER_ABORT_SHIFT 29
 
 typedef struct {
     uint32_t bdf;

--- a/val/include/sbsa_avs_pcie.h
+++ b/val/include/sbsa_avs_pcie.h
@@ -67,12 +67,13 @@
 #define MAX_BITFIELD_ENTRIES 100
 #define ERR_STRING_SIZE 64
 
-#define MEM_OFFSET_10   0x10
-#define MEM_OFF_100000  0x100000
-#define MEM_SHIFT       20
-#define MEM_BASE_SHIFT  16
-#define BAR_MASK        0xFFFFFFF0
-#define MSI_BIR_MASK    0xFFFFFFF8
+#define MEM_OFFSET_SMALL   0x10
+#define MEM_OFFSET_MEDIUM  0x1000
+#define MEM_OFFSET_LARGE   0x100000
+#define MEM_SHIFT          20
+#define MEM_BASE_SHIFT     16
+#define BAR_MASK           0xFFFFFFF0
+#define MSI_BIR_MASK       0xFFFFFFF8
 
 /* Allows storage of 2048 valid BDFs */
 #define PCIE_DEVICE_BDF_TABLE_SZ 8192

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -211,7 +211,7 @@ void val_pcie_clear_device_status_error(uint32_t bdf);
 uint32_t val_pcie_is_device_status_error(uint32_t bdf);
 uint32_t val_pcie_is_sig_target_abort(uint32_t bdf);
 void val_pcie_clear_sig_target_abort(uint32_t bdf);
-uint32_t val_pcie_mem_get_offset(void);
+uint32_t val_pcie_mem_get_offset(uint32_t type);
 
 /* IO-VIRT APIs */
 typedef enum {

--- a/val/src/avs_memory.c
+++ b/val/src/avs_memory.c
@@ -280,20 +280,5 @@ val_memory_free_pages(void *addr, uint32_t num_pages)
 void
 *val_aligned_alloc( uint32_t alignment, uint32_t size )
 {
-  void *Mem = NULL;
-  void *Aligned_Ptr = NULL;
-
-  /* Generate mask for the Alignment parameter*/
-  uint64_t Mask = ~(uint64_t)(alignment - 1);
-
-  /* Allocate memory with extra bytes, so we can return an aligned address*/
-  Mem = (void *)pal_mem_alloc(size + alignment);
-
-  if( Mem == NULL)
-    return 0;
-
-  /* Add the alignment to allocated memory address and align it to target alignment*/
-  Aligned_Ptr = (void *)(((uint64_t) Mem + alignment-1) & Mask);
-
-  return Aligned_Ptr;
+  return pal_aligned_alloc(alignment, size);
 }

--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -2122,12 +2122,11 @@ uint32_t val_pcie_get_ecam_index(uint32_t bdf, uint32_t *ecam_index)
           accessed from the BAR base and is within
           BAR limit value
 
-  @param  None
+  @param  type
   @return memory offset
 
 **/
-uint32_t val_pcie_mem_get_offset(void)
+uint32_t val_pcie_mem_get_offset(uint32_t type)
 {
-
-  return pal_pcie_mem_get_offset();
+  return pal_pcie_mem_get_offset(type);
 }


### PR DESCRIPTION
- pal_mem_alloc: Use memalign when aligned address is required
- Pass runtime params for PCIe supported features
  pal_pcie_p2p_support() and pal_pcie_is_cache_present()
- Fix for enumeration of Prefetchable memory range
- Provide custom offset input for test p048.c and p049.c
- Received Master Abort bit to be set in the Exerciser for
  Completions with a Completion Status of Unsupported Request

Signed-off-by: Sujana M <sujana.m@arm.com>