### PR TITLE
Removing module header when module is skipped.

### DIFF
--- a/baremetal_app/SbsaAvsMain.c
+++ b/baremetal_app/SbsaAvsMain.c
@@ -384,31 +384,26 @@ ShellAppMainsbsa(
   val_pe_context_save(AA64ReadSp(), (uint64_t)branch_label);
   val_pe_initialize_default_exception_handler(val_pe_default_esr);
 
-  val_print(AVS_PRINT_TEST, "\n      ***  Starting PE tests ***  \n", 0);
+  /***         Starting PE tests                     ***/
   Status = val_pe_execute_tests(g_sbsa_level, val_pe_get_num());
 
-  val_print(AVS_PRINT_TEST, "\n      ***  Starting Memory tests ***  \n", 0);
+  /***         Starting Memory tests                 ***/
   Status |= val_memory_execute_tests(g_sbsa_level, val_pe_get_num());
 
-  val_print(AVS_PRINT_TEST, "\n      ***  Starting GIC tests ***  \n", 0);
+  /***         Starting GIC tests                    ***/
   Status |= val_gic_execute_tests(g_sbsa_level, val_pe_get_num());
 
-  if (g_sbsa_level > 3) {
-    val_print(AVS_PRINT_TEST, "\n      *** Starting SMMU  tests ***  \n", 0);
+  /***         Starting SMMU tests                   ***/
+  if (g_sbsa_level > 3)
     Status |= val_smmu_execute_tests(g_sbsa_level, val_pe_get_num());
-  }
 
+  /***         Starting Watchdog tests               ***/
   if (g_sbsa_level > 5)
-  {
-    val_print(AVS_PRINT_TEST, "\n      *** Starting Watchdog tests ***  \n", 0);
     Status |= val_wd_execute_tests(g_sbsa_level, val_pe_get_num());
-  }
 
+  /***         Starting PCIe tests                   ***/
   if (g_sbsa_level > 5)
-  {
-    val_print(AVS_PRINT_TEST, "\n      *** Starting PCIe tests ***  \n", 0);
     Status |= val_pcie_execute_tests(g_enable_pcie_tests, g_sbsa_level, val_pe_get_num());
-  }
 
   /*
    * Configure Gic Redistributor and ITS to support
@@ -416,23 +411,20 @@ ShellAppMainsbsa(
    */
   configureGicIts();
 
-  val_print(AVS_PRINT_TEST, "\n      *** Starting PCIe Exerciser tests ***  \n", 0);
+  /***         Starting Exerciser tests              ***/
   Status |= val_exerciser_execute_tests(g_sbsa_level);
 
-  if (g_sbsa_level > 6) {
-    val_print(AVS_PRINT_TEST, "\n      *** Starting MPAM tests ***  \n", 0);
+  /***         Starting MPAM tests                   ***/
+  if (g_sbsa_level > 6)
     Status |= val_mpam_execute_tests(g_sbsa_level, val_pe_get_num());
-  }
 
-  if (g_sbsa_level > 6) {
-    val_print(AVS_PRINT_TEST, "\n      *** Starting PMU tests ***  \n",  0);
+  /***         Starting PMU tests                    ***/
+  if (g_sbsa_level > 6)
     Status |= val_pmu_execute_tests(g_sbsa_level, val_pe_get_num());
-  }
 
-  if (g_sbsa_level > 6) {
-    val_print(AVS_PRINT_TEST, "\n      *** Starting RAS tests ***  \n", 0);
+  /***         Starting RAS tests                    ***/
+  if (g_sbsa_level > 6)
     Status |= val_ras_execute_tests(g_sbsa_level, val_pe_get_num());
-  }
 
 print_test_status:
   val_print(AVS_PRINT_TEST, "\n     ------------------------------------------------------- \n", 0);

--- a/uefi_app/SbsaAvsMain.c
+++ b/uefi_app/SbsaAvsMain.c
@@ -781,32 +781,26 @@ ShellAppMainsbsa (
   val_pe_initialize_default_exception_handler(val_pe_default_esr);
   FlushImage();
 
-  val_print(AVS_PRINT_TEST, "\n      ***  Starting PE tests ***  \n", 0);
+  /***         Starting PE tests                     ***/
   Status = val_pe_execute_tests(g_sbsa_level, val_pe_get_num());
 
-  val_print(AVS_PRINT_TEST, "\n      ***  Starting Memory tests ***  \n", 0);
+  /***         Starting Memory tests                 ***/
   Status |= val_memory_execute_tests(g_sbsa_level, val_pe_get_num());
 
-  val_print(AVS_PRINT_TEST, "\n      ***  Starting GIC tests ***  \n", 0);
+  /***         Starting GIC tests                    ***/
   Status |= val_gic_execute_tests(g_sbsa_level, val_pe_get_num());
 
+  /***         Starting SMMU tests                   ***/
   if (g_sbsa_level > 3)
-  {
-    val_print(AVS_PRINT_TEST, "\n      *** Starting SMMU  tests ***  \n", 0);
     Status |= val_smmu_execute_tests(g_sbsa_level, val_pe_get_num());
-  }
 
+  /***         Starting Watchdog tests               ***/
   if (g_sbsa_level > 5)
-  {
-    val_print(AVS_PRINT_TEST, "\n      *** Starting Watchdog tests ***  \n", 0);
     Status |= val_wd_execute_tests(g_sbsa_level, val_pe_get_num());
-  }
 
+  /***         Starting PCIe tests                   ***/
   if (g_sbsa_level > 3)
-  {
-    val_print(AVS_PRINT_TEST, "\n      *** Starting PCIe tests ***  \n", 0);
     Status |= val_pcie_execute_tests(g_sbsa_level, val_pe_get_num());
-  }
 
   /*
    * Configure Gic Redistributor and ITS to support
@@ -814,27 +808,24 @@ ShellAppMainsbsa (
    */
   configureGicIts();
 
-  val_print(AVS_PRINT_TEST, "\n      *** Starting PCIe Exerciser tests ***  \n", 0);
+  /***         Starting Exerciser tests              ***/
   Status |= val_exerciser_execute_tests(g_sbsa_level);
 
-  if (g_sbsa_level > 6) {
-    val_print(AVS_PRINT_TEST, "\n      *** Starting MPAM tests ***  \n", 0);
+  /***         Starting MPAM tests                   ***/
+  if (g_sbsa_level > 6)
     Status |= val_mpam_execute_tests(g_sbsa_level, val_pe_get_num());
-  }
 
-  if (g_sbsa_level > 6) {
-    val_print(AVS_PRINT_TEST, "\n      *** Starting PMU tests ***  \n",  0);
+  /***         Starting PMU tests                    ***/
+  if (g_sbsa_level > 6)
     Status |= val_pmu_execute_tests(g_sbsa_level, val_pe_get_num());
-  }
 
-  if (g_sbsa_level > 6) {
-    val_print(AVS_PRINT_TEST, "\n      *** Starting RAS tests ***  \n", 0);
+  /***         Starting RAS tests                    ***/
+  if (g_sbsa_level > 6)
     Status |= val_ras_execute_tests(g_sbsa_level, val_pe_get_num());
-  }
 
 #ifdef ENABLE_NIST
+  /***         Starting NIST tests                   ***/
   if (g_execute_nist == TRUE) {
-    val_print(AVS_PRINT_TEST, "\n      *** Starting NIST statistical tests ***  \n", 0);
     Status |= val_nist_execute_tests(g_sbsa_level, val_pe_get_num());
   }
 #endif

--- a/val/src/avs_exerciser.c
+++ b/val/src/avs_exerciser.c
@@ -299,8 +299,7 @@ val_exerciser_execute_tests(uint32_t level)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(AVS_EXERCISER_TEST_NUM_BASE);
   if (status) {
-    val_print(AVS_PRINT_TEST, " USER Override - Skipping all Exerciser tests \n", 0);
-    val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
+    val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all Exerciser tests \n", 0);
     return AVS_STATUS_SKIP;
   }
 
@@ -331,6 +330,7 @@ val_exerciser_execute_tests(uint32_t level)
   for (instance = 0; instance < num_smmu; ++instance)
       val_smmu_disable(instance);
 
+  val_print(AVS_PRINT_TEST, "\n      *** Starting PCIe Exerciser tests ***  \n", 0);
 
   g_curr_module = 1 << EXERCISER_MODULE;
   status = e001_entry();

--- a/val/src/avs_gic.c
+++ b/val/src/avs_gic.c
@@ -49,11 +49,11 @@ val_gic_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   module_skip = val_check_skip_module(AVS_GIC_TEST_NUM_BASE);
   if (module_skip) {
-      val_print(AVS_PRINT_TEST, " USER Override - Skipping all GIC tests \n", 0);
-      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
+      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all GIC tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 
+  val_print(AVS_PRINT_TEST, "\n      *** Starting GIC tests ***  \n", 0);
   g_curr_module = 1 << GIC_MODULE;
 
   status = g001_entry(num_pe);

--- a/val/src/avs_memory.c
+++ b/val/src/avs_memory.c
@@ -48,11 +48,11 @@ val_memory_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in the current module with user override*/
   status = val_check_skip_module(AVS_MEM_MAP_TEST_NUM_BASE);
   if (status) {
-      val_print(AVS_PRINT_TEST, " USER Override - Skipping all memory tests \n", 0);
-      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
+      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all memory tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 
+  val_print(AVS_PRINT_TEST, "\n      *** Starting Memory tests ***  \n", 0);
   g_curr_module = 1 << MEM_MAP_MODULE;
 
   status = m001_entry(num_pe);

--- a/val/src/avs_mpam.c
+++ b/val/src/avs_mpam.c
@@ -49,8 +49,7 @@ val_mpam_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in the current module with user override*/
   skip_module = val_check_skip_module(AVS_MPAM_TEST_NUM_BASE);
   if (skip_module) {
-      val_print(AVS_PRINT_TEST, " USER Override - Skipping all MPAM tests \n", 0);
-      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
+      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all MPAM tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 
@@ -61,6 +60,7 @@ val_mpam_execute_tests(uint32_t level, uint32_t num_pe)
       return AVS_STATUS_SKIP;
   }
 
+  val_print(AVS_PRINT_TEST, "\n      *** Starting MPAM tests ***  \n", 0);
   g_curr_module = 1 << MPAM_MODULE;
 
   /* run tests which don't check MPAM MSCs */

--- a/val/src/avs_nist.c
+++ b/val/src/avs_nist.c
@@ -42,11 +42,11 @@ val_nist_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(AVS_NIST_TEST_NUM_BASE);
   if (status) {
-      val_print(AVS_PRINT_TEST, " USER Override - Skipping all NIST tests \n", 0);
-      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
+      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all NIST tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 
+  val_print(AVS_PRINT_TEST, "\n      *** Starting NIST tests ***  \n", 0);
   status = n001_entry(num_pe);
 
   val_print_test_end(status, "NIST");

--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -274,11 +274,11 @@ val_pcie_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(AVS_PCIE_TEST_NUM_BASE);
   if (status) {
-      val_print(AVS_PRINT_TEST, " USER Override - Skipping all PCIe tests \n", 0);
-      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
+      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all PCIe tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 
+  val_print(AVS_PRINT_TEST, "\n      *** Starting PCIe tests ***  \n", 0);
   g_curr_module = 1 << PCIE_MODULE;
 
   /* Only the test p062 will be run at L4+ with the test number (AVS_PER_TEST_NUM_BASE + 1) */

--- a/val/src/avs_pe.c
+++ b/val/src/avs_pe.c
@@ -54,11 +54,11 @@ val_pe_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(AVS_PE_TEST_NUM_BASE);
   if (status) {
-      val_print(AVS_PRINT_TEST, " USER Override - Skipping all PE tests \n", 0);
-      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
+      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all PE tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 
+  val_print(AVS_PRINT_TEST, "\n      *** Starting PE tests ***  \n", 0);
   g_curr_module = 1 << PE_MODULE;
 
   status |= c001_entry(num_pe);

--- a/val/src/avs_peripherals.c
+++ b/val/src/avs_peripherals.c
@@ -49,10 +49,11 @@ val_peripheral_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   skip_module = val_check_skip_module(AVS_PER_TEST_NUM_BASE);
   if (skip_module) {
-      val_print(AVS_PRINT_TEST, " USER Override - Skipping all Peripheral tests \n", 0);
-      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
+      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all Peripheral tests \n", 0);
       return AVS_STATUS_SKIP;
   }
+
+  val_print(AVS_PRINT_TEST, "\n      *** Starting Peripheral tests ***  \n", 0);
 
   return status;
 }

--- a/val/src/avs_pmu.c
+++ b/val/src/avs_pmu.c
@@ -48,8 +48,7 @@ val_pmu_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   skip_module = val_check_skip_module(AVS_PMU_TEST_NUM_BASE);
   if (skip_module) {
-      val_print(AVS_PRINT_TEST, " USER Override - Skipping all PMU tests \n", 0);
-      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
+      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all PMU tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 
@@ -60,6 +59,7 @@ val_pmu_execute_tests(uint32_t level, uint32_t num_pe)
       return AVS_STATUS_SKIP;
   }
 
+  val_print(AVS_PRINT_TEST, "\n      *** Starting PMU tests ***  \n", 0);
   g_curr_module = 1 << PMU_MODULE;
 
   /* run tests which don't check PMU nodes */

--- a/val/src/avs_ras.c
+++ b/val/src/avs_ras.c
@@ -48,8 +48,7 @@ val_ras_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   skip_module = val_check_skip_module(AVS_RAS_TEST_NUM_BASE);
   if (skip_module) {
-      val_print(AVS_PRINT_TEST, " USER Override - Skipping all RAS tests \n", 0);
-      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
+      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all RAS tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 
@@ -70,6 +69,8 @@ val_ras_execute_tests(uint32_t level, uint32_t num_pe)
 
   /* set default status to AVS_STATUS_FAIL */
   status = AVS_STATUS_FAIL;
+
+  val_print(AVS_PRINT_TEST, "\n      *** Starting RAS tests ***  \n", 0);
 
   if (g_sbsa_level > 6) {
       status = ras001_entry(num_pe);

--- a/val/src/avs_smmu.c
+++ b/val/src/avs_smmu.c
@@ -67,8 +67,7 @@ val_smmu_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(AVS_SMMU_TEST_NUM_BASE);
   if (status) {
-      val_print(AVS_PRINT_TEST, " USER Override - Skipping all SMMU tests \n", 0);
-      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
+      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all SMMU tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 
@@ -78,6 +77,7 @@ val_smmu_execute_tests(uint32_t level, uint32_t num_pe)
     return AVS_STATUS_SKIP;
   }
 
+  val_print(AVS_PRINT_TEST, "\n      *** Starting SMMU tests ***  \n", 0);
   g_curr_module = 1 << SMMU_MODULE;
 
 #ifndef TARGET_LINUX

--- a/val/src/avs_timer.c
+++ b/val/src/avs_timer.c
@@ -48,11 +48,11 @@ val_timer_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   skip_module = val_check_skip_module(AVS_TIMER_TEST_NUM_BASE);
   if (skip_module) {
-      val_print(AVS_PRINT_TEST, " USER Override - Skipping all Timer tests \n", 0);
-      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
+      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all Timer tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 
+  val_print(AVS_PRINT_TEST, "\n      *** Starting Timer tests ***  \n", 0);
 
   return status;
 }

--- a/val/src/avs_wakeup.c
+++ b/val/src/avs_wakeup.c
@@ -49,10 +49,11 @@ val_wakeup_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   skip_module = val_check_skip_module(AVS_WAKEUP_TEST_NUM_BASE);
   if (skip_module) {
-      val_print(AVS_PRINT_TEST, " USER Override - Skipping all Wakeup tests \n", 0);
-      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
+      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all Wakeup tests \n", 0);
       return AVS_STATUS_SKIP;
   }
+
+  val_print(AVS_PRINT_TEST, "\n      *** Starting Wakeup tests ***  \n", 0);
 
   return status;
 

--- a/val/src/avs_wd.c
+++ b/val/src/avs_wd.c
@@ -46,11 +46,11 @@ val_wd_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(AVS_WD_TEST_NUM_BASE);
   if (status) {
-      val_print(AVS_PRINT_TEST, " USER Override - Skipping all Watchdog tests \n", 0);
-      val_print(AVS_PRINT_TEST, " (Running only specific modules)\n", 0);
+      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all Watchdog tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 
+  val_print(AVS_PRINT_TEST, "\n      *** Starting Watchdog tests ***  \n", 0);
   g_curr_module = 1 << WD_MODULE;
 
   status |= w001_entry(num_pe);


### PR DESCRIPTION
 - Removed module header when no tests are run from the module.
 - Moved module header prints from SbsaAvsMain.c to relevent files in val/ directory.
 - Resolves: #333