### PR TITLE
Replace ETR CID with HID

### DIFF
--- a/test_pool/smmu/operating_system/test_i016.c
+++ b/test_pool/smmu/operating_system/test_i016.c
@@ -44,8 +44,8 @@ payload(void)
   index = val_pe_get_index_mpid(val_pe_get_mpid());
   memset(etr_path, 0, sizeof(etr_path));
 
-  /*Check for ETR devices using ETR using unique HID (ARMHC501)*/
-  status = val_get_device_path("ARMHC501", etr_path);
+  /*Check for ETR devices using ETR using unique HID (ARMHC97C)*/
+  status = val_get_device_path("ARMHC97C", etr_path);
   if (status != 0) {
     val_print(AVS_PRINT_ERR, "\n       Unable to get ETR device info from ACPI namespace", 0);
     val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 1));


### PR DESCRIPTION
     - CID will only be a subset of ETR devices but HID will
       cover every ETR and acpi_get_devices only capable to match
       the HID not CID.
     - HID for ETR devices included in ARMHC97C. Refer
       https://developer.arm.com/documentation/den0067/a/