### PR TITLE
use of verb "must" in place "should" to express requirements

### DIFF
--- a/test_pool/exerciser/operating_system/test_e009.c
+++ b/test_pool/exerciser/operating_system/test_e009.c
@@ -223,7 +223,7 @@ inject_error(uint32_t e_bdf, uint32_t instance, uint32_t aer_offset)
         status = val_exerciser_set_param(ERROR_INJECT_TYPE, err_code, 0, instance);
         value = val_exerciser_ops(INJECT_ERROR, err_code, instance);
 
-        /*Interrupt should be generated on error detection if errors are not masked*/
+        /*Interrupt must be generated on error detection if errors are not masked*/
         if (mask_value == 0) {
             timeout = TIMEOUT_LARGE;
             while ((--timeout > 0) && irq_pending)

--- a/test_pool/mpam/operating_system/test_mpam003.c
+++ b/test_pool/mpam/operating_system/test_mpam003.c
@@ -166,8 +166,8 @@ static void payload(void)
 
                 val_print(AVS_PRINT_DEBUG, "\n       byte_count = 0x%llx bytes", byte_count);
 
-                /* the monitor should count both read and write bandwidth,
-                   hence count should be twice of the buffer size */
+                /* the monitor must count both read and write bandwidth,
+                   hence count must be twice of the buffer size */
                 if ((byte_count != 2 * BUFFER_SIZE)) {
                     val_print(AVS_PRINT_ERR, "\n       Monitor count incorrect for MSC %d",
                                                                                        msc_index);

--- a/test_pool/pcie/operating_system/test_p003.c
+++ b/test_pool/pcie/operating_system/test_p003.c
@@ -142,7 +142,7 @@ payload(void)
                else{
                   val_pcie_read_cfg(bdf, PCIE_ECAP_START, &data);
 
-                  /* Returned data should be FF's, otherwise the test should fail */
+                  /* Returned data must be FF's, otherwise the test must fail */
                   if (data != PCIE_UNKNOWN_RESPONSE) {
                      val_print(AVS_PRINT_ERR, "\n       Incorrect data for Bdf 0x%x    ", bdf);
                      val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM,
@@ -152,7 +152,7 @@ payload(void)
 
                   val_pcie_read_cfg(bdf, PCIE_ECAP_END, &data);
 
-                  /* Returned data should be FF's, otherwise the test should fail */
+                  /* Returned data must be FF's, otherwise the test must fail */
                   if (data != PCIE_UNKNOWN_RESPONSE) {
                      val_print(AVS_PRINT_ERR, "\n       Incorrect data for Bdf 0x%x    ", bdf);
                      val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM,

--- a/test_pool/pcie/operating_system/test_p007.c
+++ b/test_pool/pcie/operating_system/test_p007.c
@@ -59,7 +59,7 @@ payload(void)
       val_print(AVS_PRINT_DEBUG, "       data %x", data);
 
       if ((data & PER_FLAG_MSI_ENABLED) == 0) {
-          val_print(AVS_PRINT_ERR, "\n       MSI should be enabled for a PCIe device ", 0);
+          val_print(AVS_PRINT_ERR, "\n       MSI must be enabled for a PCIe device ", 0);
           val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
           status = 1;
           break;

--- a/test_pool/pcie/operating_system/test_p014.c
+++ b/test_pool/pcie/operating_system/test_p014.c
@@ -68,7 +68,7 @@ payload(void)
           {
             val_print(AVS_PRINT_ERR,
                       "\n       DMA controller %d: IO Coherent DMA mem", target_dev_index);
-            val_print(AVS_PRINT_ERR, " should be inner/outer writeback, inner shareable", 0);
+            val_print(AVS_PRINT_ERR, " must be inner/outer writeback, inner shareable", 0);
             val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
             status = 1;
           }
@@ -90,7 +90,7 @@ payload(void)
                 MEM_DEVICE(attr)))
           {
               val_print(AVS_PRINT_ERR, "\n       DMA controler %d: DMA memory", target_dev_index);
-              val_print(AVS_PRINT_ERR, " should be inner/outer writeback inner shareable, ", 0);
+              val_print(AVS_PRINT_ERR, " must be inner/outer writeback inner shareable, ", 0);
               val_print(AVS_PRINT_ERR, "inner/outer non-cacheable, or device type\n", 0);
               val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 02));
               status = 1;

--- a/test_pool/pcie/operating_system/test_p034.c
+++ b/test_pool/pcie/operating_system/test_p034.c
@@ -83,7 +83,7 @@ payload(void)
               /* If test runs for atleast an endpoint */
               test_skip = 0;
 
-              /* Check type[1:2] should be 32-bit or 64-bit */
+              /* Check type[1:2] must be 32-bit or 64-bit */
               addr_type = (reg_value >> BAR_MDT_SHIFT) & BAR_MDT_MASK;
               if ((addr_type != BITS_32) && (addr_type != BITS_64))
               {
@@ -97,7 +97,7 @@ payload(void)
               if (addr_type == BITS_64)
                   bar_index++;
 
-              /* Check BAR should be MMIO */
+              /* Check BAR must be MMIO */
               if (reg_value & BAR_MIT_MASK)
               {
                  val_print(AVS_PRINT_ERR, "\n       BDF 0x%x Not MMIO", 0);

--- a/test_pool/pcie/operating_system/test_p035.c
+++ b/test_pool/pcie/operating_system/test_p035.c
@@ -149,7 +149,7 @@ payload(void)
           /* If test runs for atleast an endpoint */
           test_skip = 0;
 
-          /* Vendor Id should not be 0xFF after max FLR period */
+          /* Vendor Id must not be 0xFF after max FLR period */
           val_pcie_read_cfg(bdf, 0, &reg_value);
           if ((reg_value & TYPE01_VIDR_MASK) == TYPE01_VIDR_MASK)
           {

--- a/test_pool/pcie/operating_system/test_p039.c
+++ b/test_pool/pcie/operating_system/test_p039.c
@@ -83,7 +83,7 @@ payload(void)
           /* If test runs for atleast an endpoint */
           test_skip = 0;
 
-          /* if iEP is atomicop completer capable, RP should be routing or requester capable */
+          /* if iEP is atomicop completer capable, RP must be routing or requester capable */
           if ((atomicop_32_cap || atomicop_64_cap || atomicop_128_cap) &&
              ((rp_routing_cap == 0) && (rp_requester_cap == 0)))
           {
@@ -93,7 +93,7 @@ payload(void)
 
           ep_requester_cap = val_pcie_get_atomicop_requester_capable(bdf);
 
-          /* if iEP is atomicop requester capable, RP should be routing or completer capable */
+          /* if iEP is atomicop requester capable, RP must be routing or completer capable */
           if ((ep_requester_cap) &&
              ((rp_routing_cap == 0) && (rp_requester_cap == 0)))
           {

--- a/test_pool/pcie/operating_system/test_p048.c
+++ b/test_pool/pcie/operating_system/test_p048.c
@@ -182,10 +182,10 @@ payload(void)
         test_skip = 0;
 
         /* Check_1: Accessing address in range of P memory
-         * should not cause any exception or data abort
+         * must not cause any exception or data abort
          *
          * Write known value to an address which is in range
-         * Base + offset should always be in the range.
+         * Base + offset must always be in the range.
          * Read the same
          */
 
@@ -213,7 +213,7 @@ payload(void)
             continue;
         }
 
-        /**Check_2: Accessing out of NP memory limit range should return 0xFFFFFFFF
+        /**Check_2: Accessing out of NP memory limit range must return 0xFFFFFFFF
          *
          * If the limit exceeds 1MB then modify the range to be 1MB
          * and access out of the limit set

--- a/test_pool/pcie/operating_system/test_p049.c
+++ b/test_pool/pcie/operating_system/test_p049.c
@@ -182,10 +182,10 @@ payload(void)
         test_skip = 0;
 
         /* Check_1: Accessing address in range of P memory
-         * should not cause any exception or data abort
+         * mjust not cause any exception or data abort
          *
          * Write known value to an address which is in range
-         * Base + offset should always be in the range.
+         * Base + offset must always be in the range.
          * Read the same
         */
         mem_offset = val_pcie_mem_get_offset(MEM_OFFSET_MEDIUM);
@@ -222,7 +222,7 @@ payload(void)
             continue;
         }
 
-        /**Check_2: Accessing out of P memory limit range should return 0xFFFFFFFF
+        /**Check_2: Accessing out of P memory limit range must return 0xFFFFFFFF
          *
          * If the limit exceeds 1MB then modify the range to be 1MB
          * and access out of the limit set

--- a/test_pool/pcie/operating_system/test_p052.c
+++ b/test_pool/pcie/operating_system/test_p052.c
@@ -68,7 +68,7 @@ payload(void)
 
          test_skip = 0;
 
-         /* If ATC Present, Check ATS Capability should be present. */
+         /* If ATC Present,  ATS Capability must be present. */
          if (val_pcie_find_capability(bdf, PCIE_ECAP, ECID_ATS, &cap_base) != PCIE_SUCCESS)
          {
              val_print(AVS_PRINT_ERR, "\n       ATS Capability Not Present, Bdf : 0x%x", bdf);

--- a/test_pool/pcie/operating_system/test_p056.c
+++ b/test_pool/pcie/operating_system/test_p056.c
@@ -133,7 +133,7 @@ payload(void)
               curr_bdf_failed++;
           }
 
-          /* If iEP_RP supports ACS then it should have AER Capability */
+          /* If iEP_RP supports ACS then it must have AER Capability */
           if (val_pcie_find_capability(iep_rp_bdf, PCIE_ECAP, ECID_AER, &cap_base) != PCIE_SUCCESS)
           {
               val_print(AVS_PRINT_DEBUG, "\n       AER Capability not supported, Bdf : 0x%x", iep_rp_bdf);

--- a/test_pool/pcie/operating_system/test_p060.c
+++ b/test_pool/pcie/operating_system/test_p060.c
@@ -57,7 +57,7 @@ payload(void)
 
           /* Extract Hdr Type */
           hdr_type = val_pcie_function_header_type(bdf);
-          /* Type should be 0 for RCiEP*/
+          /* Type must be 0 for RCiEP*/
           if (hdr_type != TYPE0_HEADER) {
               val_print(AVS_PRINT_ERR, "\n       Invalid HDR TYPE 0x%x", hdr_type);
               fail_cnt++;

--- a/test_pool/pe/operating_system/test_c001.c
+++ b/test_pool/pe/operating_system/test_c001.c
@@ -33,10 +33,10 @@ payload(void)
 
   /* PEs must support 4k, 64k granule for Stage 1 & Stage 2.
    * 1. Implementation before v8.5
-   *    ID_AA64MMFR0_EL1 [43:36] should be RES0.
+   *    ID_AA64MMFR0_EL1 [43:36] must be RES0.
    *    Check For TGran4[31:28] == 0 & TGran64[27:24] == 0.
    * 2. Implementation After v8.5
-   *    ID_AA64MMFR0_EL1 [43:36] should not be 0.
+   *    ID_AA64MMFR0_EL1 [43:36] must not be 0.
    *    Check For TGran4[31:28] == 0 or 0x1 & TGran64[27:24] == 0.
    *    Check For TGran4_2[43:40] == 0x2 or 0x3 & TGran64_2[39:36] == 0x2.
    */

--- a/test_pool/pmu/operating_system/test_pmu004.c
+++ b/test_pool/pmu/operating_system/test_pmu004.c
@@ -125,7 +125,7 @@ static void payload(void)
         /* Check if the PMU supports atleast 3 counters */
         data = val_pmu_get_monitor_count(node_index);
         if (data < 3) {
-            val_print(AVS_PRINT_ERR, "\n       PMU should support atleast 3 counter", 0);
+            val_print(AVS_PRINT_ERR, "\n       PMU node must support atleast 3 counter", 0);
             fail_cnt++;
             continue;
         }

--- a/test_pool/pmu/operating_system/test_pmu007.c
+++ b/test_pool/pmu/operating_system/test_pmu007.c
@@ -117,7 +117,7 @@ static void payload(void)
             /* Check if the PMU supports atleast 6 counter */
             data = val_pmu_get_monitor_count(node_index);
             if (data < NUM_TOTAL_PMU_MON) {
-                val_print(AVS_PRINT_ERR, "\n       PMU should support atleast 6 counters", 0);
+                val_print(AVS_PRINT_ERR, "\n       PMU node must support atleast 6 counters", 0);
                 fail_cnt++;
                 continue;
             }

--- a/test_pool/pmu/operating_system/test_pmu008.c
+++ b/test_pool/pmu/operating_system/test_pmu008.c
@@ -153,7 +153,7 @@ static void payload(void)
     /* Check if the PMU supports atleast 3 counters */
     data = val_pmu_get_monitor_count(mc_node_index);
     if (data < 3) {
-        val_print(AVS_PRINT_ERR, "\n       PMU should support atleast 3 counter", 0);
+        val_print(AVS_PRINT_ERR, "\n       PMU node must support atleast 3 counter", 0);
         val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 5));
         return;
     }

--- a/test_pool/pmu/operating_system/test_pmu009.c
+++ b/test_pool/pmu/operating_system/test_pmu009.c
@@ -75,7 +75,7 @@ static void payload(void)
     /* Get number of monitor to the interface pmu node */
     num_mon = val_pmu_get_monitor_count(pmu_node_index);
     if (num_mon == 0) {
-        val_print(AVS_PRINT_ERR, "\n       PMU should support atleast 1 counter", 0);
+        val_print(AVS_PRINT_ERR, "\n       PMU node must support atleast 1 counter", 0);
         val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 5));
         return;
     }

--- a/test_pool/ras/operating_system/test_ras006.c
+++ b/test_pool/ras/operating_system/test_ras006.c
@@ -212,8 +212,8 @@ payload()
               if ((err_rec_impl_bitmap >> err_rec_index) & 0x1)
                   continue;
               /* since we have injected error in a memory location in current MC proximity domain
-                 space, one of the error record should have recorded address syndrome and
-                 ERR<n>STATUS AV, bit [31] & V, bit [30] should be valid for that error record */
+                 space, one of the error record must have recorded address syndrome and
+                 ERR<n>STATUS AV, bit [31] & V, bit [30] must be valid for that error record */
 
               /* if ERR<n>STATUS AV, bit [31] & V, bit [30] is invalid, continue with next
                  error record */

--- a/test_pool/smmu/operating_system/test_i001.c
+++ b/test_pool/smmu/operating_system/test_i001.c
@@ -43,7 +43,7 @@ payload(void)
   while (num_smmu--) {
       if (val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu) == 2) {
           if (g_sbsa_level > 3) {
-              val_print(AVS_PRINT_ERR, "\n       SMMUv3 should be supported Level %x",
+              val_print(AVS_PRINT_ERR, "\n       SMMUv3 must be supported by level %x systems",
                                                                                   g_sbsa_level);
               val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
               return;
@@ -60,8 +60,10 @@ payload(void)
               }
           } else {
               if (data < 0x2) { /* Smmuv3.2 or higher not implemented */
-                  val_print(AVS_PRINT_ERR, "\n       Level %x should support Smmuv3.2 or higher  ",
-                                           g_sbsa_level);
+                  val_print(AVS_PRINT_ERR,
+                            "\n       Level %x systems must be compliant with the \
+                             Arm SMMUv3.2 or higher  ",
+                            g_sbsa_level);
                   val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 02));
                   return;
               }

--- a/test_pool/smmu/operating_system/test_i002.c
+++ b/test_pool/smmu/operating_system/test_i002.c
@@ -48,7 +48,7 @@ payload(void)
 
             if (g_sbsa_level > 3) {
                 val_print(AVS_PRINT_ERR,
-                          "\n       SMMUv3 should be supported at level %x", g_sbsa_level);
+                          "\n       SMMUv3 must be supported by level %x systems", g_sbsa_level);
                 val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
                 return;
             }

--- a/test_pool/smmu/operating_system/test_i014.c
+++ b/test_pool/smmu/operating_system/test_i014.c
@@ -68,7 +68,7 @@ payload()
       smmu_base = val_smmu_get_info(SMMU_CTRL_BASE, num_smmu);
 
       num_pmcg_found = 0;
-      /* Each SMMUv3 should contain atleast 1 PMCG*/
+      /* Each SMMUv3 must contain atleast 1 PMCG*/
       for (i = 0; i < num_pmcg; i++) {
           pmcg_smmu_base = val_iovirt_get_pmcg_info(PMCG_NODE_SMMU_BASE, i);
           if (smmu_base ==  pmcg_smmu_base) {
@@ -77,7 +77,7 @@ payload()
               num_pmcg_count = VAL_EXTRACT_BITS(val_mmio_read(pmcg_base + SMMU_PMCG_CFGR), 0, 5);
               /*No of counters in a group is SMMU_PMCG_CFGR.NCTR + 1*/
               num_pmcg_count++;
-              /* Each PMCG should have atleast 4 counters*/
+              /* Each PMCG must have atleast 4 counters*/
               if (num_pmcg_count < 4) {
                   val_print(AVS_PRINT_ERR,
                             "\n       PMCG has less then 4 counters for SMMU index : %d",

--- a/test_pool/smmu/operating_system/test_i016.c
+++ b/test_pool/smmu/operating_system/test_i016.c
@@ -69,7 +69,7 @@ payload(void)
   num_named_comp = val_iovirt_get_named_comp_info(NUM_NAMED_COMP, 0);
   val_print(AVS_PRINT_DEBUG, "\n       NUM Named component  : %d", num_named_comp);
 
-  /*ETR device should be behind SMMU or CATU*/
+  /*ETR device must be behind SMMU or CATU*/
   for (i = 0; i < etr_count; i++) {
     for (j = 0; j < num_named_comp; j++) {
       smmu_found = 0;


### PR DESCRIPTION
- "must" carries a stronger sense of obligation or necessity than "should" hence using it for prints conveying non-compilance to mandatory rules.

Fixes #309