### PR TITLE
Issue #299 : S_L3SM_01 is not tested on level 3

### DIFF
--- a/uefi_app/SbsaAvsMain.c
+++ b/uefi_app/SbsaAvsMain.c
@@ -740,10 +740,8 @@ ShellAppMainsbsa (
   val_print(AVS_PRINT_TEST, "\n      ***  Starting GIC tests ***  \n", 0);
   Status |= val_gic_execute_tests(g_sbsa_level, val_pe_get_num());
 
-  if (g_sbsa_level > 3) {
-    val_print(AVS_PRINT_TEST, "\n      *** Starting SMMU  tests ***  \n", 0);
-    Status |= val_smmu_execute_tests(g_sbsa_level, val_pe_get_num());
-  }
+  val_print(AVS_PRINT_TEST, "\n      *** Starting SMMU  tests ***  \n", 0);
+  Status |= val_smmu_execute_tests(g_sbsa_level, val_pe_get_num());
 
   if (g_sbsa_level > 4)
   {


### PR DESCRIPTION
Issue #299 : S_L3SM_01 is not tested on level 3
 - Test was being skipped because there was a level check in the code, in the file "uefi_app/SbsaAvsMain.c". To resolve this issue, the check was removed and now it is based on the conditions in "avs_smmu.c" instead.