### PR TITLE
Synchronize level checks

### DIFF
--- a/baremetal_app/SbsaAvsMain.c
+++ b/baremetal_app/SbsaAvsMain.c
@@ -390,7 +390,7 @@ ShellAppMainsbsa(
     Status |= val_smmu_execute_tests(g_sbsa_level, val_pe_get_num());
   }
 
-  if (g_sbsa_level > 4)
+  if (g_sbsa_level > 5)
   {
     val_print(AVS_PRINT_TEST, "\n      *** Starting Watchdog tests ***  \n", 0);
     Status |= val_wd_execute_tests(g_sbsa_level, val_pe_get_num());
@@ -408,10 +408,8 @@ ShellAppMainsbsa(
    */
   configureGicIts();
 
-  if (g_sbsa_level > 2) {
-    val_print(AVS_PRINT_TEST, "\n      *** Starting PCIe Exerciser tests ***  \n", 0);
-    Status |= val_exerciser_execute_tests(g_sbsa_level);
-  }
+  val_print(AVS_PRINT_TEST, "\n      *** Starting PCIe Exerciser tests ***  \n", 0);
+  Status |= val_exerciser_execute_tests(g_sbsa_level);
 
   if (g_sbsa_level > 6) {
     val_print(AVS_PRINT_TEST, "\n      *** Starting MPAM tests ***  \n", 0);

--- a/uefi_app/SbsaAvsMain.c
+++ b/uefi_app/SbsaAvsMain.c
@@ -743,7 +743,7 @@ ShellAppMainsbsa (
   val_print(AVS_PRINT_TEST, "\n      *** Starting SMMU  tests ***  \n", 0);
   Status |= val_smmu_execute_tests(g_sbsa_level, val_pe_get_num());
 
-  if (g_sbsa_level > 4)
+  if (g_sbsa_level > 5)
   {
     val_print(AVS_PRINT_TEST, "\n      *** Starting Watchdog tests ***  \n", 0);
     Status |= val_wd_execute_tests(g_sbsa_level, val_pe_get_num());
@@ -761,10 +761,8 @@ ShellAppMainsbsa (
    */
   configureGicIts();
 
-  if (g_sbsa_level > 2) {
-    val_print(AVS_PRINT_TEST, "\n      *** Starting PCIe Exerciser tests ***  \n", 0);
-    Status |= val_exerciser_execute_tests(g_sbsa_level);
-  }
+  val_print(AVS_PRINT_TEST, "\n      *** Starting PCIe Exerciser tests ***  \n", 0);
+  Status |= val_exerciser_execute_tests(g_sbsa_level);
 
   if (g_sbsa_level > 6) {
     val_print(AVS_PRINT_TEST, "\n      *** Starting MPAM tests ***  \n", 0);

--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -286,10 +286,6 @@ val_pcie_execute_tests(uint32_t enable_pcie, uint32_t level, uint32_t num_pe)
 #if defined(TARGET_LINUX) || defined(TARGET_EMULATION)
   status = p009_entry(num_pe);  /* This covers GIC rule */
 #endif
-  if (level < 6) {
-      val_print(AVS_PRINT_TEST, " RCiEP and iEP tests are for sbsa level 6+ \n", 0);
-      return AVS_STATUS_SKIP;
-  }
 
   status = p001_entry(num_pe);
 

--- a/val/src/avs_wd.c
+++ b/val/src/avs_wd.c
@@ -54,8 +54,7 @@ val_wd_execute_tests(uint32_t level, uint32_t num_pe)
 
   g_curr_module = 1 << WD_MODULE;
 
-  if (level > 5)
-    status |= w001_entry(num_pe);
+  status |= w001_entry(num_pe);
 
   val_print_test_end(status, "Watchdog");
 


### PR DESCRIPTION
Fix for #307 
 
- Changed condition to execute watchdog tests for level greater than 5
 - Removed conditions checking for level greater than 2
 - Removed unreachable code form val/src/avs_pcie.c