### PR TITLE
 #234: 413 test failure- Added check for driver present

### DIFF
--- a/platform/pal_baremetal/src/pal_pcie.c
+++ b/platform/pal_baremetal/src/pal_pcie.c
@@ -551,6 +551,21 @@ pal_pcie_is_devicedma_64bit(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t f
 }
 
 /**
+    @brief   Return if driver present for pcie device
+    @param   bus        PCI bus address
+    @param   dev        PCI device address
+    @param   fn         PCI function number
+    @return  Driver present : 0 or 1
+**/
+uint32_t
+pal_pcie_device_driver_present(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t fn)
+{
+
+  return 1;
+
+}
+
+/**
   @brief  This API checks if a PCIe device has an Address
           Translation Cache or not.
   @param   bdf      - PCIe BUS/Device/Function

--- a/test_pool/pcie/test_p013.c
+++ b/test_pool/pcie/test_p013.c
@@ -37,6 +37,7 @@ payload (void)
   uint32_t data;
   uint32_t dev_type;
   uint32_t dev_bdf;
+  uint32_t test_run = 0;
 
   index = val_pe_get_index_mpid (val_pe_get_mpid());
   count = val_peripheral_get_info (NUM_ALL, 0);
@@ -53,26 +54,34 @@ payload (void)
       dev_type = val_pcie_get_device_type(dev_bdf);
       // 1: Normal PCIe device, 2: PCIe Host bridge, 3: PCIe bridge device, else: INVALID
 
+      val_print(AVS_PRINT_INFO, "\n Dev bdf 0x%x", dev_bdf);
+
       if ((!dev_type) || (dev_type > 1)) {
           //Skip this device, if we either got pdev as NULL or if it is a bridge
           continue;
       }
 
+      if (!val_pcie_device_driver_present(dev_bdf)) {
+          val_print(AVS_PRINT_DEBUG, "\n Driver not present for bdf 0x%x", dev_bdf);
+          continue;
+      }
+      test_run = 1;
+
       data = val_pcie_is_devicedma_64bit(dev_bdf);
       if (data == 0) {
           if(!val_pcie_is_device_behind_smmu(dev_bdf)) {
               val_print (AVS_PRINT_ERR, "\n       WARNING:The device with bdf=0x%x doesn't support 64 bit addressing", dev_bdf);
-              val_print (AVS_PRINT_ERR, "\n       and is not behind SMMU. Please install driver for this device and", 0);
-              val_print (AVS_PRINT_ERR, "\n       test again. If driver is already installed, this test has failed.", 0);
-              val_print (AVS_PRINT_ERR, "\n       The device is of type = %d", dev_type);
+              val_print (AVS_PRINT_ERR, "\n       and is not behind SMMU. The device is of type = %d", dev_type);
               val_set_status (index, RESULT_FAIL (g_sbsa_level, TEST_NUM, 1));
               return;
           }
       }
-
   }
 
-  val_set_status (index, RESULT_PASS (g_sbsa_level, TEST_NUM, 01));
+  if (test_run)
+      val_set_status (index, RESULT_PASS (g_sbsa_level, TEST_NUM, 01));
+  else
+      val_set_status (index, RESULT_SKIP (g_sbsa_level, TEST_NUM, 02));
 }
 
 uint32_t

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -525,6 +525,7 @@ uint32_t pal_pcie_get_snoop_bit(uint32_t seg, uint32_t bus, uint32_t dev, uint32
 uint32_t pal_pcie_get_dma_support(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t fn);
 uint32_t pal_pcie_get_dma_coherent(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t fn);
 uint32_t pal_pcie_is_devicedma_64bit(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t fn);
+uint32_t pal_pcie_device_driver_present(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t fn);
 uint32_t pal_pcie_scan_bridge_devices_and_check_memtype(uint32_t seg, uint32_t bus,
                                                             uint32_t dev, uint32_t fn);
 uint32_t pal_pcie_get_rp_transaction_frwd_support(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t fn);

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -181,6 +181,7 @@ void *val_pcie_bdf_table_ptr(void);
 void     val_pcie_free_info_table(void);
 uint32_t val_pcie_execute_tests(uint32_t enable_pcie, uint32_t level, uint32_t num_pe);
 uint32_t val_pcie_is_devicedma_64bit(uint32_t bdf);
+uint32_t val_pcie_device_driver_present(uint32_t bdf);
 uint32_t val_pcie_scan_bridge_devices_and_check_memtype(uint32_t bdf);
 void val_pcie_read_ext_cap_word(uint32_t bdf, uint32_t ext_cap_id, uint8_t offset, uint16_t *val);
 uint32_t val_pcie_get_pcie_type(uint32_t bdf);

--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -756,6 +756,24 @@ val_pcie_is_devicedma_64bit(uint32_t bdf)
 }
 
 /**
+  @brief   This API checks if device driver present for a pcie device
+           1. Caller       -  Test Suite
+  @param   bdf      - PCIe BUS/Device/Function
+  @return  0 -> not Present, 1 -> Present
+**/
+uint32_t
+val_pcie_device_driver_present(uint32_t bdf)
+{
+
+  uint32_t seg  = PCIE_EXTRACT_BDF_SEG (bdf);
+  uint32_t bus  = PCIE_EXTRACT_BDF_BUS (bdf);
+  uint32_t dev  = PCIE_EXTRACT_BDF_DEV (bdf);
+  uint32_t func = PCIE_EXTRACT_BDF_FUNC (bdf);
+
+  return (pal_pcie_device_driver_present(seg, bus, dev, func));
+}
+
+/**
   @brief   This API scans bridge devices and checks memory type
            1. Caller       -  Test Suite
   @param   bdf      - PCIe BUS/Device/Function


### PR DESCRIPTION
Test is updated to check if device driver present for a BDF and if driver is not present the BDF will be skipped.