### PR TITLE
Add ability to select individual tests or skip test modules

### DIFF
--- a/test_pool/timer_wd/test_w003.c
+++ b/test_pool/timer_wd/test_w003.c
@@ -33,12 +33,6 @@ payload(void)
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
   uint32_t data, ns_wdg = 0;
 
-  if (TEST_NUM != SINGLE_TEST_SENTINEL) {
-		val_print(AVS_PRINT_WARN, "\n       Skipping via single test override %d  ", wd_num);
-		val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
-		return;
-	}
-
   if (g_sbsa_level < 5) {
       val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
       return;

--- a/test_pool/timer_wd/test_w003.c
+++ b/test_pool/timer_wd/test_w003.c
@@ -33,6 +33,12 @@ payload(void)
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
   uint32_t data, ns_wdg = 0;
 
+  if (TEST_NUM != SINGLE_TEST_SENTINEL) {
+		val_print(AVS_PRINT_WARN, "\n       Skipping via single test override %d  ", wd_num);
+		val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+		return;
+	}
+
   if (g_sbsa_level < 5) {
       val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
       return;

--- a/uefi_app/SbsaAvsMain.c
+++ b/uefi_app/SbsaAvsMain.c
@@ -41,6 +41,8 @@ UINT32 g_curr_module;
 UINT32 g_enable_module;
 UINT32  g_skip_test_num[MAX_TEST_SKIP_NUM] = { 10000, 10000, 10000, 10000, 10000,
                                                10000, 10000, 10000, 10000 };
+UINT32  g_single_test = SINGLE_TEST_SENTINEL;
+UINT32  g_single_module = SINGLE_MODULE_SENTINEL;
 UINT32  g_sbsa_tests_total;
 UINT32  g_sbsa_tests_pass;
 UINT32  g_sbsa_tests_fail;

--- a/uefi_app/SbsaAvsMain.c
+++ b/uefi_app/SbsaAvsMain.c
@@ -256,7 +256,7 @@ HelpMsg (
   VOID
   )
 {
-	Print (L"\nUsage: Sbsa.efi [-v <n>] | [-l <n>] | [-f <filename>] | [-skip <n>] | [-nist] | [-p <n>] | [-t <n>] | [-m <n>]\n"
+  Print (L"\nUsage: Sbsa.efi [-v <n>] | [-l <n>] | [-f <filename>] | [-skip <n>] | [-nist] | [-p <n>] | [-t <n>] | [-m <n>]\n"
          "[-skip <n>] | [-nist] | [-p <n>]\n"
          "Options:\n"
          "-v      Verbosity of the Prints\n"
@@ -276,7 +276,7 @@ HelpMsg (
          "-nist   Enable the NIST Statistical test suite\n"
          "-p      Enable/disable PCIe SBSA 6.0 (RCiEP) compliance tests\n"
          "        1 - enables PCIe tests, 0 - disables PCIe tests\n"
-				 "-t      If set, will only run the specified test, all others will be skipped.\n"
+         "-t      If set, will only run the specified test, all others will be skipped.\n"
          "-m      If set, will only run the specified module, all others will be skipped.\n"
          "-p2p    Pass this flag to indicate that PCIe Hierarchy Supports Peer-to-Peer\n"
          "-cache  Pass this flag to indicate that if the test system supports PCIe address translation cache\n"
@@ -455,7 +455,7 @@ ShellAppMainsbsa (
       }
   }
 
-	// Options with Values
+  // Options with Values
   CmdLineArg  = ShellCommandLineGetValue (ParamPackage, L"-t");
   if (CmdLineArg != NULL) {
     g_single_test = StrDecimalToUintn(CmdLineArg);

--- a/uefi_app/SbsaAvsMain.c
+++ b/uefi_app/SbsaAvsMain.c
@@ -256,7 +256,7 @@ HelpMsg (
   VOID
   )
 {
-  Print (L"\nUsage: Sbsa.efi [-v <nn>] | [-l <n>] | [-f <filename>] | "
+	Print (L"\nUsage: Sbsa.efi [-v <n>] | [-l <n>] | [-f <filename>] | [-skip <n>] | [-nist] | [-p <n>] | [-t <n>] | [-m <n>]\n"
          "[-skip <n>] | [-nist] | [-p <n>]\n"
          "Options:\n"
          "-v      Verbosity of the Prints\n"
@@ -276,6 +276,8 @@ HelpMsg (
          "-nist   Enable the NIST Statistical test suite\n"
          "-p      Enable/disable PCIe SBSA 6.0 (RCiEP) compliance tests\n"
          "        1 - enables PCIe tests, 0 - disables PCIe tests\n"
+				 "-t      If set, will only run the specified test, all others will be skipped.\n"
+         "-m      If set, will only run the specified module, all others will be skipped.\n"
          "-p2p    Pass this flag to indicate that PCIe Hierarchy Supports Peer-to-Peer\n"
          "-cache  Pass this flag to indicate that if the test system supports PCIe address translation cache\n"
          "-timeout  Set timeout multiple for wakeup tests\n"
@@ -293,6 +295,8 @@ STATIC CONST SHELL_PARAM_ITEM ParamList[] = {
   {L"-nist" , TypeFlag},     // -nist # Binary Flag to enable the execution of NIST STS
   {L"-p"    , TypeValue},    // -p    # Enable/disable PCIe SBSA 6.0 (RCiEP) compliance tests.
   {L"-mmio" , TypeFlag},     // -mmio # Enable pal_mmio prints
+  {L"-t"    , TypeValue},    // -t    # Test to be run
+  {L"-m"    , TypeValue},    // -m    # Module to be run
   {L"-p2p", TypeFlag},       // -p2p  # Peer-to-Peer is supported
   {L"-cache", TypeFlag},     // -cache# PCIe address translation cache is supported
   {L"-timeout" , TypeValue}, // -timeout # Set timeout multiple for wakeup tests
@@ -449,6 +453,18 @@ ShellAppMainsbsa (
           Print(L"Invalid PCIe option.\nEnter \"-p 1\" to enable or \"-p 0\" to disable PCIe SBSA 6.0 (RCiEP) tests\n", g_enable_pcie_tests);
           return 0;
       }
+  }
+
+	// Options with Values
+  CmdLineArg  = ShellCommandLineGetValue (ParamPackage, L"-t");
+  if (CmdLineArg != NULL) {
+    g_single_test = StrDecimalToUintn(CmdLineArg);
+  }
+
+  // Options with Values
+  CmdLineArg  = ShellCommandLineGetValue (ParamPackage, L"-m");
+  if (CmdLineArg != NULL) {
+    g_single_module = StrDecimalToUintn(CmdLineArg);
   }
 
   //

--- a/val/include/sbsa_avs_cfg.h
+++ b/val/include/sbsa_avs_cfg.h
@@ -35,5 +35,7 @@ extern uint64_t g_stack_pointer;
 extern uint64_t g_exception_ret_addr;
 extern uint64_t g_ret_addr;
 extern uint32_t g_curr_module;
+extern uint32_t g_single_test;
+extern uint32_t g_single_module;
 
 #endif

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -51,6 +51,9 @@
 
 #define VAL_EXTRACT_BITS(data, start, end) ((data >> start) & ((1ul << (end-start+1))-1))
 
+#define SINGLE_TEST_SENTINEL   10000
+#define SINGLE_MODULE_SENTINEL 10001
+
 /* GENERIC VAL APIs */
 void val_allocate_shared_mem(void);
 void val_free_shared_mem(void);

--- a/val/src/avs_exerciser.c
+++ b/val/src/avs_exerciser.c
@@ -235,6 +235,7 @@ val_exerciser_execute_tests(uint32_t level)
   }
 
   if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_EXERCISER_TEST_NUM_BASE) {
+    val_print(AVS_PRINT_TEST, " USER Override - Skipping all Exerciser tests (running only a single module)\n", 0);
     return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_exerciser.c
+++ b/val/src/avs_exerciser.c
@@ -234,6 +234,10 @@ val_exerciser_execute_tests(uint32_t level)
       }
   }
 
+  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_EXERCISER_TEST_NUM_BASE) {
+    return AVS_STATUS_SKIP;
+  }
+
   /* Create the list of valid Pcie Device Functions */
   if (val_pcie_create_device_bdf_table()) {
       val_print(AVS_PRINT_WARN, "\n     Create BDF Table Failed, Skipping Exerciser tests...\n", 0);

--- a/val/src/avs_gic.c
+++ b/val/src/avs_gic.c
@@ -44,7 +44,10 @@ val_gic_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_GIC_TEST_NUM_BASE) {
+  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_GIC_TEST_NUM_BASE &&
+       (g_single_test == SINGLE_MODULE_SENTINEL ||
+         (g_single_test - AVS_GIC_TEST_NUM_BASE > 100 ||
+          g_single_test - AVS_GIC_TEST_NUM_BASE < 0))) {
     val_print(AVS_PRINT_TEST, "      USER Override - Skipping all GIC tests (running only a single module)\n", 0);
     return AVS_STATUS_SKIP;
   }

--- a/val/src/avs_gic.c
+++ b/val/src/avs_gic.c
@@ -44,6 +44,11 @@ val_gic_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
+  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_GIC_TEST_NUM_BASE) {
+    val_print(AVS_PRINT_TEST, "      USER Override - Skipping all GIC tests (running only a single module)\n", 0);
+    return AVS_STATUS_SKIP;
+  }
+
   g_curr_module = 1 << GIC_MODULE;
   status = g001_entry(num_pe);
   status |= g002_entry(num_pe);

--- a/val/src/avs_nist.c
+++ b/val/src/avs_nist.c
@@ -39,6 +39,11 @@ val_nist_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
+  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_NIST_TEST_NUM_BASE) {
+    val_print(AVS_PRINT_TEST, "      USER Override - Skipping all NIST tests (running only a single module)\n", 0);
+    return AVS_STATUS_SKIP;
+  }
+
   status = n001_entry(num_pe);
 
   val_print_test_end(status, "NIST");

--- a/val/src/avs_nist.c
+++ b/val/src/avs_nist.c
@@ -39,7 +39,10 @@ val_nist_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_NIST_TEST_NUM_BASE) {
+  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_NIST_TEST_NUM_BASE &&
+       (g_single_test == SINGLE_MODULE_SENTINEL ||
+         (g_single_test - AVS_NIST_TEST_NUM_BASE > 100 ||
+          g_single_test - AVS_NIST_TEST_NUM_BASE < 0))) {
     val_print(AVS_PRINT_TEST, "      USER Override - Skipping all NIST tests (running only a single module)\n", 0);
     return AVS_STATUS_SKIP;
   }

--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -271,7 +271,10 @@ val_pcie_execute_tests(uint32_t enable_pcie, uint32_t level, uint32_t num_pe)
     return AVS_STATUS_SKIP;
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_PCIE_TEST_NUM_BASE) {
+  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_PCIE_TEST_NUM_BASE &&
+       (g_single_test == SINGLE_MODULE_SENTINEL ||
+         (g_single_test - AVS_PCIE_TEST_NUM_BASE > 100 ||
+          g_single_test - AVS_PCIE_TEST_NUM_BASE < 0))) {
     val_print(AVS_PRINT_TEST, "      USER Override - Skipping all PCIe tests (running only a single module)\n", 0);
     return AVS_STATUS_SKIP;
   }

--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -271,6 +271,11 @@ val_pcie_execute_tests(uint32_t enable_pcie, uint32_t level, uint32_t num_pe)
     return AVS_STATUS_SKIP;
   }
 
+  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_PCIE_TEST_NUM_BASE) {
+    val_print(AVS_PRINT_TEST, "      USER Override - Skipping all PCIe tests (running only a single module)\n", 0);
+    return AVS_STATUS_SKIP;
+  }
+
   g_curr_module = 1 << PCIE_MODULE;
   status = p001_entry(num_pe);
 

--- a/val/src/avs_pe.c
+++ b/val/src/avs_pe.c
@@ -51,6 +51,11 @@ val_pe_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
+  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_PE_TEST_NUM_BASE) {
+    val_print(AVS_PRINT_TEST, "      USER Override - Skipping all PE tests (running only a single module)\n", 0);
+    return AVS_STATUS_SKIP;
+  }
+
   g_curr_module = 1 << PE_MODULE;
   status = c001_entry();
   status |= c002_entry(num_pe);

--- a/val/src/avs_pe.c
+++ b/val/src/avs_pe.c
@@ -51,7 +51,9 @@ val_pe_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_PE_TEST_NUM_BASE) {
+  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_PE_TEST_NUM_BASE &&
+       (g_single_test == SINGLE_MODULE_SENTINEL ||
+       (g_single_test - AVS_PE_TEST_NUM_BASE > 100))) {
     val_print(AVS_PRINT_TEST, "      USER Override - Skipping all PE tests (running only a single module)\n", 0);
     return AVS_STATUS_SKIP;
   }

--- a/val/src/avs_peripherals.c
+++ b/val/src/avs_peripherals.c
@@ -45,7 +45,12 @@ val_peripheral_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
-   g_curr_module = 1 << PERIPHERAL_MODULE;
+	if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_PER_TEST_NUM_BASE) {
+    val_print(AVS_PRINT_TEST, "      USER Override - Skipping all Peripheral tests (running only a single module)\n", 0);
+    return AVS_STATUS_SKIP;
+  }
+
+  g_curr_module = 1 << PERIPHERAL_MODULE;
   status = d001_entry(num_pe);
   status |= d002_entry(num_pe);
   status |= d003_entry(num_pe);

--- a/val/src/avs_peripherals.c
+++ b/val/src/avs_peripherals.c
@@ -45,7 +45,10 @@ val_peripheral_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
-	if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_PER_TEST_NUM_BASE) {
+  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_PER_TEST_NUM_BASE &&
+       (g_single_test == SINGLE_MODULE_SENTINEL ||
+         (g_single_test - AVS_PER_TEST_NUM_BASE > 100 ||
+          g_single_test - AVS_PER_TEST_NUM_BASE < 0))) {
     val_print(AVS_PRINT_TEST, "      USER Override - Skipping all Peripheral tests (running only a single module)\n", 0);
     return AVS_STATUS_SKIP;
   }

--- a/val/src/avs_smmu.c
+++ b/val/src/avs_smmu.c
@@ -66,7 +66,10 @@ val_smmu_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_SMMU_TEST_NUM_BASE) {
+  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_SMMU_TEST_NUM_BASE &&
+       (g_single_test == SINGLE_MODULE_SENTINEL ||
+         (g_single_test - AVS_SMMU_TEST_NUM_BASE > 100 ||
+          g_single_test - AVS_SMMU_TEST_NUM_BASE < 0))) {
     val_print(AVS_PRINT_TEST, "      USER Override - Skipping all SMMU tests (running only a single module)\n", 0);
     return AVS_STATUS_SKIP;
   }

--- a/val/src/avs_smmu.c
+++ b/val/src/avs_smmu.c
@@ -66,6 +66,11 @@ val_smmu_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
+  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_SMMU_TEST_NUM_BASE) {
+    val_print(AVS_PRINT_TEST, "      USER Override - Skipping all SMMU tests (running only a single module)\n", 0);
+    return AVS_STATUS_SKIP;
+  }
+
   num_smmu = val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);
   if (num_smmu == 0) {
     val_print(AVS_PRINT_WARN, "\n     No SMMU Controller Found, Skipping SMMU tests...\n", 0);

--- a/val/src/avs_test_infra.c
+++ b/val/src/avs_test_infra.c
@@ -260,6 +260,12 @@ val_initialize_test(uint32_t test_num, char8_t *desc, uint32_t num_pe, uint32_t 
       }
   }
 
+  if (g_single_test != SINGLE_TEST_SENTINEL && test_num != g_single_test) {
+    val_print(AVS_PRINT_TEST, "\n       USER OVERRIDE VIA SINGLE TEST - Skip Test        ", 0);
+    val_set_status(index, RESULT_SKIP(g_sbsa_level, test_num, 0));
+    return AVS_STATUS_SKIP;
+  }
+
   return AVS_STATUS_PASS;
 }
 

--- a/val/src/avs_test_infra.c
+++ b/val/src/avs_test_infra.c
@@ -223,7 +223,7 @@ val_mmio_write64(addr_t addr, uint64_t data)
 }
 
 /**
-  @brief  This API prinst the test number, description and
+  @brief  This API prints the test number, description and
           sets the test status to pending for the input number of PEs.
           1. Caller       - Application layer
           2. Prerequisite - val_allocate_shared_mem
@@ -260,7 +260,10 @@ val_initialize_test(uint32_t test_num, char8_t *desc, uint32_t num_pe, uint32_t 
       }
   }
 
-  if (g_single_test != SINGLE_TEST_SENTINEL && test_num != g_single_test) {
+  if ((g_single_test != SINGLE_TEST_SENTINEL && test_num != g_single_test) &&
+        (g_single_module == SINGLE_MODULE_SENTINEL ||
+          (test_num - g_single_module >= 100 ||
+           test_num - g_single_module < 0))) {
     val_print(AVS_PRINT_TEST, "\n       USER OVERRIDE VIA SINGLE TEST - Skip Test        ", 0);
     val_set_status(index, RESULT_SKIP(g_sbsa_level, test_num, 0));
     return AVS_STATUS_SKIP;

--- a/val/src/avs_timer.c
+++ b/val/src/avs_timer.c
@@ -45,6 +45,7 @@ val_timer_execute_tests(uint32_t level, uint32_t num_pe)
   }
 
   if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_TIMER_TEST_NUM_BASE) {
+    val_print(AVS_PRINT_TEST, " USER Override - Skipping all Timer tests (running only a single module)\n", 0);
     return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_timer.c
+++ b/val/src/avs_timer.c
@@ -44,7 +44,10 @@ val_timer_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_TIMER_TEST_NUM_BASE) {
+  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_TIMER_TEST_NUM_BASE &&
+       (g_single_test == SINGLE_MODULE_SENTINEL ||
+         (g_single_test - AVS_TIMER_TEST_NUM_BASE > 100 ||
+          g_single_test - AVS_TIMER_TEST_NUM_BASE < 0))) {
     val_print(AVS_PRINT_TEST, " USER Override - Skipping all Timer tests (running only a single module)\n", 0);
     return AVS_STATUS_SKIP;
   }

--- a/val/src/avs_timer.c
+++ b/val/src/avs_timer.c
@@ -44,6 +44,10 @@ val_timer_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
+  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_TIMER_TEST_NUM_BASE) {
+    return AVS_STATUS_SKIP;
+  }
+
   g_curr_module = 1 << TIMER_MODULE;
   status = t001_entry(num_pe);
   status |= t002_entry(num_pe);

--- a/val/src/avs_wakeup.c
+++ b/val/src/avs_wakeup.c
@@ -42,6 +42,10 @@ val_wakeup_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
+  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_WAKEUP_TEST_NUM_BASE) {
+    return AVS_STATUS_SKIP;
+  }
+
   g_curr_module = 1 << WAKEUP_MODULE;
   status = u001_entry(num_pe);
   //status |= u002_entry(num_pe);

--- a/val/src/avs_wakeup.c
+++ b/val/src/avs_wakeup.c
@@ -42,7 +42,10 @@ val_wakeup_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_WAKEUP_TEST_NUM_BASE) {
+  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_WAKEUP_TEST_NUM_BASE &&
+       (g_single_test == SINGLE_MODULE_SENTINEL ||
+         (g_single_test - AVS_WAKEUP_TEST_NUM_BASE > 100 ||
+          g_single_test - AVS_WAKEUP_TEST_NUM_BASE < 0))) {
     val_print(AVS_PRINT_TEST, " USER Override - Skipping all Wakeup tests (running only a single module)\n", 0);
     return AVS_STATUS_SKIP;
   }

--- a/val/src/avs_wakeup.c
+++ b/val/src/avs_wakeup.c
@@ -43,6 +43,7 @@ val_wakeup_execute_tests(uint32_t level, uint32_t num_pe)
   }
 
   if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_WAKEUP_TEST_NUM_BASE) {
+    val_print(AVS_PRINT_TEST, " USER Override - Skipping all Wakeup tests (running only a single module)\n", 0);
     return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_wd.c
+++ b/val/src/avs_wd.c
@@ -43,6 +43,10 @@ val_wd_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
+  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_WD_TEST_NUM_BASE) {
+    return AVS_STATUS_SKIP;
+  }
+
   g_curr_module = 1 << WD_MODULE;
   status = w001_entry(num_pe);
   status |= w002_entry(num_pe);

--- a/val/src/avs_wd.c
+++ b/val/src/avs_wd.c
@@ -43,7 +43,10 @@ val_wd_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_WD_TEST_NUM_BASE) {
+  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_WD_TEST_NUM_BASE &&
+       (g_single_test == SINGLE_MODULE_SENTINEL ||
+         (g_single_test - AVS_WD_TEST_NUM_BASE > 100 ||
+          g_single_test - AVS_WD_TEST_NUM_BASE < 0))) {
     val_print(AVS_PRINT_TEST, " USER Override - Skipping all Watchdog tests (running only a single module)\n", 0);
     return AVS_STATUS_SKIP;
   }

--- a/val/src/avs_wd.c
+++ b/val/src/avs_wd.c
@@ -44,6 +44,7 @@ val_wd_execute_tests(uint32_t level, uint32_t num_pe)
   }
 
   if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_WD_TEST_NUM_BASE) {
+    val_print(AVS_PRINT_TEST, " USER Override - Skipping all Watchdog tests (running only a single module)\n", 0);
     return AVS_STATUS_SKIP;
   }
 


### PR DESCRIPTION
This pull requests proposes a new set of parameters to the testing suite that allows the user to select specific test modules instead of being forced to run all of them. Having this feature greatly aids automated testing solutions and allows for more rapid debugging and testing of specific SBSA tests.