### PR TITLE
Removed limitation on -t and -m options

### DIFF
--- a/baremetal_app/SbsaAvsMain.c
+++ b/baremetal_app/SbsaAvsMain.c
@@ -37,9 +37,9 @@ uint64_t  g_stack_pointer;
 uint64_t  g_exception_ret_addr;
 uint64_t  g_ret_addr;
 uint32_t  g_wakeup_timeout;
-uint32_t  g_single_test = SINGLE_TEST_SENTINEL;
-uint32_t  g_single_module = SINGLE_MODULE_SENTINEL;
 uint32_t  *g_skip_test_num;
+uint32_t  *g_execute_tests;
+uint32_t  *g_execute_modules;
 
 uint32_t
 createPeInfoTable(
@@ -291,7 +291,15 @@ ShellAppMainsbsa(
   uint32_t             Status;
   void                 *branch_label;
 
-  g_skip_test_num = &g_skip_array[0];
+  g_skip_test_num   = &g_skip_array[0];
+  if (g_num_tests) {
+      g_execute_tests   = &g_test_array[0];
+  }
+
+  if (g_num_modules) {
+      g_execute_modules = &g_module_array[0];
+  }
+
   g_print_level = PLATFORM_OVERRIDE_PRINT_LEVEL;
   if (g_print_level < AVS_PRINT_INFO)
   {

--- a/platform/pal_baremetal/FVP/RDN2/include/platform_override_fvp.h
+++ b/platform/pal_baremetal/FVP/RDN2/include/platform_override_fvp.h
@@ -22,6 +22,10 @@
 
 extern uint32_t g_skip_array[];
 extern uint32_t g_num_skip;
+extern uint32_t g_test_array[];
+extern uint32_t g_num_tests;
+extern uint32_t g_module_array[];
+extern uint32_t g_num_modules;
 
 /* Settings */
 #define PLATFORM_OVERRIDE_SBSA_LEVEL   0x7     //The permissible levels are 3,4,5,6 and 7

--- a/platform/pal_baremetal/FVP/RDN2/src/platform_cfg_fvp.c
+++ b/platform/pal_baremetal/FVP/RDN2/src/platform_cfg_fvp.c
@@ -18,8 +18,32 @@
 #include "include/pal_common_support.h"
 #include "include/platform_override_struct.h"
 
-uint32_t g_skip_array[] = {10000, 10000};
-uint32_t g_num_skip = sizeof(g_skip_array)/sizeof(g_skip_array[0]);
+/*
+    To run a specific modules:
+      - Give the module base numbers in the g_module_array.
+      - All module base numbers can be found in val/include/bsa_acs_common.h
+      - Example - if g_module_array = {0}, only PE tests will be run while skipping other modules
+
+    To run a specific tests:
+      - Give the test numbers in the g_test_array.
+      - Test numbers can be found in test_pool/<module>/test.c.
+      - For example, if g_test_array = {801}, only first test in PCIe will be run.
+        All other tests in all other modules will be skipped.
+      - If g_single_module is also given, then single test + tests under single module will be run.
+
+    To skip tests/modules:
+      - Give test numbers or module test bases as the entries of g_skip_array.
+      - This will only skip the tests or modules given in the array and runs all other tests.
+
+    Tests run = g_test_array + g_module_array - Tests under skip array
+*/
+uint32_t  g_skip_array[]   = {10000, 10000, 10000, 10000};
+uint32_t  g_test_array[]   = {};
+uint32_t  g_module_array[] = {};
+
+uint32_t  g_num_skip         = sizeof(g_skip_array)/sizeof(g_skip_array[0]);
+uint32_t  g_num_tests        = sizeof(g_test_array)/sizeof(g_test_array[0]);
+uint32_t  g_num_modules      = sizeof(g_module_array)/sizeof(g_module_array[0]);
 
 PE_INFO_TABLE platform_pe_cfg = {
 

--- a/val/include/sbsa_avs_cfg.h
+++ b/val/include/sbsa_avs_cfg.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +30,8 @@ extern uint64_t g_stack_pointer;
 extern uint64_t g_exception_ret_addr;
 extern uint64_t g_ret_addr;
 extern uint32_t g_curr_module;
-extern uint32_t g_single_test;
-extern uint32_t g_single_module;
-
+extern uint32_t *g_execute_tests;
+extern uint32_t g_num_tests;
+extern uint32_t *g_execute_modules;
+extern uint32_t g_num_modules;
 #endif

--- a/val/include/sbsa_avs_common.h
+++ b/val/include/sbsa_avs_common.h
@@ -114,6 +114,9 @@ void
 val_mmio_write64(addr_t addr, uint64_t data);
 
 uint32_t
+val_check_skip_module(uint32_t module_base);
+
+uint32_t
 val_initialize_test(uint32_t test_num, char8_t *desc, uint32_t num_pe, uint32_t level,
                     char8_t *ruleid);
 

--- a/val/src/avs_exerciser.c
+++ b/val/src/avs_exerciser.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -296,12 +296,11 @@ val_exerciser_execute_tests(uint32_t level)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_EXERCISER_TEST_NUM_BASE &&
-       (g_single_test == SINGLE_MODULE_SENTINEL ||
-         (g_single_test - AVS_EXERCISER_TEST_NUM_BASE > 100 ||
-          g_single_test - AVS_EXERCISER_TEST_NUM_BASE < 0))) {
+  /* Check if there are any tests to be executed in current module with user override options*/
+  status = val_check_skip_module(AVS_EXERCISER_TEST_NUM_BASE);
+  if (status) {
     val_print(AVS_PRINT_TEST, " USER Override - Skipping all Exerciser tests \n", 0);
-    val_print(AVS_PRINT_TEST, " (Running only a single module)\n", 0);
+    val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
     return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_gic.c
+++ b/val/src/avs_gic.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,6 +36,7 @@ val_gic_execute_tests(uint32_t level, uint32_t num_pe)
 {
 
   uint32_t status, i;
+  uint32_t module_skip;
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_GIC_TEST_NUM_BASE) {
@@ -44,12 +45,12 @@ val_gic_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_GIC_TEST_NUM_BASE &&
-       (g_single_test == SINGLE_MODULE_SENTINEL ||
-         (g_single_test - AVS_GIC_TEST_NUM_BASE > 100 ||
-          g_single_test - AVS_GIC_TEST_NUM_BASE < 0))) {
+
+  /* Check if there are any tests to be executed in current module with user override options*/
+  module_skip = val_check_skip_module(AVS_GIC_TEST_NUM_BASE);
+  if (module_skip) {
       val_print(AVS_PRINT_TEST, " USER Override - Skipping all GIC tests \n", 0);
-      val_print(AVS_PRINT_TEST, " (Running only a single module)\n", 0);
+      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
       return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_memory.c
+++ b/val/src/avs_memory.c
@@ -45,12 +45,11 @@ val_memory_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_MEM_MAP_TEST_NUM_BASE &&
-       (g_single_test == SINGLE_MODULE_SENTINEL ||
-         (g_single_test - AVS_MEM_MAP_TEST_NUM_BASE > 100 ||
-          g_single_test - AVS_MEM_MAP_TEST_NUM_BASE < 0))) {
+  /* Check if there are any tests to be executed in the current module with user override*/
+  status = val_check_skip_module(AVS_MEM_MAP_TEST_NUM_BASE);
+  if (status) {
       val_print(AVS_PRINT_TEST, " USER Override - Skipping all memory tests \n", 0);
-      val_print(AVS_PRINT_TEST, " (Running only a single module)\n", 0);
+      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
       return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_mpam.c
+++ b/val/src/avs_mpam.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,6 +36,7 @@ uint32_t
 val_mpam_execute_tests(uint32_t level, uint32_t num_pe)
 {
   uint32_t status = AVS_STATUS_FAIL, i;
+  uint32_t skip_module;
   uint32_t msc_node_cnt;
 
   for (i = 0; i < g_num_skip; i++) {
@@ -45,12 +46,11 @@ val_mpam_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_MPAM_TEST_NUM_BASE &&
-    (g_single_test == SINGLE_MODULE_SENTINEL ||
-      (g_single_test - AVS_MPAM_TEST_NUM_BASE > 100 ||
-        g_single_test - AVS_MPAM_TEST_NUM_BASE < 0))) {
+  /* Check if there are any tests to be executed in the current module with user override*/
+  skip_module = val_check_skip_module(AVS_MPAM_TEST_NUM_BASE);
+  if (skip_module) {
       val_print(AVS_PRINT_TEST, " USER Override - Skipping all MPAM tests \n", 0);
-      val_print(AVS_PRINT_TEST, " (Running only a single module)\n", 0);
+      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
       return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_nist.c
+++ b/val/src/avs_nist.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2020, 2022-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,19 +33,18 @@ val_nist_execute_tests(uint32_t level, uint32_t num_pe)
   uint32_t status, i;
 
   for (i = 0; i < g_num_skip; i++) {
-      if (g_skip_test_num[i] == AVS_GIC_TEST_NUM_BASE) {
+      if (g_skip_test_num[i] == AVS_NIST_TEST_NUM_BASE) {
           val_print(AVS_PRINT_TEST, "      USER Override - Skipping all NIST tests \n", 0);
           return AVS_STATUS_SKIP;
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_NIST_TEST_NUM_BASE &&
-       (g_single_test == SINGLE_MODULE_SENTINEL ||
-         (g_single_test - AVS_NIST_TEST_NUM_BASE > 100 ||
-          g_single_test - AVS_NIST_TEST_NUM_BASE < 0))) {
-    val_print(AVS_PRINT_TEST, " USER Override - Skipping all NIST tests \n", 0);
-    val_print(AVS_PRINT_TEST, " (Running only a single module)\n", 0);
-    return AVS_STATUS_SKIP;
+  /* Check if there are any tests to be executed in current module with user override options*/
+  status = val_check_skip_module(AVS_NIST_TEST_NUM_BASE);
+  if (status) {
+      val_print(AVS_PRINT_TEST, " USER Override - Skipping all NIST tests \n", 0);
+      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
+      return AVS_STATUS_SKIP;
   }
 
   status = n001_entry(num_pe);

--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -271,13 +271,12 @@ val_pcie_execute_tests(uint32_t level, uint32_t num_pe)
     return AVS_STATUS_SKIP;
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_PCIE_TEST_NUM_BASE &&
-       (g_single_test == SINGLE_MODULE_SENTINEL ||
-         (g_single_test - AVS_PCIE_TEST_NUM_BASE > 100 ||
-          g_single_test - AVS_PCIE_TEST_NUM_BASE < 0))) {
-    val_print(AVS_PRINT_TEST, " USER Override - Skipping all PCIE tests \n", 0);
-    val_print(AVS_PRINT_TEST, " (Running only a single module)\n", 0);
-    return AVS_STATUS_SKIP;
+  /* Check if there are any tests to be executed in current module with user override options*/
+  status = val_check_skip_module(AVS_PCIE_TEST_NUM_BASE);
+  if (status) {
+      val_print(AVS_PRINT_TEST, " USER Override - Skipping all PCIe tests \n", 0);
+      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
+      return AVS_STATUS_SKIP;
   }
 
   g_curr_module = 1 << PCIE_MODULE;
@@ -297,7 +296,7 @@ val_pcie_execute_tests(uint32_t level, uint32_t num_pe)
 
     status = p001_entry(num_pe);
 
-    if (status != AVS_STATUS_PASS) {
+    if (status == AVS_STATUS_FAIL) {
       val_print(AVS_PRINT_WARN, "\n     *** Skipping remaining PCIE tests *** \n", 0);
       return status;
     }

--- a/val/src/avs_pe.c
+++ b/val/src/avs_pe.c
@@ -51,12 +51,12 @@ val_pe_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_PE_TEST_NUM_BASE &&
-       (g_single_test == SINGLE_MODULE_SENTINEL ||
-       (g_single_test - AVS_PE_TEST_NUM_BASE > 100))) {
-    val_print(AVS_PRINT_TEST, " USER Override - Skipping all PE tests \n", 0);
-    val_print(AVS_PRINT_TEST, " (Running only a single module)\n", 0);
-    return AVS_STATUS_SKIP;
+  /* Check if there are any tests to be executed in current module with user override options*/
+  status = val_check_skip_module(AVS_PE_TEST_NUM_BASE);
+  if (status) {
+      val_print(AVS_PRINT_TEST, " USER Override - Skipping all PE tests \n", 0);
+      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
+      return AVS_STATUS_SKIP;
   }
 
   g_curr_module = 1 << PE_MODULE;

--- a/val/src/avs_peripherals.c
+++ b/val/src/avs_peripherals.c
@@ -37,6 +37,7 @@ val_peripheral_execute_tests(uint32_t level, uint32_t num_pe)
 {
 
   uint32_t status = AVS_STATUS_SKIP, i;
+  uint32_t skip_module;
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_PER_TEST_NUM_BASE) {
@@ -45,15 +46,13 @@ val_peripheral_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_PER_TEST_NUM_BASE &&
-       (g_single_test == SINGLE_MODULE_SENTINEL ||
-         (g_single_test - AVS_PER_TEST_NUM_BASE > 100 ||
-          g_single_test - AVS_PER_TEST_NUM_BASE < 0))) {
-    val_print(AVS_PRINT_TEST, " USER Override - Skipping all Peripheral tests \n", 0);
-    val_print(AVS_PRINT_TEST, " (Running only a single module)\n", 0);
-    return AVS_STATUS_SKIP;
+  /* Check if there are any tests to be executed in current module with user override options*/
+  skip_module = val_check_skip_module(AVS_PER_TEST_NUM_BASE);
+  if (skip_module) {
+      val_print(AVS_PRINT_TEST, " USER Override - Skipping all Peripheral tests \n", 0);
+      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
+      return AVS_STATUS_SKIP;
   }
-
 
   return status;
 }

--- a/val/src/avs_pmu.c
+++ b/val/src/avs_pmu.c
@@ -35,6 +35,7 @@ val_pmu_execute_tests(uint32_t level, uint32_t num_pe)
 {
 
   uint32_t status = AVS_STATUS_FAIL;
+  uint32_t skip_module;
   uint32_t i, pmu_node_count;
 
   for (i = 0; i < g_num_skip; i++) {
@@ -44,12 +45,11 @@ val_pmu_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_PMU_TEST_NUM_BASE &&
-    (g_single_test == SINGLE_MODULE_SENTINEL ||
-      (g_single_test - AVS_PMU_TEST_NUM_BASE > 100 ||
-        g_single_test - AVS_PMU_TEST_NUM_BASE < 0))) {
+  /* Check if there are any tests to be executed in current module with user override options*/
+  skip_module = val_check_skip_module(AVS_PMU_TEST_NUM_BASE);
+  if (skip_module) {
       val_print(AVS_PRINT_TEST, " USER Override - Skipping all PMU tests \n", 0);
-      val_print(AVS_PRINT_TEST, " (Running only a single module)\n", 0);
+      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
       return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_ras.c
+++ b/val/src/avs_ras.c
@@ -35,6 +35,7 @@ uint32_t
 val_ras_execute_tests(uint32_t level, uint32_t num_pe)
 {
   uint32_t status, i;
+  uint32_t skip_module;
   uint64_t num_ras_nodes = 0;
 
   for (i = 0; i < g_num_skip; i++) {
@@ -44,12 +45,11 @@ val_ras_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_RAS_TEST_NUM_BASE &&
-    (g_single_test == SINGLE_MODULE_SENTINEL ||
-      (g_single_test - AVS_RAS_TEST_NUM_BASE > 100 ||
-        g_single_test - AVS_RAS_TEST_NUM_BASE < 0))) {
+  /* Check if there are any tests to be executed in current module with user override options*/
+  skip_module = val_check_skip_module(AVS_RAS_TEST_NUM_BASE);
+  if (skip_module) {
       val_print(AVS_PRINT_TEST, " USER Override - Skipping all RAS tests \n", 0);
-      val_print(AVS_PRINT_TEST, " (Running only a single module)\n", 0);
+      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
       return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_smmu.c
+++ b/val/src/avs_smmu.c
@@ -64,13 +64,12 @@ val_smmu_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_SMMU_TEST_NUM_BASE &&
-       (g_single_test == SINGLE_MODULE_SENTINEL ||
-         (g_single_test - AVS_SMMU_TEST_NUM_BASE > 100 ||
-          g_single_test - AVS_SMMU_TEST_NUM_BASE < 0))) {
-    val_print(AVS_PRINT_TEST, " USER Override - Skipping all SMMU tests \n", 0);
-    val_print(AVS_PRINT_TEST, " (Running only a single module)\n", 0);
-    return AVS_STATUS_SKIP;
+  /* Check if there are any tests to be executed in current module with user override options*/
+  status = val_check_skip_module(AVS_SMMU_TEST_NUM_BASE);
+  if (status) {
+      val_print(AVS_PRINT_TEST, " USER Override - Skipping all SMMU tests \n", 0);
+      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
+      return AVS_STATUS_SKIP;
   }
 
   num_smmu = val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);

--- a/val/src/avs_test_infra.c
+++ b/val/src/avs_test_infra.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -223,6 +223,43 @@ val_mmio_write64(addr_t addr, uint64_t data)
 }
 
 /**
+  @brief  This API checks if all the tests in the current module needs to be skipped.
+          Skip if no tests are to be executed with user override options.
+          1. Caller       - Test suite
+          2. Prerequisite - None.
+
+  @param module_base Base number of the module
+
+  @return         Skip - if the user override has no tests to run in the current module.
+ **/
+uint32_t
+val_check_skip_module(uint32_t module_base)
+{
+  uint32_t i, skip_module = 0;
+
+  /* Case 1 - Don't skip the module if the module number is mentioned in -m option parameters */
+  for (i = 0; i < g_num_modules; i++) {
+      if (g_execute_modules[i] == module_base) {
+          skip_module++;
+      }
+  }
+
+  /* Case 2 - Don't skip the module if any of module's tests are in -t option parameters  */
+  for (i = 0; i < g_num_tests; i++) {
+      if ((g_execute_tests[i] - module_base) < 100) {
+          skip_module++;
+      }
+  }
+
+  /* Skip the module if neither of above 2 cases are true */
+  if ((!skip_module) && (g_num_tests || g_num_modules)) {
+      return AVS_STATUS_SKIP;
+  }
+
+  return AVS_STATUS_PASS;
+}
+
+/**
   @brief  This API prints the test number, description and
           sets the test status to pending for the input number of PEs.
           1. Caller       - Application layer
@@ -241,6 +278,7 @@ val_initialize_test(uint32_t test_num, char8_t *desc, uint32_t num_pe, uint32_t 
 {
 
   uint32_t i;
+  uint32_t override_skip = 0;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
   val_print(AVS_PRINT_ERR, "%4d : ", test_num); //Always print this
@@ -261,13 +299,26 @@ val_initialize_test(uint32_t test_num, char8_t *desc, uint32_t num_pe, uint32_t 
       }
   }
 
-  if ((g_single_test != SINGLE_TEST_SENTINEL && test_num != g_single_test) &&
-        (g_single_module == SINGLE_MODULE_SENTINEL ||
-          (test_num - g_single_module >= 100 ||
-           test_num - g_single_module < 0))) {
-    val_print(AVS_PRINT_TEST, "\n       USER OVERRIDE VIA SINGLE TEST - Skip Test        ", 0);
-    val_set_status(index, RESULT_SKIP(g_sbsa_level, test_num, 0));
-    return AVS_STATUS_SKIP;
+  /* Don't skip if test_num is one of the -t option parameters */
+  for (i = 0; i < g_num_tests; i++) {
+      if (test_num == g_execute_tests[i]) {
+          override_skip++;
+      }
+  }
+
+  /* Don't skip if the test belongs to one of the modules in -m option parameters */
+  for (i = 0; i < g_num_modules; i++) {
+      if ((test_num - g_execute_modules[i]) > 0 &&
+          (test_num - g_execute_modules[i]) < 100)
+      {
+          override_skip++;
+      }
+  }
+
+  if ((!override_skip) && (g_num_tests || g_num_modules)) {
+      val_print(AVS_PRINT_TEST, "\n       USER OVERRIDE VIA SPECIFIC TESTS - Skip Test      ", 0);
+      val_set_status(index, RESULT_SKIP(g_sbsa_level, test_num, 0));
+      return AVS_STATUS_SKIP;
   }
 
   return AVS_STATUS_PASS;

--- a/val/src/avs_timer.c
+++ b/val/src/avs_timer.c
@@ -36,6 +36,7 @@ uint32_t
 val_timer_execute_tests(uint32_t level, uint32_t num_pe)
 {
   uint32_t status = AVS_STATUS_SKIP, i;
+  uint32_t skip_module;
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_TIMER_TEST_NUM_BASE) {
@@ -44,13 +45,12 @@ val_timer_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_TIMER_TEST_NUM_BASE &&
-       (g_single_test == SINGLE_MODULE_SENTINEL ||
-         (g_single_test - AVS_TIMER_TEST_NUM_BASE > 100 ||
-          g_single_test - AVS_TIMER_TEST_NUM_BASE < 0))) {
-    val_print(AVS_PRINT_TEST, " USER Override - Skipping all Timer tests \n", 0);
-    val_print(AVS_PRINT_TEST, " (Running only a single module)\n", 0);
-    return AVS_STATUS_SKIP;
+  /* Check if there are any tests to be executed in current module with user override options*/
+  skip_module = val_check_skip_module(AVS_TIMER_TEST_NUM_BASE);
+  if (skip_module) {
+      val_print(AVS_PRINT_TEST, " USER Override - Skipping all Timer tests \n", 0);
+      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
+      return AVS_STATUS_SKIP;
   }
 
 

--- a/val/src/avs_wakeup.c
+++ b/val/src/avs_wakeup.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,6 +36,8 @@ uint32_t
 val_wakeup_execute_tests(uint32_t level, uint32_t num_pe)
 {
   uint32_t status = AVS_STATUS_SKIP, i;
+  uint32_t skip_module;
+
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_WAKEUP_TEST_NUM_BASE) {
@@ -44,13 +46,12 @@ val_wakeup_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_WAKEUP_TEST_NUM_BASE &&
-       (g_single_test == SINGLE_MODULE_SENTINEL ||
-         (g_single_test - AVS_WAKEUP_TEST_NUM_BASE > 100 ||
-          g_single_test - AVS_WAKEUP_TEST_NUM_BASE < 0))) {
-    val_print(AVS_PRINT_TEST, " USER Override - Skipping all Wakeup tests \n", 0);
-    val_print(AVS_PRINT_TEST, " (Running only a single module)\n", 0);
-    return AVS_STATUS_SKIP;
+  /* Check if there are any tests to be executed in current module with user override options*/
+  skip_module = val_check_skip_module(AVS_WAKEUP_TEST_NUM_BASE);
+  if (skip_module) {
+      val_print(AVS_PRINT_TEST, " USER Override - Skipping all Wakeup tests \n", 0);
+      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
+      return AVS_STATUS_SKIP;
   }
 
   return status;

--- a/val/src/avs_wd.c
+++ b/val/src/avs_wd.c
@@ -43,13 +43,12 @@ val_wd_execute_tests(uint32_t level, uint32_t num_pe)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != AVS_WD_TEST_NUM_BASE &&
-       (g_single_test == SINGLE_MODULE_SENTINEL ||
-         (g_single_test - AVS_WD_TEST_NUM_BASE > 100 ||
-          g_single_test - AVS_WD_TEST_NUM_BASE < 0))) {
-    val_print(AVS_PRINT_TEST, " USER Override - Skipping all Watchdog tests \n", 0);
-    val_print(AVS_PRINT_TEST, " (Running only a single module)\n", 0);
-    return AVS_STATUS_SKIP;
+  /* Check if there are any tests to be executed in current module with user override options*/
+  status = val_check_skip_module(AVS_WD_TEST_NUM_BASE);
+  if (status) {
+      val_print(AVS_PRINT_TEST, " USER Override - Skipping all Watchdog tests \n", 0);
+      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
+      return AVS_STATUS_SKIP;
   }
 
   g_curr_module = 1 << WD_MODULE;


### PR DESCRIPTION
 - Resolves: #328 
 - Removed the limitation on number of tests and modules to be run using -t and -m options in UEFI and Baremetal.