### PR TITLE
PCIe test 41 updated to fail when RCiEP supports only legacy interrupt and no MSI/MSI-X interrupt.

### DIFF
--- a/test_pool/pcie/test_p007.c
+++ b/test_pool/pcie/test_p007.c
@@ -42,6 +42,8 @@ payload(void)
   while (count > 0) {
       count--;
       dev_bdf = val_peripheral_get_info(ANY_BDF, count);
+
+      val_print(AVS_PRINT_DEBUG, "\n       dev_bdf %x", dev_bdf);
       /* Check for pcie device */
       if (!val_peripheral_is_pcie(dev_bdf))
           continue;
@@ -52,6 +54,7 @@ payload(void)
           continue;
 
       data = val_peripheral_get_info(ANY_FLAGS, count);
+      val_print(AVS_PRINT_DEBUG, "       data %x", data);
 
       if ((data & PER_FLAG_MSI_ENABLED) == 0) {
           val_print(AVS_PRINT_ERR, "\n       MSI should be enabled for a PCIe device ", 0);

--- a/test_pool/pcie/test_p041.c
+++ b/test_pool/pcie/test_p041.c
@@ -37,6 +37,9 @@ payload(void)
   uint32_t cap_base;
   uint32_t test_fails;
   uint32_t test_skip = 1;
+  uint32_t reg_value;
+  uint32_t int_pin;
+
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
@@ -57,12 +60,24 @@ payload(void)
       /* Check entry is endpoint or rciep */
       if ((dp_type == iEP_EP) || (dp_type == RCiEP))
       {
+         val_print(AVS_PRINT_DEBUG, "\n    BDF 0x%x", bdf);
+
+         val_pcie_read_cfg(bdf, TYPE01_ILR, &reg_value);
+         int_pin = VAL_EXTRACT_BITS(reg_value, TYPE01_IPR_SHIFT, TYPE01_IPR_SHIFT + 7);
+         val_print(AVS_PRINT_DEBUG, " int pin value %d", int_pin);
+
+         val_print(AVS_PRINT_DEBUG, " MSI cap %d",
+                                    val_pcie_find_capability(bdf, PCIE_CAP, CID_MSI, &cap_base));
+         val_print(AVS_PRINT_DEBUG, " MSIX cap %d",
+                                   val_pcie_find_capability(bdf, PCIE_CAP, CID_MSIX, &cap_base));
+
          /* If test runs for atleast an endpoint */
          test_skip = 0;
 
-         /* If MSI or MSI-X not supported, test fails */
-         if ((val_pcie_find_capability(bdf, PCIE_CAP, CID_MSI, &cap_base) == PCIE_CAP_NOT_FOUND) &&
-             (val_pcie_find_capability(bdf, PCIE_CAP, CID_MSIX, &cap_base) == PCIE_CAP_NOT_FOUND))
+         /* If MSI or MSI-X not supported, but INTx supported test fails */
+         if ((val_pcie_find_capability(bdf, PCIE_CAP, CID_MSI, &cap_base) == PCIE_CAP_NOT_FOUND)
+           && (val_pcie_find_capability(bdf, PCIE_CAP, CID_MSIX, &cap_base) == PCIE_CAP_NOT_FOUND)
+             && ((int_pin >= 1) && (int_pin <= 4)))
               test_fails++;
       }
   }


### PR DESCRIPTION
* Test 41 updated to reflect 
RE_INT_1 If the RCiEP supports interrupt generation, the RCiEP must support MSI or MSI-X interrupt generation.

* Debug print also added in pcie test 7 and 41