### PR TITLE
Fix for Issue #293: Update to memory_map test test_m001.c

### DIFF
--- a/platform/pal_uefi/src/pal_peripherals.c
+++ b/platform/pal_uefi/src/pal_peripherals.c
@@ -50,6 +50,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
 {
   UINT32   DeviceBdf = 0;
   UINT32   StartBdf  = 0;
+  UINT32   bar_index = 0;
   PERIPHERAL_INFO_BLOCK *per_info = NULL;
   EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE *spcr = NULL;
 
@@ -65,6 +66,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
   peripheralInfoTable->header.num_sata = 0;
   peripheralInfoTable->header.num_uart = 0;
   peripheralInfoTable->header.num_all = 0;
+  per_info->base0 = 0;
 
   /* check for any USB Controllers */
   do {
@@ -72,7 +74,12 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
        DeviceBdf = palPcieGetBdf(USB_CLASSCODE, StartBdf);
        if (DeviceBdf != 0) {
           per_info->type  = PERIPHERAL_TYPE_USB;
-          per_info->base0 = palPcieGetBase(DeviceBdf, BAR0);
+          for (bar_index = 0; bar_index < TYPE0_MAX_BARS; bar_index++)
+          {
+              per_info->base0 = palPcieGetBase(DeviceBdf, bar_index);
+              if (per_info->base0 != 0)
+                  break;
+          }
           per_info->bdf   = DeviceBdf;
           sbsa_print(AVS_PRINT_INFO, L" Found a USB controller %4x \n", per_info->base0);
           peripheralInfoTable->header.num_usb++;
@@ -90,7 +97,12 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
        DeviceBdf = palPcieGetBdf(SATA_CLASSCODE, StartBdf);
        if (DeviceBdf != 0) {
           per_info->type  = PERIPHERAL_TYPE_SATA;
-          per_info->base0 = palPcieGetBase(DeviceBdf, BAR0);
+          for (bar_index = 0; bar_index < TYPE0_MAX_BARS; bar_index++)
+          {
+              per_info->base0 = palPcieGetBase(DeviceBdf, bar_index);
+              if (per_info->base0 != 0)
+                  break;
+          }
           per_info->bdf   = DeviceBdf;
           sbsa_print(AVS_PRINT_INFO, L" Found a SATA controller %4x \n", per_info->base0);
           peripheralInfoTable->header.num_sata++;

--- a/test_pool/memory_map/operating_system/test_m001.c
+++ b/test_pool/memory_map/operating_system/test_m001.c
@@ -31,6 +31,7 @@ static void payload(void)
     uint32_t peri_index, peri_index1;
     uint64_t peri_count, addr_diff;
     uint64_t peri_addr1, peri_addr2;
+    uint32_t fail_cnt = 0;
 
     pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
     peri_count = val_peripheral_get_info(NUM_ALL, 0);
@@ -41,17 +42,27 @@ static void payload(void)
 
             peri_addr1 = val_peripheral_get_info(ANY_BASE0, peri_index);
             peri_addr2 = val_peripheral_get_info(ANY_BASE0, peri_index1);
+            val_print(AVS_PRINT_INFO, "\n   addr of Peripheral 1 is  %llx", peri_addr1);
+            val_print(AVS_PRINT_INFO, "\n   addr of Peripheral 2 is  %llx", peri_addr2);
+
+           if ((peri_addr1 == 0) || (peri_addr2 == 0))
+                continue;
 
             addr_diff = (peri_addr1 > peri_addr2) ?
                          peri_addr1 - peri_addr2 : peri_addr2 - peri_addr1;
 
             if (addr_diff < MEM_SIZE_64KB) {
                 val_print(AVS_PRINT_ERR,
-                         "\n      Peripheral base addresses isn't atleast 64Kb apart", 0);
-                val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
-                return;
+                         "\n  Peripheral base addresses isn't atleast 64Kb apart %llx", addr_diff);
+                fail_cnt++;
             }
         }
+    }
+
+    if (fail_cnt)
+    {
+        val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
+        return;
     }
 
     val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));

--- a/val/src/avs_peripherals.c
+++ b/val/src/avs_peripherals.c
@@ -78,8 +78,10 @@ val_peripheral_get_entry_index(uint32_t type, uint32_t instance)
 
   while (g_peripheral_info_table->info[i].type != 0xFF) {
       if (type == PERIPHERAL_TYPE_NONE || g_peripheral_info_table->info[i].type == type) {
-          if (instance == 0)
+          if (instance == 0) {
+             val_print(AVS_PRINT_INFO, "\n Peripheral %x", g_peripheral_info_table->info[i].type);
              return i;
+          }
           else
              instance--;
 


### PR DESCRIPTION
Bug Fix for #293 

- Updated the PAL Peripheral table to check for all BAR registers
- Added Debug prints for test m001
- Check for all Peripheral devices even if it fails on one device in test m001.c