### PR TITLE
PCIe: Update tests

### DIFF
--- a/test_pool/pcie/test_p048.c
+++ b/test_pool/pcie/test_p048.c
@@ -82,7 +82,7 @@ check_bdf_under_rp(uint32_t rp_bdf)
                       val_pcie_read_cfg(dev_bdf, TYPE01_RIDR, &reg_value);
                       val_print(AVS_PRINT_DEBUG, "\n Class code is %x", reg_value);
                       base_cc = reg_value >> TYPE01_BCC_SHIFT;
-                      if ((base_cc == CNTRL_CC) || (base_cc == DP_CNTRL_CC))
+                      if ((base_cc == CNTRL_CC) || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC))
                           return 1;
                   }
               }

--- a/test_pool/pcie/test_p049.c
+++ b/test_pool/pcie/test_p049.c
@@ -83,7 +83,7 @@ check_bdf_under_rp(uint32_t rp_bdf)
                       val_pcie_read_cfg(dev_bdf, TYPE01_RIDR, &reg_value);
                       val_print(AVS_PRINT_DEBUG, "\n Class code is %x", reg_value);
                       base_cc = reg_value >> TYPE01_BCC_SHIFT;
-                      if ((base_cc == CNTRL_CC) || (base_cc == DP_CNTRL_CC))
+                      if ((base_cc == CNTRL_CC) || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC))
                           return 1;
                   }
               }

--- a/val/include/sbsa_avs_pcie_spec.h
+++ b/val/include/sbsa_avs_pcie_spec.h
@@ -46,6 +46,7 @@
 
 #define TYPE0_HEADER 0
 #define TYPE1_HEADER 1
+#define MAS_CC       0x1
 #define CNTRL_CC     0x2
 #define DP_CNTRL_CC  0x3
 

--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -1905,8 +1905,9 @@ val_pcie_get_rootport(uint32_t bdf, uint32_t *rp_bdf)
 
   val_print(AVS_PRINT_DEBUG, " DP type 0x%x ", dp_type);
 
-  /* If the device is RP, set its rootport value to same */
-  if (dp_type == RP)
+
+  /* If the device is RP or iEP_RP, set its rootport value to same */
+  if ((dp_type == RP) || (dp_type == iEP_RP))
   {
       *rp_bdf = bdf;
       return 0;
@@ -1969,7 +1970,7 @@ val_pcie_parent_is_rootport(uint32_t dsf_bdf, uint32_t *rp_bdf)
       dp_type = val_pcie_device_port_type(bdf);
 
       /* Check if this table entry is a Root Port */
-      if (dp_type == RP)
+      if ((dp_type == RP) || (dp_type == iEP_RP))
       {
          /* Check if device is a direct child of this root port */
           val_pcie_read_cfg(bdf, TYPE1_PBN, &reg_value);


### PR DESCRIPTION
- If Device is iEP_RP, set RP value to same BDF
- Skip check of "Accessing out of memory limit range"
  with mass storage controller

Signed-off-by: Sujana M <sujana.m@arm.com>