### PR TITLE
Added additional prints to print info of all cards in PCI info block

### DIFF
--- a/val/include/sbsa_avs_pcie_spec.h
+++ b/val/include/sbsa_avs_pcie_spec.h
@@ -375,6 +375,8 @@
 #define DP       (1 << 0b0110)
 #define iEP_EP   (1 << 0b1100)
 #define iEP_RP   (1 << 0b1011)
+#define PCI_PCIE (1 << 0b1000)
+#define PCIE_PCI (1 << 0b0111)
 #define PCIe_ALL (iEP_RP | iEP_EP | RP | EP | RCEC | RCiEP)
 
 /* MSI-X Capabilities */

--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -380,6 +380,8 @@ val_pcie_print_device_info(void)
   uint32_t num_rciep = 0, num_rcec = 0;
   uint32_t num_iep = 0, num_irp = 0;
   uint32_t num_ep = 0, num_rp = 0;
+  uint32_t num_dp = 0, num_up = 0;
+  uint32_t num_pcie_pci = 0, num_pci_pcie = 0;
   uint32_t bdf_counter;
 
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
@@ -399,12 +401,36 @@ val_pcie_print_device_info(void)
 
       switch (dp_type)
       {
-        case RCiEP  : num_rciep++; break;
-        case RCEC   : num_rcec++; break;
-        case EP     : num_ep++; break;
-        case RP     : num_rp++; break;
-        case iEP_EP : num_iep++; break;
-        case iEP_RP : num_irp++; break;
+        case RCiEP:
+            num_rciep++;
+            break;
+        case RCEC:
+            num_rcec++;
+            break;
+        case EP:
+            num_ep++;
+            break;
+        case RP:
+            num_rp++;
+            break;
+        case iEP_EP:
+            num_iep++;
+            break;
+        case iEP_RP:
+            num_irp++;
+            break;
+        case UP:
+            num_up++;
+            break;
+        case DP:
+            num_dp++;
+            break;
+        case PCI_PCIE:
+            num_pci_pcie++;
+            break;
+        case PCIE_PCI:
+            num_pcie_pci++;
+            break;
       }
   }
 
@@ -414,7 +440,10 @@ val_pcie_print_device_info(void)
   val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of RP              : %4d \n", num_rp);
   val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of iEP_EP          : %4d \n", num_iep);
   val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of iEP_RP          : %4d \n", num_irp);
-
+  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of UP of switch    : %4d \n", num_up);
+  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of DP of switch    : %4d \n", num_dp);
+  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of PCI/PCIe Bridge : %4d \n", num_pci_pcie);
+  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of PCIe/PCI Bridge : %4d \n", num_pcie_pci);
 
   while (ecam_index < val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0))
   {
@@ -639,12 +668,12 @@ val_pcie_create_device_bdf_table()
       /* Discard the bdf table */
       g_pcie_bdf_table->num_entries = 0;
       val_print(AVS_PRINT_TEST,
-            " PCIE_INFO: Number of BDFs found      :    %x\n", g_pcie_bdf_table->num_entries);
+            " PCIE_INFO: Number of BDFs found      :    %d\n", g_pcie_bdf_table->num_entries);
 
       return 1;
   }
   val_print(AVS_PRINT_TEST,
-            " PCIE_INFO: Number of BDFs found      :    %x\n", g_pcie_bdf_table->num_entries);
+            " PCIE_INFO: Number of BDFs found      :    %d\n", g_pcie_bdf_table->num_entries);
 
   return 0;
 }


### PR DESCRIPTION
- Fix for issue https://github.com/ARM-software/bsa-acs/issues/150
- Added changes to print additional information on the number of Upstream ports of a switch, Downstream ports of a switch, PCIe to PCI/PCI-X Bridge and PCIe to PCI/PCI-X to PCIe Bridge to match the total BDF's identified