### PR TITLE
SMMU test 301 & 302 test reorder and updates

### DIFF
--- a/test_pool/smmu/operating_system/test_i001.c
+++ b/test_pool/smmu/operating_system/test_i001.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2020-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2020-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,57 +21,61 @@
 #include "val/include/sbsa_avs_smmu.h"
 
 #define TEST_NUM   (AVS_SMMU_TEST_NUM_BASE + 1)
-#define TEST_RULE  "S_L3SM_01 "
-#define TEST_DESC  "Check SMMU Version                "
+#define TEST_RULE  "S_L4SM_01, S_L4SM_02"
+#define TEST_DESC  "SMMU Compatibility Check          "
 
 static
 void
 payload(void)
 {
-  uint64_t data;
-  uint32_t num_smmu;
-  uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
-  num_smmu = val_smmu_get_info(SMMU_NUM_CTRL, 0);
+    uint64_t data;
+    uint32_t num_smmu;
+    uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
-  if (num_smmu == 0) {
-      val_print(AVS_PRINT_ERR, "\n       No SMMU Controllers are discovered ", 0);
-      val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
-      return;
-  }
+    num_smmu = val_smmu_get_info(SMMU_NUM_CTRL, 0);
 
-  while (num_smmu--) {
-      if (val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu) == 2) {
-          if (g_sbsa_level > 3) {
-              val_print(AVS_PRINT_ERR, "\n       SMMUv3 must be supported by level %x systems",
-                                                                                  g_sbsa_level);
-              val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
-              return;
-          }
-      } else {
-          /* Read SMMU Version */
-          data = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_AIDR, num_smmu), 0, 7);
+    if (num_smmu == 0) {
+        val_print(AVS_PRINT_ERR, "\n       No SMMU Controllers are discovered ", 0);
+        val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+        return;
+    }
 
-          if (g_sbsa_level < 5) {
-              if ((data != 0) && (data != 0x1) && (data != 0x2)) {
-                  val_print(AVS_PRINT_ERR, "\n       Invalid Architecture Revision %x  ", data);
-                  val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 02));
-                  return;
-              }
-          } else {
-              if (data < 0x2) { /* Smmuv3.2 or higher not implemented */
-                  val_print(AVS_PRINT_ERR,
-                            "\n       Level %x systems must be compliant with the "
-                            "Arm SMMUv3.2 or higher  ",
-                            g_sbsa_level);
-                  val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 02));
-                  return;
-              }
-          }
-      }
-  }
+    while (num_smmu--)
+    {
+        if (val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu) < 3) {
+            val_print(AVS_PRINT_ERR,
+                     "\n       SMMUv3, or higher must be supported by level 4 or higher systems",
+                        0);
+            val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
+            return;
+        } else {
+            val_print(AVS_PRINT_INFO, "\n       Detected SMMUv3, or higher implementation ", 0);
+            data = val_smmu_read_cfg(SMMUv3_IDR0, num_smmu);
+            /* Check Stage 2 translation support */
+            if ((data & BIT0) == 0) {
+                val_print(AVS_PRINT_ERR, "\n       Stage 2 translation not supported ", 0);
+                val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 02));
+                return;
+            }
 
-  val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
+            /* Check Stage 1 translation support */
+            if ((data & BIT1) == 0) {
+                val_print(AVS_PRINT_ERR, "\n       Stage 1 translation not supported ", 0);
+                val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 03));
+                return;
+            }
+
+            /* Check I/O coherent, (SMMU_IDR0.COHACC == 1) */
+            if ((data & BIT4) == 0) {
+                val_print(AVS_PRINT_ERR, "\n       IO-Coherent access not supported  ", 0);
+                val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 04));
+                return;
+            }
+        }
+    }
+
+    val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
 
 }
 
@@ -81,7 +85,7 @@ i001_entry(uint32_t num_pe)
 
   uint32_t status = AVS_STATUS_FAIL;
 
-  num_pe = 1;  //This test is run on single processor
+  num_pe = 1;  /* This test is run on single processor */
 
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe, g_sbsa_level, TEST_RULE);
   if (status != AVS_STATUS_SKIP)

--- a/test_pool/smmu/operating_system/test_i002.c
+++ b/test_pool/smmu/operating_system/test_i002.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2020-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,75 +21,46 @@
 #include "val/include/sbsa_avs_smmu.h"
 
 #define TEST_NUM   (AVS_SMMU_TEST_NUM_BASE + 2)
-#define TEST_RULE  "S_L4SM_01, S_L4SM_02, S_L5SM_01, S_L5SM_02"
-#define TEST_DESC  "SMMU Compatibility Check          "
+#define TEST_RULE  "S_L5SM_01, S_L5SM_02"
+#define TEST_DESC  "Check SMMUv3.2 or higher          "
 
 static
 void
 payload(void)
 {
+  uint64_t data;
+  uint32_t num_smmu;
+  uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
-    uint64_t data;
-    uint32_t num_smmu;
-    uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
+  num_smmu = val_smmu_get_info(SMMU_NUM_CTRL, 0);
 
-    num_smmu = val_smmu_get_info(SMMU_NUM_CTRL, 0);
+  if (num_smmu == 0) {
+      val_print(AVS_PRINT_ERR, "\n       No SMMU Controllers are discovered ", 0);
+      val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+      return;
+  }
 
-    if (num_smmu == 0) {
-        val_print(AVS_PRINT_ERR, "\n       No SMMU Controllers are discovered ", 0);
-        val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
-        return;
-    }
+  while (num_smmu--) {
+      if (val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu) < 3) {
+          val_print(AVS_PRINT_ERR,
+                            "\n       Level 5 or higher systems must be compliant "
+                            "with the Arm SMMUv3.2 or higher  ", 0);
+          val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
+          return;
+      } else {
+          /* Read SMMU minor version */
+          data = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_AIDR, num_smmu), 0, 7);
+          if (data < 0x2) { /* SMMUv3.2 or higher not implemented */
+                  val_print(AVS_PRINT_ERR,
+                            "\n       Level 5 or higher systems must be compliant "
+                            "with the Arm SMMUv3.2 or higher  ", 0);
+                  val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 02));
+                  return;
+          }
+      }
+  }
 
-    while (num_smmu--)
-    {
-        if (val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu) == 2) {
-            val_print(AVS_PRINT_INFO, "\n       Detected SMMUv2 ", 0);
-
-            if (g_sbsa_level > 3) {
-                val_print(AVS_PRINT_ERR,
-                          "\n       SMMUv3 must be supported by level %x systems", g_sbsa_level);
-                val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
-                return;
-            }
-
-            data = val_smmu_read_cfg(SMMUv2_IDR0, num_smmu);
-            if ((data & BIT29) == 0) {
-                val_print(AVS_PRINT_ERR, "\n       Stage 2 Translation not supported ", 0);
-                val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 02));
-                return;
-            }
-
-        } else {
-            val_print(AVS_PRINT_INFO, "\n       Detected SMMUv3 ", 0);
-            data = val_smmu_read_cfg(SMMUv3_IDR0, num_smmu);
-            /* Check Stage2 translation support */
-            if ((data & BIT0) == 0) {
-                val_print(AVS_PRINT_ERR, "\n       Stage 2 Translation not supported ", 0);
-                val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
-                return;
-            }
-
-            /* Check Stage1 translation support for level > 3 */
-            if (g_sbsa_level > 3) {
-                if ((data & BIT1) == 0) {
-                    val_print(AVS_PRINT_ERR, "\n       Stage 1 Translation not supported ", 0);
-                    val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 02));
-                    return;
-                }
-            }
-
-            // Check COHACC
-            if ((data & BIT4) == 0) {
-                val_print(AVS_PRINT_ERR, "\n       IO-Coherent access not supported  ", 0);
-                val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 03));
-                return;
-            }
-        }
-    }
-
-    val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
-
+  val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
 }
 
 uint32_t
@@ -98,7 +69,7 @@ i002_entry(uint32_t num_pe)
 
   uint32_t status = AVS_STATUS_FAIL;
 
-  num_pe = 1;  //This test is run on single processor
+  num_pe = 1;  /* This test is run on single processor */
 
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe, g_sbsa_level, TEST_RULE);
   if (status != AVS_STATUS_SKIP)

--- a/uefi_app/SbsaAvsMain.c
+++ b/uefi_app/SbsaAvsMain.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -722,8 +722,11 @@ ShellAppMainsbsa (
   val_print(AVS_PRINT_TEST, "\n      ***  Starting GIC tests ***  \n", 0);
   Status |= val_gic_execute_tests(g_sbsa_level, val_pe_get_num());
 
-  val_print(AVS_PRINT_TEST, "\n      *** Starting SMMU  tests ***  \n", 0);
-  Status |= val_smmu_execute_tests(g_sbsa_level, val_pe_get_num());
+  if (g_sbsa_level > 3)
+  {
+    val_print(AVS_PRINT_TEST, "\n      *** Starting SMMU  tests ***  \n", 0);
+    Status |= val_smmu_execute_tests(g_sbsa_level, val_pe_get_num());
+  }
 
   if (g_sbsa_level > 5)
   {

--- a/val/src/avs_smmu.c
+++ b/val/src/avs_smmu.c
@@ -82,19 +82,14 @@ val_smmu_execute_tests(uint32_t level, uint32_t num_pe)
   g_curr_module = 1 << SMMU_MODULE;
 
 #ifndef TARGET_LINUX
-  status |= i001_entry(num_pe);
-  if (status != AVS_STATUS_PASS) {
-      val_print(AVS_PRINT_ERR, "\n      SMMU Version Not Compliant, "
-                               "Skipping Remaining SMMU Tests\n", 0);
-      return AVS_STATUS_SKIP;
+  if (g_sbsa_level > 3) {
+      status = i001_entry(num_pe) ;
   }
 
-  if (g_sbsa_level > 3)
-      status |= i002_entry(num_pe);
-
   if (g_sbsa_level > 4) {
-      status = i003_entry(num_pe);
-      status = i004_entry(num_pe);
+      status |= i002_entry(num_pe);
+      status |= i003_entry(num_pe);
+      status |= i004_entry(num_pe);
   }
 
   if (g_sbsa_level > 5) {


### PR DESCRIPTION
  - test 302 covers S_L5SM_01, S_L5SM_02 directly. S_L3SM_01 is removed since it is waived off for its IMPDEF implications.
  - since test 302 runs for level >=5, redundant level checks and dead code is removed.
  - corrected RULE to test mapping.

Resolves: #308

Signed-off-by: Amrathesh <amrathesh@arm.com>