### PR TITLE
Only add usable PE in pe_info_table

### DIFF
--- a/platform/pal_uefi/src/pal_pe.c
+++ b/platform/pal_uefi/src/pal_pe.c
@@ -38,6 +38,9 @@ extern INT32 gPsciConduit;
 #define ADD_PTR(t, p, l) ((t*)((UINT8*)p + l))
 #define GET_ADDR_DIFF(a, b) ((UINT8*)a - (UINT8*)b)
 
+#define ENABLED_BIT(flags)  (flags & 0x1)
+#define ONLINE_CAP_BIT(flags)  ((flags > 3) & 0x1)
+
 UINT64
 pal_get_madt_ptr();
 
@@ -189,7 +192,7 @@ pal_pe_create_info_table(PE_INFO_TABLE *PeTable)
   UINT32                        TableLength = 0, i;
   UINT32                        Length = 0;
   UINT64                        MpidrAff0Max = 0, MpidrAff1Max = 0, MpidrAff2Max = 0, MpidrAff3Max = 0;
-
+  UINT32                        Flags;
 
   if (PeTable == NULL) {
     sbsa_print(AVS_PRINT_ERR, L" Input PE Table Pointer is NULL. Cannot create PE INFO \n");
@@ -216,22 +219,34 @@ pal_pe_create_info_table(PE_INFO_TABLE *PeTable)
 
     if (Entry->Type == EFI_ACPI_6_1_GIC) {
       //Fill in the cpu num and the mpidr in pe info table
-      Ptr->mpidr    = Entry->MPIDR;
-      Ptr->pe_num   = PeTable->header.num_of_pe;
-      Ptr->pmu_gsiv = Entry->PerformanceInterruptGsiv;
-      Ptr->gmain_gsiv = Entry->VGICMaintenanceInterrupt;
-      Ptr->acpi_proc_uid = Entry->AcpiProcessorUid;
-      for (i = 0; i < MAX_L1_CACHE_RES; i++)
-        Ptr->level_1_res[i] = DEFAULT_CACHE_IDX; //initialize cache index fields with all 1's
-      sbsa_print(AVS_PRINT_DEBUG, L" MPIDR %llx PE num %x \n", Ptr->mpidr, Ptr->pe_num);
-      pal_pe_data_cache_ops_by_va((UINT64)Ptr, CLEAN_AND_INVALIDATE);
-      Ptr++;
-      PeTable->header.num_of_pe++;
+      Flags           = Entry->Flags;
+      sbsa_print(AVS_PRINT_INFO, L"  Flags %x \n", Flags);
+      sbsa_print(AVS_PRINT_DEBUG, L"  PE Enabled %d, Online Capable %d\n", ENABLED_BIT(Flags), ONLINE_CAP_BIT(Flags));
 
-      MpidrAff0Max = UPDATE_AFF_MAX(MpidrAff0Max, Entry->MPIDR, 0x000000ff);
-      MpidrAff1Max = UPDATE_AFF_MAX(MpidrAff1Max, Entry->MPIDR, 0x0000ff00);
-      MpidrAff2Max = UPDATE_AFF_MAX(MpidrAff2Max, Entry->MPIDR, 0x00ff0000);
-      MpidrAff3Max = UPDATE_AFF_MAX(MpidrAff3Max, Entry->MPIDR, 0xff00000000);
+      /* As per MADT (GICC CPU Interface Flags) Processor is usable when
+           Enabled bit is set
+           Enabled bit is clear and Online Capable bit is set
+           if both bits are clear, PE is not usable
+      */
+      if ((ENABLED_BIT(Flags) == 1) || (ONLINE_CAP_BIT(Flags) == 1))
+      {
+          Ptr->mpidr      = Entry->MPIDR;
+          Ptr->pe_num     = PeTable->header.num_of_pe;
+          Ptr->pmu_gsiv   = Entry->PerformanceInterruptGsiv;
+          Ptr->gmain_gsiv = Entry->VGICMaintenanceInterrupt;
+          Ptr->acpi_proc_uid = Entry->AcpiProcessorUid;
+          for (i = 0; i < MAX_L1_CACHE_RES; i++)
+              Ptr->level_1_res[i] = DEFAULT_CACHE_IDX; //initialize cache index fields with all 1's
+          sbsa_print(AVS_PRINT_DEBUG, L" MPIDR %llx PE num %x \n", Ptr->mpidr, Ptr->pe_num);
+          pal_pe_data_cache_ops_by_va((UINT64)Ptr, CLEAN_AND_INVALIDATE);
+          Ptr++;
+          PeTable->header.num_of_pe++;
+
+          MpidrAff0Max = UPDATE_AFF_MAX(MpidrAff0Max, Entry->MPIDR, 0x000000ff);
+          MpidrAff1Max = UPDATE_AFF_MAX(MpidrAff1Max, Entry->MPIDR, 0x0000ff00);
+          MpidrAff2Max = UPDATE_AFF_MAX(MpidrAff2Max, Entry->MPIDR, 0x00ff0000);
+          MpidrAff3Max = UPDATE_AFF_MAX(MpidrAff3Max, Entry->MPIDR, 0xff00000000);
+      }
     }
 
     Length += Entry->Length;


### PR DESCRIPTION
Fix for SBSA-ACS similiar to https://github.com/ARM-software/bsa-acs/issues/132 
 
* Check MADT (GICC CPU interface flags) enabled and online capable bit
 * if either of those bits are set, then only add pe
 * if both bits are clear, pe is unusable