### PR TITLE
Fix function protype mismatches

### DIFF
--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -181,7 +181,7 @@ typedef enum {
 void     val_wd_create_info_table(uint64_t *wd_info_table);
 void     val_wd_free_info_table(void);
 uint32_t val_wd_execute_tests(uint32_t level, uint32_t num_pe);
-uint64_t val_wd_get_info(uint32_t index, uint32_t info_type);
+uint64_t val_wd_get_info(uint32_t index, WD_INFO_TYPE_e info_type);
 uint32_t val_wd_set_ws0(uint32_t index, uint32_t timeout);
 uint64_t val_get_counter_frequency(void);
 

--- a/val/src/avs_gic.c
+++ b/val/src/avs_gic.c
@@ -249,7 +249,7 @@ val_get_cpuif_base(void)
   @return  32-bit data
 **/
 uint32_t
-val_gic_get_info(uint32_t type)
+val_gic_get_info(GIC_INFO_e type)
 {
   uint32_t rdbase_len;
 


### PR DESCRIPTION
These are flagged by gcc13
avs_gic.c:241:1: error: conflicting types for 'val_gic_get_info' due to enum/integer mismatch; have 'uint32_t(uint32_t)' {aka 'unsigned int(unsigned int)'} [-Werror=enum-int-mismatch]
|   241 | val_gic_get_info(uint32_t type)
|       | ^~~~~~~~~~~~~~~~

Signed-off-by: Khem Raj <raj.khem@gmail.com>