### PR TITLE
Test 301 log formatting changes

### DIFF
--- a/test_pool/smmu/operating_system/test_i001.c
+++ b/test_pool/smmu/operating_system/test_i001.c
@@ -61,8 +61,8 @@ payload(void)
           } else {
               if (data < 0x2) { /* Smmuv3.2 or higher not implemented */
                   val_print(AVS_PRINT_ERR,
-                            "\n       Level %x systems must be compliant with the \
-                             Arm SMMUv3.2 or higher  ",
+                            "\n       Level %x systems must be compliant with the "
+                            "Arm SMMUv3.2 or higher  ",
                             g_sbsa_level);
                   val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 02));
                   return;

--- a/val/src/avs_smmu.c
+++ b/val/src/avs_smmu.c
@@ -84,8 +84,8 @@ val_smmu_execute_tests(uint32_t level, uint32_t num_pe)
 #ifndef TARGET_LINUX
   status |= i001_entry(num_pe);
   if (status != AVS_STATUS_PASS) {
-      val_print(AVS_PRINT_ERR, "\n      SMMU Version Not Compliant, \
-                         Skipping Remaining SMMU Tests\n", 0);
+      val_print(AVS_PRINT_ERR, "\n      SMMU Version Not Compliant, "
+                               "Skipping Remaining SMMU Tests\n", 0);
       return AVS_STATUS_SKIP;
   }
 


### PR DESCRIPTION
- use of / for long strings used to take up extra whitespaces from second line indent. fixed it.

Fixes: #316