### PR TITLE
Determine service call conduit from the FADT table

### DIFF
--- a/platform/pal_uefi/include/pal_uefi.h
+++ b/platform/pal_uefi/include/pal_uefi.h
@@ -82,8 +82,10 @@ typedef struct {
 /**
   Conduits for service calls (SMC vs HVC).
 **/
-#define CONDUIT_SMC  0
-#define CONDUIT_HVC  1
+#define CONDUIT_SMC       0
+#define CONDUIT_HVC       1
+#define CONDUIT_UNKNOWN  -1
+#define CONDUIT_NONE     -2
 
 typedef struct {
   UINT32 num_of_pe;

--- a/platform/pal_uefi/include/pal_uefi.h
+++ b/platform/pal_uefi/include/pal_uefi.h
@@ -79,6 +79,12 @@ typedef struct {
 #define sbsa_print(verbose, string, ...) if(verbose >= g_print_level) \
                                             Print(string, ##__VA_ARGS__)
 
+/**
+  Conduits for service calls (SMC vs HVC).
+**/
+#define CONDUIT_SMC  0
+#define CONDUIT_HVC  1
+
 typedef struct {
   UINT32 num_of_pe;
 }PE_INFO_HDR;

--- a/platform/pal_uefi/src/AArch64/ArmSmc.S
+++ b/platform/pal_uefi/src/AArch64/ArmSmc.S
@@ -19,11 +19,19 @@
 .text
 .align 3
 
+GCC_ASM_IMPORT(gPsciConduit)
+.equ CONDUIT_SMC,        0
+.equ CONDUIT_HVC,        1
+.equ INVALID_PARAMETER, -3
+
 GCC_ASM_EXPORT(ArmCallSmc)
 
 ASM_PFX(ArmCallSmc):
   // Push x0 on the stack - The stack must always be quad-word aligned
   str   x0, [sp, #-16]!
+
+  // Load the conduit into x10
+  mov   x10, x1
 
   // Load the SMC arguments values into the appropriate registers
   ldp   x6, x7, [x0, #48]
@@ -31,8 +39,25 @@ ASM_PFX(ArmCallSmc):
   ldp   x2, x3, [x0, #16]
   ldp   x0, x1, [x0, #0]
 
-  smc   #0
+  // Check whether the conduit is SMC or HVC
+  cmp   x10, CONDUIT_SMC
+  beq   conduit_smc
+  cmp   x10, CONDUIT_HVC
+  beq   conduit_hvc
 
+conduit_invalid:
+  mov   x0, INVALID_PARAMETER
+  b     finish
+
+conduit_smc:
+  smc   #0
+  b     finish
+
+conduit_hvc:
+  hvc   #0
+  b     finish
+
+finish:
   // Pop the ARM_SMC_ARGS structure address from the stack into x9
   ldr   x9, [sp], #16
 

--- a/platform/pal_uefi/src/pal_acpi.c
+++ b/platform/pal_uefi/src/pal_acpi.c
@@ -242,3 +242,38 @@ pal_get_iort_ptr()
   return 0;
 
 }
+
+/**
+  @brief   Iterate through the tables pointed by XSDT and return FADT Table address
+
+  @param   None
+
+  @return  64-bit address of FADT table
+  @retval  0:  FADT table could not be found
+**/
+UINT64
+pal_get_fadt_ptr (
+  VOID
+  )
+{
+  EFI_ACPI_DESCRIPTION_HEADER   *Xsdt;
+  UINT64                        *Entry64;
+  UINT32                        Entry64Num;
+  UINT32                        Idx;
+
+  Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
+  if (Xsdt == NULL) {
+      sbsa_print(AVS_PRINT_ERR, L" XSDT not found \n");
+      return 0;
+  }
+
+  Entry64 = (UINT64 *)(Xsdt + 1);
+  Entry64Num = (Xsdt->Length - sizeof (EFI_ACPI_DESCRIPTION_HEADER)) >> 3;
+  for (Idx = 0; Idx < Entry64Num; Idx++) {
+    if (*(UINT32 *)(UINTN)(Entry64[Idx]) == EFI_ACPI_6_1_FIXED_ACPI_DESCRIPTION_TABLE_SIGNATURE) {
+      return (UINT64)(Entry64[Idx]);
+    }
+  }
+
+  return 0;
+}

--- a/platform/pal_uefi/src/pal_pe.c
+++ b/platform/pal_uefi/src/pal_pe.c
@@ -54,8 +54,8 @@ ArmCallSmc (
 
   @param
 
-  @retval  -1:                    PSCI is not implemented or the FADT
-                                  table could not be discovered.
+  @retval  CONDUIT_UNKNOWN:       The FADT table could not be discovered.
+  @retval  CONDUIT_NONE:          PSCI is not implemented
   @retval  CONDUIT_SMC:           PSCI is implemented and uses SMC as
                                   the conduit.
   @retval  CONDUIT_HVC:           PSCI is implemented and uses HVC as
@@ -69,8 +69,10 @@ pal_psci_get_conduit (
   EFI_ACPI_6_1_FIXED_ACPI_DESCRIPTION_TABLE  *Fadt;
 
   Fadt = (EFI_ACPI_6_1_FIXED_ACPI_DESCRIPTION_TABLE *)pal_get_fadt_ptr ();
-  if (!Fadt || !(Fadt->ArmBootArch & EFI_ACPI_6_1_ARM_PSCI_COMPLIANT)) {
-    return -1;
+  if (!Fadt) {
+    return CONDUIT_UNKNOWN;
+  } else if (!(Fadt->ArmBootArch & EFI_ACPI_6_1_ARM_PSCI_COMPLIANT)) {
+    return CONDUIT_NONE;
   } else if (Fadt->ArmBootArch & EFI_ACPI_6_1_ARM_PSCI_USE_HVC) {
     return CONDUIT_HVC;
   } else {

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -94,8 +94,10 @@
 /**
   @brief Conduits for service calls (SMC vs HVC).
 **/
-#define CONDUIT_SMC  0
-#define CONDUIT_HVC  1
+#define CONDUIT_SMC       0
+#define CONDUIT_HVC       1
+#define CONDUIT_UNKNOWN  -1
+#define CONDUIT_NONE     -2
 int32_t pal_psci_get_conduit(void);
 
 /**

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -92,6 +92,13 @@
 /**  PE Test related Definitions **/
 
 /**
+  @brief Conduits for service calls (SMC vs HVC).
+**/
+#define CONDUIT_SMC  0
+#define CONDUIT_HVC  1
+int32_t pal_psci_get_conduit(void);
+
+/**
   @brief  number of PEs discovered
 **/
 typedef struct {
@@ -141,7 +148,7 @@ typedef struct {
   uint64_t  Arg7;
 } ARM_SMC_ARGS;
 
-void pal_pe_call_smc(ARM_SMC_ARGS *args);
+void pal_pe_call_smc(ARM_SMC_ARGS *args, int32_t conduit);
 void pal_pe_execute_payload(ARM_SMC_ARGS *args);
 uint32_t pal_pe_install_esr(uint32_t exception_type, void (*esr)(uint64_t, void *));
 /* ********** PE INFO END **********/

--- a/val/include/sbsa_std_smc.h
+++ b/val/include/sbsa_std_smc.h
@@ -106,8 +106,8 @@
 **/
 void
 ArmCallSmc (
-  ARM_SMC_ARGS *Args
+  ARM_SMC_ARGS *Args,
+  INT32         Conduit
   );
-
 
 #endif

--- a/val/include/sbsa_std_smc.h
+++ b/val/include/sbsa_std_smc.h
@@ -107,7 +107,7 @@
 void
 ArmCallSmc (
   ARM_SMC_ARGS *Args,
-  INT32         Conduit
+  int32_t      Conduit
   );
 
 #endif

--- a/val/src/avs_pe_infra.c
+++ b/val/src/avs_pe_infra.c
@@ -21,6 +21,8 @@
 #include "include/sbsa_std_smc.h"
 #include "sys_arch_src/gic/sbsa_exception.h"
 
+int32_t gPsciConduit;
+
 /**
   @brief   Pointer to the memory location of the PE Information table
 **/
@@ -42,6 +44,7 @@ ARM_SMC_ARGS g_smc_args;
 uint32_t
 val_pe_create_info_table(uint64_t *pe_info_table)
 {
+  gPsciConduit = pal_psci_get_conduit();
 
   if (pe_info_table == NULL) {
       val_print(AVS_PRINT_ERR, "Input memory for PE Info table cannot be NULL \n", 0);
@@ -189,7 +192,7 @@ val_test_entry(void)
   // We have completed our TEST code. So, switch off the PE now
   smc_args.Arg0 = ARM_SMC_ID_PSCI_CPU_OFF;
   smc_args.Arg1 = val_pe_get_mpid();
-  pal_pe_call_smc(&smc_args);
+  pal_pe_call_smc(&smc_args, gPsciConduit);
 }
 
 

--- a/val/src/avs_pe_infra.c
+++ b/val/src/avs_pe_infra.c
@@ -45,6 +45,18 @@ uint32_t
 val_pe_create_info_table(uint64_t *pe_info_table)
 {
   gPsciConduit = pal_psci_get_conduit();
+  if (gPsciConduit == CONDUIT_UNKNOWN) {
+      val_print(AVS_PRINT_WARN, " FADT not found, assuming SMC as PSCI conduit\n", 0);
+      gPsciConduit = CONDUIT_SMC;
+  } else if (gPsciConduit == CONDUIT_NONE) {
+      val_print(AVS_PRINT_WARN, " PSCI not supported, assuming SMC as conduit for tests\n"
+                                " Multi-PE and wakeup tests likely to fail\n", 0);
+      gPsciConduit = CONDUIT_SMC;
+  } else if (gPsciConduit == CONDUIT_HVC) {
+      val_print(AVS_PRINT_INFO, " Using HVC as PSCI conduit\n", 0);
+  } else {
+      val_print(AVS_PRINT_INFO, " Using SMC as PSCI conduit\n", 0);
+  }
 
   if (pe_info_table == NULL) {
       val_print(AVS_PRINT_ERR, "Input memory for PE Info table cannot be NULL \n", 0);

--- a/val/src/avs_wakeup.c
+++ b/val/src/avs_wakeup.c
@@ -22,6 +22,8 @@
 
 #include "include/sbsa_avs_wakeup.h"
 
+extern int32_t gPsciConduit;
+
 /**
   @brief   This API executes all the wakeup tests sequentially
            1. Caller       -  Application layer.
@@ -76,7 +78,7 @@ val_suspend_pe(uint32_t power_state, uint64_t entry, uint32_t context_id)
   smc_args.Arg1 = power_state;
   smc_args.Arg2 = entry;
   smc_args.Arg3 = context_id;
-  pal_pe_call_smc(&smc_args);
+  pal_pe_call_smc(&smc_args, gPsciConduit);
 }
 
 


### PR DESCRIPTION
This pull request fixes issue #263.

Summary of changes:

- A global variable `gPsciConduit` is created to store the conduit used for PSCI calls. This value is initialized during the call to `val_pe_create_info_table`.
- A function `pal_get_fadt_ptr` is added, which performs the lookup of the FADT table.
- A function `pal_psci_get_conduit` is added, which checks the FADT table and returns the PSCI conduit, or `-1` if PSCI is not implemented.
- `ArmCallSmc` and `pal_pe_call_smc` take an additional conduit argument, whose value determines whether `ArmCallSmc` will execute an `hvc` instruction or an `smc` instruction. In case of an invalid conduit, `ArmCallSmc` returns `-3`, which is `INVALID_PARAMETER` in SMCCC.

The reason why conduit is passed as a parameter instead of being retrieved from the global variable is that different services could potentially use different conduits.