### PR TITLE
SMMU tests reordering and enhancements

### DIFF
--- a/test_pool/smmu/operating_system/test_i006.c
+++ b/test_pool/smmu/operating_system/test_i006.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2020-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,26 +39,18 @@ payload(void)
       return;
   }
 
-  data = val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0);
-
-  if (data == 0) {
-      val_print(AVS_PRINT_WARN, "\n       PCIe Subsystem not  discovered   ", 0);
-      val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 02));
-      return;
-  }
-
   num_smmu = val_smmu_get_info(SMMU_NUM_CTRL, 0);
 
   if (num_smmu == 0) {
       val_print(AVS_PRINT_ERR, "\n       No SMMU Controllers are discovered ", 0);
-      val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 03));
+      val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 02));
       return;
   }
 
   while (num_smmu--) {
       if (val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu) == 2) {
           val_print(AVS_PRINT_WARN, "\n       Not valid for SMMU v2           ", 0);
-          val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 04));
+          val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 03));
           return;
       }
 

--- a/test_pool/smmu/operating_system/test_i008.c
+++ b/test_pool/smmu/operating_system/test_i008.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,14 +42,14 @@ payload()
   num_smmu = val_smmu_get_info(SMMU_NUM_CTRL, 0);
   if (num_smmu == 0) {
       val_print(AVS_PRINT_ERR, "\n       No SMMU Controllers are discovered ", 0);
-      val_set_status(index, RESULT_SKIP(6, TEST_NUM, 3));
+      val_set_status(index, RESULT_SKIP(6, TEST_NUM, 1));
       return;
   }
 
   while (num_smmu--) {
       if (val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu) == 2) {
           val_print(AVS_PRINT_WARN, "\n       Not valid for SMMU v2           ", 0);
-          val_set_status(index, RESULT_SKIP(6, TEST_NUM, 4));
+          val_set_status(index, RESULT_SKIP(6, TEST_NUM, 2));
           return;
       }
 

--- a/test_pool/smmu/operating_system/test_i011.c
+++ b/test_pool/smmu/operating_system/test_i011.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,7 +31,6 @@ void
 payload()
 {
 
-  uint64_t data;
   uint32_t num_smmu;
   uint32_t index;
   uint32_t pe_asid, asid;
@@ -40,25 +39,18 @@ payload()
   index = val_pe_get_index_mpid(val_pe_get_mpid());
   pe_asid = VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64MMFR0_EL1), 4, 7);
 
-  data = val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0);
-  if (data == 0) {
-    val_print(AVS_PRINT_WARN, "\n       PCIe Subsystem not discovered                       ", 0);
-    val_set_status(index, RESULT_SKIP(6, TEST_NUM, 2));
-    return;
-  }
-
   num_smmu = val_smmu_get_info(SMMU_NUM_CTRL, 0);
 
   if (num_smmu == 0) {
     val_print(AVS_PRINT_ERR, "\n       No SMMU Controllers are discovered                  ", 0);
-    val_set_status(index, RESULT_SKIP(6, TEST_NUM, 3));
+    val_set_status(index, RESULT_SKIP(6, TEST_NUM, 1));
     return;
   }
 
   while (num_smmu--) {
     if (val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu) == 2) {
       val_print(AVS_PRINT_WARN, "\n       Not valid for SMMU v2                               ", 0);
-      val_set_status(index, RESULT_SKIP(6, TEST_NUM, 4));
+      val_set_status(index, RESULT_SKIP(6, TEST_NUM, 2));
       return;
     }
 

--- a/test_pool/smmu/operating_system/test_i012.c
+++ b/test_pool/smmu/operating_system/test_i012.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,18 +38,11 @@ payload()
 
   index = val_pe_get_index_mpid(val_pe_get_mpid());
 
-  data = val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0);
-  if (data == 0) {
-    val_print(AVS_PRINT_WARN, "\n       PCIe Subsystem not discovered                       ", 0);
-    val_set_status(index, RESULT_SKIP(6, TEST_NUM, 2));
-    return;
-  }
-
   num_smmu = val_smmu_get_info(SMMU_NUM_CTRL, 0);
 
   if (num_smmu == 0) {
     val_print(AVS_PRINT_ERR, "\n       No SMMU Controllers are discovered                  ", 0);
-    val_set_status(index, RESULT_SKIP(6, TEST_NUM, 3));
+    val_set_status(index, RESULT_SKIP(6, TEST_NUM, 1));
     return;
   }
 
@@ -63,7 +56,7 @@ payload()
   while (num_smmu--) {
       if (val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu) == 2) {
           val_print(AVS_PRINT_WARN, "\n       Not valid for SMMU v2           ", 0);
-          val_set_status(index, RESULT_SKIP(6, TEST_NUM, 4));
+          val_set_status(index, RESULT_SKIP(6, TEST_NUM, 2));
           return;
       }
 

--- a/test_pool/smmu/operating_system/test_i013.c
+++ b/test_pool/smmu/operating_system/test_i013.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,74 +17,52 @@
 
 #include "val/include/sbsa_avs_val.h"
 #include "val/include/val_interface.h"
-#include "val/include/sbsa_avs_iovirt.h"
-#include "val/include/sbsa_avs_pe.h"
+
+#include "val/include/sbsa_avs_smmu.h"
+#include "val/include/sbsa_avs_pcie.h"
 
 #define TEST_NUM   (AVS_SMMU_TEST_NUM_BASE + 13)
-#define TEST_RULE  "S_L7SM_01"
-#define TEST_DESC  "Check if all DMA reqs behind SMMU "
+#define TEST_RULE  "S_L6SM_01"
+#define TEST_DESC  "Check SMMU Coherent Access Support"
 
 static
 void
-payload()
+payload(void)
 {
 
-  uint32_t num_pcie_rc, num_named_comp;
-  uint32_t i, test_fails = 0;
+  uint64_t data;
+  uint32_t num_smmu;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
-  if (g_sbsa_level < 7) {
+  if (g_sbsa_level < 6) {
       val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
       return;
   }
+  num_smmu = val_smmu_get_info(SMMU_NUM_CTRL, 0);
 
-  /* check whether all DMA capable PCIe root complexes are behind a SMMU */
-  num_pcie_rc = val_iovirt_get_pcie_rc_info(NUM_PCIE_RC, 0);
+  if (num_smmu == 0) {
+      val_print(AVS_PRINT_ERR, "\n       No SMMU Controllers are discovered ", 0);
+      val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 02));
+      return;
+  }
 
-  for (i = 0; i < num_pcie_rc; i++) {
-      /* print info fields */
-      val_print(AVS_PRINT_DEBUG, "\n       RC segment no  : 0x%llx",
-                    val_iovirt_get_pcie_rc_info(RC_SEGMENT_NUM, i));
-      val_print(AVS_PRINT_DEBUG, "\n       CCA attribute  : 0x%x",
-                    val_iovirt_get_pcie_rc_info(RC_MEM_ATTRIBUTE, i));
-      val_print(AVS_PRINT_DEBUG, "\n       SMMU base addr : 0x%llx\n",
-                    val_iovirt_get_pcie_rc_info(RC_SMMU_BASE, i));
+  while (num_smmu--) {
+      if (val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu) == 2) {
+          val_print(AVS_PRINT_WARN, "\n       Not valid for SMMU v2           ", 0);
+          val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 03));
+          return;
+      }
 
-      if (val_iovirt_get_pcie_rc_info(RC_MEM_ATTRIBUTE, i) == 0x1 &&
-                                    val_iovirt_get_pcie_rc_info(RC_SMMU_BASE, i) == 0) {
-          val_print(AVS_PRINT_ERR,
-                    "\n       DMA capable PCIe root port with segment no: %llx not behind a SMMU.",
-                    val_iovirt_get_pcie_rc_info(RC_SEGMENT_NUM, i));
-          test_fails++;
+      data = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_IDR0, num_smmu), 4, 4);
+
+      /* Check If SMMU_IDR0.COHACC == 1*/
+      if (data != 1) {
+          val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
+          return;
       }
   }
 
-  /* check whether all DMA capable Named component requestors are behind a SMMU */
-  num_named_comp = val_iovirt_get_named_comp_info(NUM_NAMED_COMP, 0);
-  for (i = 0; i < num_named_comp; i++) {
-      /* print info fields */
-      val_print(AVS_PRINT_DEBUG, "\n       Named component  :", 0);
-      val_print(AVS_PRINT_DEBUG,
-                    (char8_t *)val_iovirt_get_named_comp_info(NAMED_COMP_DEV_OBJ_NAME, i), 0);
-      val_print(AVS_PRINT_DEBUG, "\n       CCA attribute    : 0x%x",
-                    val_iovirt_get_named_comp_info(NAMED_COMP_CCA_ATTR, i));
-      val_print(AVS_PRINT_DEBUG, "\n       SMMU base addr   : 0x%llx\n",
-                    val_iovirt_get_named_comp_info(NAMED_COMP_SMMU_BASE, i));
-      if (val_iovirt_get_named_comp_info(NAMED_COMP_CCA_ATTR, i) == 0x1 &&
-                                    val_iovirt_get_named_comp_info(NAMED_COMP_SMMU_BASE, i) == 0) {
-          val_print(AVS_PRINT_ERR,
-                    "\n       DMA capable named component with namespace path: ", 0);
-          val_print(AVS_PRINT_ERR,
-                    (char8_t *)val_iovirt_get_named_comp_info(NAMED_COMP_DEV_OBJ_NAME, i), 0);
-          val_print(AVS_PRINT_ERR, " not behind a SMMU.", 0);
-          test_fails++;
-      }
-  }
-
-  if (test_fails)
-      val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
-  else
-      val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
+  val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
 }
 
 uint32_t
@@ -93,7 +71,7 @@ i013_entry(uint32_t num_pe)
 
   uint32_t status = AVS_STATUS_FAIL;
 
-  num_pe = 1;  /* This test is run on single processor */
+  num_pe = 1;  //This test is run on single processor
 
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe, g_sbsa_level, TEST_RULE);
   if (status != AVS_STATUS_SKIP)

--- a/test_pool/smmu/operating_system/test_i015.c
+++ b/test_pool/smmu/operating_system/test_i015.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,82 +17,80 @@
 
 #include "val/include/sbsa_avs_val.h"
 #include "val/include/val_interface.h"
-
+#include "val/include/sbsa_avs_iovirt.h"
 #include "val/include/sbsa_avs_pe.h"
-#include "val/include/sbsa_avs_smmu.h"
 
 #define TEST_NUM   (AVS_SMMU_TEST_NUM_BASE + 15)
-#define TEST_RULE  "B_SMMU_11, B_SMMU_22"
-#define TEST_DESC  "Check SMMU for MPAM support       "
+#define TEST_RULE  "S_L7SM_01"
+#define TEST_DESC  "Check if all DMA reqs behind SMMU "
 
 static
 void
 payload()
 {
 
-  uint32_t num_smmu;
-  uint32_t smmu_rev;
-  uint32_t minor;
-  uint32_t index;
-  uint32_t pe_mpam, mpam;
-  uint32_t frac;
-  uint32_t max_id;
+  uint32_t num_pcie_rc, num_named_comp;
+  uint32_t i, test_fails = 0;
+  uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
+  uint32_t num_dma_req = 0;
 
-  index = val_pe_get_index_mpid(val_pe_get_mpid());
-  // Major MPAM revision supported by the PE (i.e. MPAM v1.x)
-  pe_mpam = VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64PFR0_EL1), 40, 43);
-  // Minor MPAM revision supported by the PE (i.e. MPAM vx.1)
-  frac = VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64PFR1_EL1), 16, 19);
-
-  num_smmu = val_smmu_get_info(SMMU_NUM_CTRL, 0);
-  if (num_smmu == 0) {
-    val_print(AVS_PRINT_DEBUG, "\n       No SMMU Controllers are discovered                 ", 0);
-    val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 3));
-    return;
+  if (g_sbsa_level < 7) {
+      val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+      return;
   }
 
-  if (!(pe_mpam || frac)) {
-    val_print(AVS_PRINT_DEBUG, "\n       No MPAM controlled resources present               ", 0);
-    val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 3));
-    return;
+  /* check whether all DMA capable PCIe root complexes are behind a SMMU */
+  num_pcie_rc = val_iovirt_get_pcie_rc_info(NUM_PCIE_RC, 0);
+  num_dma_req = num_pcie_rc;
+  for (i = 0; i < num_pcie_rc; i++) {
+      /* print info fields */
+      val_print(AVS_PRINT_DEBUG, "\n       RC segment no  : 0x%llx",
+                    val_iovirt_get_pcie_rc_info(RC_SEGMENT_NUM, i));
+      val_print(AVS_PRINT_DEBUG, "\n       CCA attribute  : 0x%x",
+                    val_iovirt_get_pcie_rc_info(RC_MEM_ATTRIBUTE, i));
+      val_print(AVS_PRINT_DEBUG, "\n       SMMU base addr : 0x%llx\n",
+                    val_iovirt_get_pcie_rc_info(RC_SMMU_BASE, i));
+
+      if (val_iovirt_get_pcie_rc_info(RC_MEM_ATTRIBUTE, i) == 0x1 &&
+                                    val_iovirt_get_pcie_rc_info(RC_SMMU_BASE, i) == 0) {
+          val_print(AVS_PRINT_ERR,
+                    "\n       DMA capable PCIe root port with segment no: %llx not behind a SMMU.",
+                    val_iovirt_get_pcie_rc_info(RC_SEGMENT_NUM, i));
+          test_fails++;
+      }
   }
 
-  while (num_smmu--) {
-        smmu_rev = val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu);
-        if (smmu_rev < 3) {
-                // MPAM support not required for SMMUv2 and below
-                val_print(AVS_PRINT_DEBUG, "\n       SMMU revision v2 or lower detected  ", 0);
-                val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 4));
-                return;
-        }
-        else {
-                minor = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_AIDR, num_smmu), 0, 3);
-                // Check if MPAM is supported for any security state (only for SMMU v3.2+)
-                if (minor >= 2) {
-                        // SMMU general MPAM support (in either Secure/Non-Secure state)
-                        mpam = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_IDR3, num_smmu),
-                              7, 7);
-                        // Check if MPAM is supported for any of the NS resources (max part ID)
-                        max_id = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_MPAMIDR,
-                              num_smmu), 0, 15);
-                        if (!(mpam && max_id)) {
-                                val_print(AVS_PRINT_ERR,
-                                          "\n       SMMU without MPAM support detected  ", 0);
-                                val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 4));
-                                return;
-                        }
-                }
-                else {
-                        // MPAM support not required for SMMUv3.0/3.1
-                        val_print(AVS_PRINT_WARN,
-                              "\n       SMMU revision v3.0/3.1 detected  ", 0);
-                        val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 4));
-                        return;
-                }
-        }
+  /* check whether all DMA capable Named component requestors are behind a SMMU */
+  num_named_comp = val_iovirt_get_named_comp_info(NUM_NAMED_COMP, 0);
+  num_dma_req += num_named_comp;
+  for (i = 0; i < num_named_comp; i++) {
+      /* print info fields */
+      val_print(AVS_PRINT_DEBUG, "\n       Named component  :", 0);
+      val_print(AVS_PRINT_DEBUG,
+                    (char8_t *)val_iovirt_get_named_comp_info(NAMED_COMP_DEV_OBJ_NAME, i), 0);
+      val_print(AVS_PRINT_DEBUG, "\n       CCA attribute    : 0x%x",
+                    val_iovirt_get_named_comp_info(NAMED_COMP_CCA_ATTR, i));
+      val_print(AVS_PRINT_DEBUG, "\n       SMMU base addr   : 0x%llx\n",
+                    val_iovirt_get_named_comp_info(NAMED_COMP_SMMU_BASE, i));
+      if (val_iovirt_get_named_comp_info(NAMED_COMP_CCA_ATTR, i) == 0x1 &&
+                                    val_iovirt_get_named_comp_info(NAMED_COMP_SMMU_BASE, i) == 0) {
+          val_print(AVS_PRINT_ERR,
+                    "\n       DMA capable named component with namespace path: ", 0);
+          val_print(AVS_PRINT_ERR,
+                    (char8_t *)val_iovirt_get_named_comp_info(NAMED_COMP_DEV_OBJ_NAME, i), 0);
+          val_print(AVS_PRINT_ERR, " not behind a SMMU.", 0);
+          test_fails++;
+      }
   }
 
-  val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 1));
+  if (test_fails)
+      val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
+  else if (!num_dma_req) {
+      val_print(AVS_PRINT_DEBUG, "\n       No DMA requestors present", 0);
+      val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 02));
+  } else {
+      val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
+  }
 }
 
 uint32_t
@@ -101,7 +99,7 @@ i015_entry(uint32_t num_pe)
 
   uint32_t status = AVS_STATUS_FAIL;
 
-  num_pe = 1;  //This test is run on single processor
+  num_pe = 1;  /* This test is run on single processor */
 
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe, g_sbsa_level, TEST_RULE);
   if (status != AVS_STATUS_SKIP)

--- a/val/src/avs_smmu.c
+++ b/val/src/avs_smmu.c
@@ -89,10 +89,10 @@ val_smmu_execute_tests(uint32_t level, uint32_t num_pe)
       status |= i002_entry(num_pe);
       status |= i003_entry(num_pe);
       status |= i004_entry(num_pe);
+      status |= i005_entry(num_pe);
   }
 
   if (g_sbsa_level > 5) {
-      status |= i005_entry(num_pe);
       status |= i006_entry(num_pe);
       status |= i007_entry(num_pe);
       status |= i008_entry(num_pe);
@@ -100,12 +100,12 @@ val_smmu_execute_tests(uint32_t level, uint32_t num_pe)
       status |= i010_entry(num_pe);
       status |= i011_entry(num_pe);
       status |= i012_entry(num_pe);
-      status |= i015_entry(num_pe);
+      status |= i013_entry(num_pe);
   }
 
   if (g_sbsa_level > 6) {
-     status |= i013_entry(num_pe);
      status |= i014_entry(num_pe);
+     status |= i015_entry(num_pe);
   }
 #endif
 #if defined(TARGET_LINUX) || defined(TARGET_EMULATION)


### PR DESCRIPTION
 - tests are being reordered based SBSA spec.
 - SMMU support for MPAM test moved from L6 to L5.
 - PCIe presence checks removed from few SMMU tests as they are redundant.