### PR TITLE
Bug fixes in PMCG parsing code and ETR device HID

### DIFF
--- a/platform/pal_uefi/include/pal_uefi.h
+++ b/platform/pal_uefi/include/pal_uefi.h
@@ -274,7 +274,8 @@ typedef struct {
 typedef struct {
   UINT64 base;
   UINT32 overflow_gsiv;
-  UINT32 node_ref;
+  UINT32 node_ref;       /* offest to the IORT node in IORT ACPI table*/
+  UINT64 smmu_base;      /* SMMU base to which component is attached, else NULL */
 }IOVIRT_PMCG_INFO_BLOCK;
 
 typedef enum {

--- a/test_pool/smmu/operating_system/test_i016.c
+++ b/test_pool/smmu/operating_system/test_i016.c
@@ -45,8 +45,8 @@ payload(void)
   index = val_pe_get_index_mpid(val_pe_get_mpid());
   val_memory_set(etr_path, sizeof(etr_path), 0);
 
-  /*Check for ETR devices using ETR using unique HID (ARMHC501)*/
-  status = val_get_device_path("ARMHC501", etr_path);
+  /*Check for ETR devices using ETR using unique HID (ARMHC97C)*/
+  status = val_get_device_path("ARMHC97C", etr_path);
   if (status != 0) {
     val_print(AVS_PRINT_ERR, "\n       Unable to get ETR device info from ACPI namespace", 0);
     val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 1));

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -381,7 +381,8 @@ typedef struct {
 typedef struct {
   uint64_t base;
   uint32_t overflow_gsiv;
-  uint32_t node_ref;
+  uint32_t node_ref;       /* offest to the IORT node in IORT ACPI table*/
+  uint64_t smmu_base;      /* SMMU base to which component is attached, else NULL */
 } IOVIRT_PMCG_INFO_BLOCK;
 
 typedef enum {

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -277,7 +277,8 @@ typedef enum {
   PMCG_NUM_CTRL = 1,
   PMCG_CTRL_BASE,
   PMCG_IOVIRT_BLOCK,
-  PMCG_NODE_REF
+  PMCG_NODE_REF,
+  PMCG_NODE_SMMU_BASE
 } PMCG_INFO_e;
 
 void     val_iovirt_create_info_table(uint64_t *iovirt_info_table);

--- a/val/src/avs_iovirt.c
+++ b/val/src/avs_iovirt.c
@@ -246,6 +246,8 @@ val_iovirt_get_pmcg_info(PMCG_INFO_e type, uint32_t index)
                       return (uint64_t)block;
                   case PMCG_NODE_REF:
                       return block->data.pmcg.node_ref;
+                  case PMCG_NODE_SMMU_BASE:
+                      return block->data.pmcg.smmu_base;
                   default:
                       val_print(AVS_PRINT_ERR, "This PMCG info option not supported %d \n", type);
                       return 0;


### PR DESCRIPTION
Replace ETR CID with HID
     - CID will only be a subset of ETR devices but HID will
       cover every ETR and acpi_get_devices only capable to match
       the HID not CID.
     - HID for ETR devices included in ARMHC97C. Refer
       https://developer.arm.com/documentation/den0067/a/

SBSA 714 test and PMCG parsing bug fix
     - The PMCG info node reference is offset to the RC,SMMU etc node from start of
       ACPI IORT table. instead offset of same PMCG node was getting stored.
     - For test 714 we need to check whether PMCG is associated with a SMMU
       to do that we can see if node_reference + start address of IORT ACPI
       table points to a SMMU during parsing and store smmu_base if found
       for testing purpose.

Signed-off-by: Amrathesh <amrathesh@arm.com>