### PR TITLE
Initializing SMMU only if pcie exerciser devices present in system 

### DIFF
--- a/val/src/avs_exerciser.c
+++ b/val/src/avs_exerciser.c
@@ -22,6 +22,7 @@
 
 EXERCISER_INFO_TABLE g_exercier_info_table;
 extern uint32_t pcie_bdf_table_list_flag;
+
 /**
   @brief   This API popultaes information from all the PCIe stimulus generation IP available
            in the system into exerciser_info_table structure
@@ -218,6 +219,8 @@ val_exerciser_execute_tests(uint32_t level)
 {
   uint32_t status, i;
   uint32_t num_instances;
+  uint32_t instance;
+  uint32_t num_smmu;
 
   if (level == 3) {
     val_print(AVS_PRINT_WARN, "Exerciser Sbsa compliance is only from Level %d \n", 4);
@@ -251,6 +254,15 @@ val_exerciser_execute_tests(uint32_t level)
       return AVS_STATUS_SKIP;
   }
 
+
+  num_smmu = val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);
+  val_smmu_init();
+
+  /* Disable All SMMU's */
+  for (instance = 0; instance < num_smmu; ++instance)
+      val_smmu_disable(instance);
+
+
   g_curr_module = 1 << EXERCISER_MODULE;
   status = e001_entry();
   status |= e002_entry();
@@ -270,6 +282,8 @@ val_exerciser_execute_tests(uint32_t level)
   status |= e016_entry();
 
   val_print_test_end(status, "Exerciser");
+
+  val_smmu_stop();
 
   return status;
 }

--- a/val/src/avs_iovirt.c
+++ b/val/src/avs_iovirt.c
@@ -21,6 +21,7 @@
 #include "include/sbsa_avs_smmu.h"
 
 IOVIRT_INFO_TABLE *g_iovirt_info_table;
+uint32_t g_num_smmus;
 
 /**
   @brief   This API is a single point of entry to retrieve
@@ -263,7 +264,6 @@ val_iovirt_get_device_info(uint32_t rid, uint32_t segment, uint32_t *device_id,
 void
 val_iovirt_create_info_table(uint64_t *iovirt_info_table)
 {
-  uint32_t num_smmu;
 
   if (iovirt_info_table == NULL)
   {
@@ -275,20 +275,9 @@ val_iovirt_create_info_table(uint64_t *iovirt_info_table)
 
   pal_iovirt_create_info_table(g_iovirt_info_table);
 
-  num_smmu = val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);
+  g_num_smmus = val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);
   val_print(AVS_PRINT_TEST,
-            " SMMU_INFO: Number of SMMU CTRL       :    %x \n", num_smmu);
-
-#ifndef TARGET_LINUX
-  uint32_t instance;
-
-  val_smmu_init();
-
-  /* Disable All SMMU's */
-  for (instance = 0; instance < num_smmu; ++instance)
-      val_smmu_disable(instance);
-#endif
-
+            " SMMU_INFO: Number of SMMU CTRL       :    %x \n", g_num_smmus);
 }
 
 uint32_t
@@ -301,7 +290,6 @@ val_iovirt_check_unique_ctx_intid(uint32_t smmu_index)
 void
 val_iovirt_free_info_table()
 {
-  val_smmu_stop();
   pal_mem_free((void *)g_iovirt_info_table);
 }
 

--- a/val/sys_arch_src/smmu_v3/smmu_v3.c
+++ b/val/sys_arch_src/smmu_v3/smmu_v3.c
@@ -17,7 +17,7 @@
 #include "smmu_v3.h"
 
 smmu_dev_t *g_smmu;
-uint32_t g_num_smmus = 0;
+extern uint32_t g_num_smmus;
 
 struct smmu_master_node {
     smmu_master_t *master;


### PR DESCRIPTION
 SBSA acs smmu init code is required for pcie exerciser test only. 
Fix for #233 