### PR TITLE
Check for PMUv3 support before reading registers

### DIFF
--- a/test_pool/pe/test_c015.c
+++ b/test_pool/pe/test_c015.c
@@ -27,6 +27,7 @@
 #define SPE               2
 #define LOR               3
 #define AA32              4
+#define PMUV3             5
 
 #define MASK_AA64MMFR0    0xF
 #define MASK_MIDR         0x00F0FFFF
@@ -78,9 +79,9 @@ reg_details reg_list[] = {
     {MVFR0_EL1,        0x0,            "MVFR0_EL1"       , AA32},
     {MVFR1_EL1,        0x0,            "MVFR1_EL1"       , AA32},
     {MVFR2_EL1,        0x0,            "MVFR2_EL1"       , AA32},
-    {PMCEID0_EL0,      0x0,            "PMCEID0_EL0"     , 0x0 },
-    {PMCEID1_EL0,      0x0,            "PMCEID1_EL0"     , 0x0 },
-    {PMCR_EL0,         MASK_PMCR,      "PMCR_EL0"        , 0x0 },
+    {PMCEID0_EL0,      0x0,            "PMCEID0_EL0"     , PMUV3 },
+    {PMCEID1_EL0,      0x0,            "PMCEID1_EL0"     , PMUV3 },
+    {PMCR_EL0,         MASK_PMCR,      "PMCR_EL0"        , PMUV3 },
     {PMBIDR_EL1,       0x0,            "PMBIDR_EL1"      , SPE },
     {PMSIDR_EL1,       0x0,            "PMSIDR_EL1"      , SPE },
     {ERRIDR_EL1,       0x0,            "ERRIDR_EL1"      , RAS },
@@ -133,6 +134,15 @@ return_reg_value(uint32_t reg, uint8_t dependency)
         temp = val_pe_reg_read(ID_AA64PFR0_EL1);
         temp = (temp & 1);
         if(temp == 0)
+            return val_pe_reg_read(reg);
+        else
+            return 0;
+        break;
+
+    case PMUV3: // If PMUv3 is not supported, then skip register check
+        temp = val_pe_reg_read(ID_AA64DFR0_EL1);
+        temp = (temp >> 8) & 0xf;
+        if(temp != 0 && temp != 0b1111)
             return val_pe_reg_read(reg);
         else
             return 0;


### PR DESCRIPTION
This PR fixes an SBSA crash for virtualized environments that do not natively support PMUv3.