### PR TITLE
Test 303 & 304 test enchancements

### DIFF
--- a/test_pool/smmu/operating_system/test_i003.c
+++ b/test_pool/smmu/operating_system/test_i003.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,44 +36,50 @@ payload()
   uint32_t s_el2;
   uint32_t smmu_rev;
   uint32_t minor;
-  uint32_t s1ts, s1p;
+  uint32_t s1p;
 
   index = val_pe_get_index_mpid(val_pe_get_mpid());
   s_el2 = VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64PFR0_EL1), 36, 39);
 
+  if (!s_el2) {
+      val_print(AVS_PRINT_ERR, "\n       Secure EL2 not implemented", 0);
+      val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 1));
+      return;
+  }
+
   num_smmu = val_smmu_get_info(SMMU_NUM_CTRL, 0);
   if (num_smmu == 0) {
     val_print(AVS_PRINT_ERR, "\n       No SMMU Controllers are discovered                  ", 0);
-    val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 3));
+    val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 2));
     return;
   }
 
   while (num_smmu--) {
       smmu_rev = val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu);
 
-      if (s_el2) {
-            if (smmu_rev == 2) {
-                s1ts = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv2_IDR0, num_smmu), 30, 30);
-                // Stage 1 translation functionality cannot be provided by SMMU v2 revision
-                if (s1ts) {
-                    val_print(AVS_PRINT_ERR,
-                        "\n       SMMUv2 detected: revision must be v3.2 or higher  ", 0);
-                    val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 4));
-                    return;
-                }
-            }
-            else if (smmu_rev == 3) {
-                minor = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_AIDR, num_smmu), 0, 3);
-                s1p = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_IDR0, num_smmu), 1, 1);
-                // Stage 1 translation functionality cannot be provided by SMMU v3.0/3.1 revisions
-                if ((minor < 2) && s1p) {
-                    val_print(AVS_PRINT_ERR,
-                        "\n       SMMUv3.%d detected: revision must be v3.2 or higher  ", minor);
-                    val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 4));
-                    return;
-                }
-            }
+      if (smmu_rev < 3) {
+          val_print(AVS_PRINT_ERR,
+                    "\n       SMMUv2 or lower detected: revision must be v3.2 or higher  ", 0);
+          val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 1));
+          return;
+      } else {
+          minor = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_AIDR, num_smmu), 0, 3);
+          if (minor < 2) {
+              val_print(AVS_PRINT_ERR,
+                  "\n       SMMUv3.%d detected: revision must be v3.2 or higher  ", minor);
+              val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 2));
+              return;
+          }
+          s1p = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_IDR0, num_smmu), 1, 1);
+          if (!s1p) {
+              val_print(AVS_PRINT_ERR,
+                        "\n       SMMUv3.%d detected: but "
+                        "Stage 1 translation not supported  ", minor);
+              val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 3));
+              return;
+          }
       }
+
   }
 
   val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 1));

--- a/test_pool/smmu/operating_system/test_i004.c
+++ b/test_pool/smmu/operating_system/test_i004.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,44 +36,50 @@ payload()
   uint32_t s_el2;
   uint32_t smmu_rev;
   uint32_t minor;
-  uint32_t s2ts, s2p;
+  uint32_t s2p;
 
   index = val_pe_get_index_mpid(val_pe_get_mpid());
   s_el2 = VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64PFR0_EL1), 36, 39);
 
+  if (!s_el2) {
+      val_print(AVS_PRINT_ERR, "\n       Secure EL2 not implemented", 0);
+      val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 1));
+      return;
+  }
+
   num_smmu = val_smmu_get_info(SMMU_NUM_CTRL, 0);
   if (num_smmu == 0) {
       val_print(AVS_PRINT_ERR, "\n       No SMMU Controllers are discovered ", 0);
-      val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 3));
+      val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 2));
       return;
   }
 
   while (num_smmu--) {
       smmu_rev = val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu);
 
-      if (s_el2) {
-            if (smmu_rev == 2) {
-                s2ts = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv2_IDR0, num_smmu), 29, 29);
-                // Stage 2 translation functionality cannot be provided by SMMU v2 revision
-                if (s2ts) {
-                    val_print(AVS_PRINT_ERR,
-                        "\n       SMMUv2 detected: revision must be v3.2 or higher  ", 0);
-                    val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 4));
-                    return;
-                }
-            }
-            else if (smmu_rev == 3) {
-                minor = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_AIDR, num_smmu), 0, 3);
-                s2p = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_IDR0, num_smmu), 0, 0);
-                // Stage 2 translation functionality cannot be provided by SMMU v3.0/3.1 revisions
-                if ((minor < 2) && s2p) {
-                    val_print(AVS_PRINT_ERR,
-                        "\n       SMMUv3.%d detected: revision must be v3.2 or higher  ", minor);
-                    val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 4));
-                    return;
-                }
-            }
+      if (smmu_rev < 3) {
+          val_print(AVS_PRINT_ERR,
+                    "\n       SMMUv2 or lower detected: revision must be v3.2 or higher  ", 0);
+          val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 1));
+          return;
+      } else {
+          minor = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_AIDR, num_smmu), 0, 3);
+          if (minor < 2) {
+              val_print(AVS_PRINT_ERR,
+                  "\n       SMMUv3.%d detected: revision must be v3.2 or higher  ", minor);
+              val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 2));
+              return;
+          }
+          s2p = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_IDR0, num_smmu), 0, 0);
+          if (!s2p) {
+              val_print(AVS_PRINT_ERR,
+                        "\n       SMMUv3.%d detected: but Stage 2 "
+                        "translation not supported  ", minor);
+              val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 3));
+              return;
+          }
       }
+
   }
 
   val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 1));


### PR DESCRIPTION
- test 303 & 304 were falsely passing when Secure EL2 was not implemented.
- added a check for secure EL2, so that test can be skipped if it is not implemented.