### PR TITLE
Increase IORT Table Size

### DIFF
--- a/uefi_app/SbsaAvs.h
+++ b/uefi_app/SbsaAvs.h
@@ -29,15 +29,16 @@
   #define SBSA_MAX_LEVEL_SUPPORTED 7
   #define G_PRINT_LEVEL AVS_PRINT_TEST
 
-  #define PE_INFO_TBL_SZ         8192 /*Supports maximum 400 PEs*/
+  #define PE_INFO_TBL_SZ         8192   /*Supports maximum 400 PEs*/
   #define GIC_INFO_TBL_SZ        239616 /* Supports maximum 832 gic info */
                                         /* (GICH, CPUIF, RD, ITS, MSI, D) */
-  #define TIMER_INFO_TBL_SZ      1024 /*Supports maximum 2 system timers*/
-  #define WD_INFO_TBL_SZ         512  /*Supports maximum 20 Watchdogs*/
-  #define MEM_INFO_TBL_SZ        32768/*Supports maximum 800 memory regions*/
-  #define IOVIRT_INFO_TBL_SZ     32768/*Supports maximum 240 nodes of a typical iort table*/
-  #define PERIPHERAL_INFO_TBL_SZ 1024 /*Supports maximum 20 PCIe EPs (USB and SATA controllers only) */
-  #define PCIE_INFO_TBL_SZ       1024  /*Supports maximum 20 RC's*/
+  #define TIMER_INFO_TBL_SZ      1024   /*Supports maximum 2 system timers*/
+  #define WD_INFO_TBL_SZ         512    /*Supports maximum 20 Watchdogs*/
+  #define MEM_INFO_TBL_SZ        32768  /*Supports maximum 800 memory regions*/
+  #define IOVIRT_INFO_TBL_SZ     163840 /*Supports maximum 600 nodes of a typical iort table*/
+  #define PERIPHERAL_INFO_TBL_SZ 1024   /*Supports maximum 20 PCIe EPs */
+                                        /*(USB and SATA controllers only) */
+  #define PCIE_INFO_TBL_SZ       1024   /*Supports maximum 20 RC's*/
 
   #define PMU_INFO_TBL_SZ        20488   /*Supports maximum 512 PMUs*/
   #define RAS_INFO_TBL_SZ        32768   /*Supports maximum 256 RAS Nodes*/


### PR DESCRIPTION
Increase IORT Table Size
- Increased the IORT Info table size to accomodate 600 typical IORT nodes. 
- Issue https://github.com/ARM-software/bsa-acs/issues/134