### PR TITLE
PCIe: Updates to test p048 and p049

### DIFF
--- a/test_pool/pcie/test_p048.c
+++ b/test_pool/pcie/test_p048.c
@@ -44,6 +44,56 @@ esr(uint64_t interrupt_type, void *context)
 }
 
 static
+uint32_t
+check_bdf_under_rp(uint32_t rp_bdf)
+{
+
+  uint32_t reg_value;
+  uint32_t rp_sec_bus, rp_sub_bus;
+  uint32_t dev_bdf, dev_bus, dev_sec_bus;
+  uint32_t rp_seg, dev_seg;
+  uint32_t dp_type;
+  uint32_t base_cc;
+  uint32_t dev_num, func_num;
+
+  rp_seg = PCIE_EXTRACT_BDF_SEG(rp_bdf);
+  val_pcie_read_cfg(rp_bdf, TYPE1_PBN, &reg_value);
+  rp_sec_bus = ((reg_value >> SECBN_SHIFT) & SECBN_MASK);
+  rp_sub_bus = ((reg_value >> SUBBN_SHIFT) & SUBBN_MASK);
+
+  for (dev_sec_bus = rp_sec_bus; dev_sec_bus <= rp_sub_bus; dev_sec_bus++)
+  {
+      for (dev_num = 0; dev_num < PCIE_MAX_DEV; dev_num++)
+      {
+          for (func_num = 0; func_num < PCIE_MAX_FUNC; func_num++)
+          {
+              dev_bdf = PCIE_CREATE_BDF(rp_seg, dev_sec_bus, dev_num, func_num);
+              val_pcie_read_cfg(dev_bdf, TYPE01_VIDR, &reg_value);
+              if (reg_value == PCIE_UNKNOWN_RESPONSE)
+                  continue;
+
+              dp_type = val_pcie_device_port_type(dev_bdf);
+              if ((dp_type == iEP_EP) || (dp_type == EP))
+              {
+                  dev_bus = PCIE_EXTRACT_BDF_BUS(dev_bdf);
+                  dev_seg = PCIE_EXTRACT_BDF_SEG(dev_bdf);
+                  if ((dev_seg == rp_seg) && ((dev_bus >= rp_sec_bus) && (dev_bus <= rp_sub_bus)))
+                  {
+                      val_pcie_read_cfg(dev_bdf, TYPE01_RIDR, &reg_value);
+                      val_print(AVS_PRINT_DEBUG, "\n Class code is %x", reg_value);
+                      base_cc = reg_value >> TYPE01_BCC_SHIFT;
+                      if ((base_cc == CNTRL_CC) || (base_cc == DP_CNTRL_CC))
+                          return 1;
+                  }
+              }
+           }
+       }
+  }
+
+   return 0;
+}
+
+static
 void
 payload(void)
 {
@@ -105,11 +155,15 @@ payload(void)
 
         /* Read Function's NP Memory Base Limit Register */
         val_pcie_read_cfg(bdf, TYPE1_NP_MEM, &read_value);
+        val_print(AVS_PRINT_DEBUG, "\n  BDF is 0x%x", bdf);
         if (read_value == 0)
           continue;
 
         mem_base = (read_value & MEM_BA_MASK) << MEM_BA_SHIFT;
         mem_lim = (read_value & MEM_LIM_MASK) | MEM_LIM_LOWER_BITS;
+
+        val_print(AVS_PRINT_DEBUG, "\n   Memory base is 0x%llx", mem_base);
+        val_print(AVS_PRINT_DEBUG, " Memory lim is  0x%llx", mem_lim);
 
         /* If Memory Limit is programmed with value less the Base, then Skip.*/
         if (mem_lim < mem_base)
@@ -147,6 +201,15 @@ payload(void)
           return;
         }
 
+        /** Skip Check_2 if there is an Ethernet or Display controller
+         * under the RP device
+         **/
+        if (check_bdf_under_rp(bdf))
+        {
+            val_print(AVS_PRINT_DEBUG, "\n   Skipping for RP BDF %x", bdf);
+            continue;
+        }
+
         /**Check_2: Accessing out of NP memory limit range should return 0xFFFFFFFF
          *
          * If the limit exceeds 1MB then modify the range to be 1MB
@@ -156,12 +219,14 @@ payload(void)
 
         if ((mem_lim >> MEM_SHIFT) > (mem_base >> MEM_SHIFT))
         {
+           val_print(AVS_PRINT_DEBUG, "\n Entered Check_2 for bdf %x", bdf);
            new_mem_lim = mem_base + MEM_OFFSET_LARGE;
            mem_base = mem_base | (mem_base  >> 16);
            val_pcie_write_cfg(bdf, TYPE1_NP_MEM, mem_base);
            val_pcie_read_cfg(bdf, TYPE1_NP_MEM, &read_value);
 
            value = (*(volatile uint32_t *)(new_mem_lim + MEM_OFFSET_SMALL));
+           val_print(AVS_PRINT_DEBUG, "  Value read is 0x%llx", value);
            if (value != PCIE_UNKNOWN_RESPONSE)
            {
                val_print(AVS_PRINT_ERR, "\n Memory range for bdf 0x%x", bdf);

--- a/test_pool/pcie/test_p049.c
+++ b/test_pool/pcie/test_p049.c
@@ -43,6 +43,57 @@ esr(uint64_t interrupt_type, void *context)
   val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
 }
 
+
+static
+uint32_t
+check_bdf_under_rp(uint32_t rp_bdf)
+{
+
+  uint32_t reg_value;
+  uint32_t rp_sec_bus, rp_sub_bus;
+  uint32_t dev_bdf, dev_bus, dev_sec_bus;
+  uint32_t rp_seg, dev_seg;
+  uint32_t dp_type;
+  uint32_t base_cc;
+  uint32_t dev_num, func_num;
+
+  rp_seg = PCIE_EXTRACT_BDF_SEG(rp_bdf);
+  val_pcie_read_cfg(rp_bdf, TYPE1_PBN, &reg_value);
+  rp_sec_bus = ((reg_value >> SECBN_SHIFT) & SECBN_MASK);
+  rp_sub_bus = ((reg_value >> SUBBN_SHIFT) & SUBBN_MASK);
+
+  for (dev_sec_bus = rp_sec_bus; dev_sec_bus <= rp_sub_bus; dev_sec_bus++)
+  {
+      for (dev_num = 0; dev_num < PCIE_MAX_DEV; dev_num++)
+      {
+          for (func_num = 0; func_num < PCIE_MAX_FUNC; func_num++)
+          {
+              dev_bdf = PCIE_CREATE_BDF(rp_seg, dev_sec_bus, dev_num, func_num);
+              val_pcie_read_cfg(dev_bdf, TYPE01_VIDR, &reg_value);
+              if (reg_value == PCIE_UNKNOWN_RESPONSE)
+                  continue;
+
+              dp_type = val_pcie_device_port_type(dev_bdf);
+              if ((dp_type == iEP_EP) || (dp_type == EP))
+              {
+                  dev_bus = PCIE_EXTRACT_BDF_BUS(dev_bdf);
+                  dev_seg = PCIE_EXTRACT_BDF_SEG(dev_bdf);
+                  if ((dev_seg == rp_seg) && ((dev_bus >= rp_sec_bus) && (dev_bus <= rp_sub_bus)))
+                  {
+                      val_pcie_read_cfg(dev_bdf, TYPE01_RIDR, &reg_value);
+                      val_print(AVS_PRINT_DEBUG, "\n Class code is %x", reg_value);
+                      base_cc = reg_value >> TYPE01_BCC_SHIFT;
+                      if ((base_cc == CNTRL_CC) || (base_cc == DP_CNTRL_CC))
+                          return 1;
+                  }
+              }
+           }
+       }
+  }
+
+   return 0;
+}
+
 static
 void
 payload(void)
@@ -103,6 +154,7 @@ payload(void)
 
         /* Read Function's Memory Base Limit Register */
         val_pcie_read_cfg(bdf, TYPE1_P_MEM, &read_value);
+        val_print(AVS_PRINT_DEBUG, "\n  BDF is 0x%x", bdf);
         if (read_value == 0)
           continue;
 
@@ -119,6 +171,9 @@ payload(void)
 
         mem_base |= (mem_base_upper << P_MEM_BU_SHIFT);
         mem_lim |= (mem_lim_upper << P_MEM_LU_SHIFT);
+
+        val_print(AVS_PRINT_DEBUG, "\n   Memory base is 0x%llx", mem_base);
+        val_print(AVS_PRINT_DEBUG, " Memory lim is  0x%llx", mem_lim);
 
         /* If Memory Limit is programmed with value less the Base, then Skip.*/
         if (mem_lim < mem_base)
@@ -155,6 +210,15 @@ payload(void)
           return;
         }
 
+        /** Skip Check_2 if there is an Ethernet or Display controller
+         * under the RP device
+         **/
+        if (check_bdf_under_rp(bdf))
+        {
+            val_print(AVS_PRINT_DEBUG, "\n   Skipping for RP BDF %x", bdf);
+            continue;
+        }
+
         /**Check_2: Accessing out of P memory limit range should return 0xFFFFFFFF
          *
          * If the limit exceeds 1MB then modify the range to be 1MB
@@ -164,6 +228,7 @@ payload(void)
 
         if ((mem_lim >> MEM_SHIFT) > (mem_base >> MEM_SHIFT))
         {
+           val_print(AVS_PRINT_DEBUG, "\n Entered Check_2 for bdf %x", bdf);
            new_mem_lim  = mem_base + MEM_OFFSET_LARGE;
            val_pcie_read_cfg(bdf, TYPE1_P_MEM, &new_value);
 
@@ -190,6 +255,7 @@ payload(void)
            updated_mem_lim |= (mem_lim_upper << P_MEM_LU_SHIFT);
 
            value = (*(volatile uint32_t *)(new_mem_lim + MEM_OFFSET_SMALL));
+           val_print(AVS_PRINT_DEBUG, "  Value read is 0x%llx", value);
            if (value != PCIE_UNKNOWN_RESPONSE)
            {
                val_print(AVS_PRINT_ERR, "\n Memory range for bdf 0x%x", bdf);

--- a/val/include/sbsa_avs_pcie_spec.h
+++ b/val/include/sbsa_avs_pcie_spec.h
@@ -42,9 +42,12 @@
 #define TYPE01_IPR_MASK     0xFF
 #define TYPE01_ILR_SHIFT    0
 #define TYPE01_ILR_MASK     0xFF
+#define TYPE01_BCC_SHIFT    24
 
 #define TYPE0_HEADER 0
 #define TYPE1_HEADER 1
+#define CNTRL_CC     0x2
+#define DP_CNTRL_CC  0x3
 
 /* Command register shifts */
 #define CR_MSE_SHIFT   1


### PR DESCRIPTION
- Skip check of "Accessing out of memory limit range
  should return 0xFFFFFFFF" for RP's with an Ethernet
  or Display controller under them

Signed-off-by: Sujana M <sujana.m@arm.com>