### PR TITLE
Bug fixes and infra changes in PCIe tests and module header prints.

### DIFF
--- a/baremetal_app/SbsaAvsMain.c
+++ b/baremetal_app/SbsaAvsMain.c
@@ -24,7 +24,6 @@
 #include "SbsaAvs.h"
 
 uint32_t  g_sbsa_level;
-uint32_t  g_enable_pcie_tests;
 uint32_t  g_print_level;
 uint32_t  g_execute_nist;
 uint32_t  g_print_mmio;
@@ -326,7 +325,6 @@ ShellAppMainsbsa(
 
   g_execute_nist = FALSE;
   g_print_mmio = FALSE;
-  g_enable_pcie_tests = 1;
   g_wakeup_timeout = PLATFORM_OVERRIDE_TIMEOUT;
 
   //
@@ -402,8 +400,8 @@ ShellAppMainsbsa(
     Status |= val_wd_execute_tests(g_sbsa_level, val_pe_get_num());
 
   /***         Starting PCIe tests                   ***/
-  if (g_sbsa_level > 5)
-    Status |= val_pcie_execute_tests(g_enable_pcie_tests, g_sbsa_level, val_pe_get_num());
+  if (g_sbsa_level > 3)
+    Status |= val_pcie_execute_tests(g_sbsa_level, val_pe_get_num());
 
   /*
    * Configure Gic Redistributor and ITS to support
@@ -412,7 +410,8 @@ ShellAppMainsbsa(
   configureGicIts();
 
   /***         Starting Exerciser tests              ***/
-  Status |= val_exerciser_execute_tests(g_sbsa_level);
+  if (g_sbsa_level > 3)
+    Status |= val_exerciser_execute_tests(g_sbsa_level);
 
   /***         Starting MPAM tests                   ***/
   if (g_sbsa_level > 6)

--- a/platform/pal_baremetal/FVP/src/pal_bm_misc.c
+++ b/platform/pal_baremetal/FVP/src/pal_bm_misc.c
@@ -34,8 +34,6 @@ pal_print(char *string, uint64_t data)
 
 }
 
-}
-
 /**
   @brief   Creates a buffer with length equal to size within the
            address range (mem_base, mem_base + mem_size)

--- a/test_pool/pcie/operating_system/test_p017.c
+++ b/test_pool/pcie/operating_system/test_p017.c
@@ -111,7 +111,8 @@ static void payload(void)
     }
 
     if (!valid_cnt) {
-        val_print(AVS_PRINT_DEBUG, "\n       No RP with P2P support detected. Skipping test.", 0);
+        val_print(AVS_PRINT_DEBUG,
+                 "\n       No RCiEP/ RCEC/ iEPs with P2P support detected. Skipping test.", 0);
         val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 3));
         return;
     }

--- a/test_pool/pcie/operating_system/test_p030.c
+++ b/test_pool/pcie/operating_system/test_p030.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -163,7 +163,8 @@ exception_return:
   }
 
   if (test_skip == 1) {
-      val_print(AVS_PRINT_DEBUG, "\n       Found no PCIe Device with MMIO Bar. Skipping test.", 0);
+      val_print(AVS_PRINT_DEBUG,
+               "\n       Found no RCiEP/ RCEC/ iEP type device with MMIO Bar. Skipping test.", 0);
       val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
   }
   else if (test_fails)

--- a/test_pool/pcie/operating_system/test_p035.c
+++ b/test_pool/pcie/operating_system/test_p035.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -173,7 +173,7 @@ payload(void)
 
   if (test_skip == 1) {
       val_print(AVS_PRINT_DEBUG,
-               "\n       No RCiEP/iEP_EP/ EP with FLR Cap found. Skipping test", 0);
+               "\n       No RCiEP/iEP_EP with FLR Cap found. Skipping test", 0);
       val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
   }
   else if (test_fails)

--- a/test_pool/pcie/operating_system/test_p036.c
+++ b/test_pool/pcie/operating_system/test_p036.c
@@ -85,7 +85,7 @@ payload(void)
 
   if (test_skip == 1) {
       val_print(AVS_PRINT_DEBUG,
-                "\n       No iEP found with ARI Capability Support. Skipping test", 0);
+                "\n       No iEP_EP found with ARI Capability Support. Skipping test", 0);
       val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
   }
   else if (test_fails)

--- a/test_pool/pcie/operating_system/test_p040.c
+++ b/test_pool/pcie/operating_system/test_p040.c
@@ -74,7 +74,7 @@ payload(void)
   }
 
   if (test_skip == 1) {
-      val_print(AVS_PRINT_DEBUG, "\n       No iEP_RP/ RP type device found. Skipping test", 0);
+      val_print(AVS_PRINT_DEBUG, "\n       No iEP_RP type device found. Skipping test", 0);
       val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
   }
   else if (test_fails)

--- a/test_pool/pcie/operating_system/test_p044.c
+++ b/test_pool/pcie/operating_system/test_p044.c
@@ -124,7 +124,7 @@ payload(void)
   }
 
   if (test_skip == 1) {
-      val_print(AVS_PRINT_DEBUG, "\n       No DP/ UP/iEP_EP type device found. Skipping test", 0);
+      val_print(AVS_PRINT_DEBUG, "\n       No iEP_EP type device found. Skipping test", 0);
       val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
   }
   else if (fail_cnt)

--- a/test_pool/pcie/operating_system/test_p045.c
+++ b/test_pool/pcie/operating_system/test_p045.c
@@ -96,7 +96,7 @@ payload(void)
   }
 
   if (test_skip == 1) {
-      val_print(AVS_PRINT_DEBUG, "\n       No RP/ iEP_RP type device found. Skipping test", 0);
+      val_print(AVS_PRINT_DEBUG, "\n       No iEP_RP type device found. Skipping test", 0);
       val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
   }
   else if (test_fail)

--- a/test_pool/pcie/operating_system/test_p046.c
+++ b/test_pool/pcie/operating_system/test_p046.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2020-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -133,10 +133,10 @@ payload(void)
   }
 
   if (test_skip) {
-      val_print(AVS_PRINT_DEBUG, "\n       No RP/ iEP_RP type device found. Skipping test", 0);
+      val_print(AVS_PRINT_DEBUG, "\n       No iEP_RP type device found. Skipping test", 0);
       val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
   }
-  if (test_fail)
+  else if (test_fail)
       val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
   else
       val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));

--- a/test_pool/pcie/operating_system/test_p047.c
+++ b/test_pool/pcie/operating_system/test_p047.c
@@ -89,7 +89,7 @@ payload(void)
   }
 
   if (test_skip == 1) {
-      val_print(AVS_PRINT_DEBUG, "\n       No RP/ iEP_RP type device found. Skipping test", 0);
+      val_print(AVS_PRINT_DEBUG, "\n       No iEP_RP type device found. Skipping test", 0);
       val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
   }
   else if (fail_cnt)

--- a/test_pool/pcie/operating_system/test_p048.c
+++ b/test_pool/pcie/operating_system/test_p048.c
@@ -262,7 +262,7 @@ exception_return:
 
   if (test_skip == 1) {
       val_print(AVS_PRINT_DEBUG,
-        "\n       No RP/ iEP_RP type device found with valid Memory Base/Limit Reg.", 0);
+        "\n       No iEP_RP type device found with valid Memory Base/Limit Reg.", 0);
       val_print(AVS_PRINT_DEBUG, "\n       Skipping Test", 0);
       val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
   }

--- a/test_pool/pcie/operating_system/test_p049.c
+++ b/test_pool/pcie/operating_system/test_p049.c
@@ -293,7 +293,7 @@ exception_return:
 
   if (test_skip == 1) {
       val_print(AVS_PRINT_DEBUG,
-        "\n       No RP/ iEP_RP type device found with valid Memory Base/Limit Reg.", 0);
+        "\n       No iEP_RP type device found with valid Memory Base/Limit Reg.", 0);
       val_print(AVS_PRINT_DEBUG, "\n       Skipping Test", 0);
       val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
   }

--- a/uefi_app/SbsaAvsMain.c
+++ b/uefi_app/SbsaAvsMain.c
@@ -809,7 +809,8 @@ ShellAppMainsbsa (
   configureGicIts();
 
   /***         Starting Exerciser tests              ***/
-  Status |= val_exerciser_execute_tests(g_sbsa_level);
+  if (g_sbsa_level > 3)
+    Status |= val_exerciser_execute_tests(g_sbsa_level);
 
   /***         Starting MPAM tests                   ***/
   if (g_sbsa_level > 6)

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -60,6 +60,7 @@ void val_free_shared_mem(void);
 void val_print(uint32_t level, char8_t *string, uint64_t data);
 void val_print_raw(uint64_t uart_address, uint32_t level, char8_t *string,
                                                                 uint64_t data);
+void val_print_test_start(char8_t *string);
 void val_print_test_end(uint32_t status, char8_t *string);
 void val_set_test_data(uint32_t index, uint64_t addr, uint64_t test_data);
 void val_get_test_data(uint32_t index, uint64_t *data0, uint64_t *data1);

--- a/val/src/avs_exerciser.c
+++ b/val/src/avs_exerciser.c
@@ -64,10 +64,10 @@ void val_exerciser_create_info_table(void)
       {
           g_exerciser_info_table.e_info[g_exerciser_info_table.num_exerciser].bdf = Bdf;
           g_exerciser_info_table.e_info[g_exerciser_info_table.num_exerciser++].initialized = 0;
-          val_print(AVS_PRINT_DEBUG, "    exerciser Bdf %x\n", Bdf);
+          val_print(AVS_PRINT_DEBUG, "      exerciser Bdf %x\n", Bdf);
       }
   }
-  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of exerciser cards : %4d \n",
+  val_print(AVS_PRINT_TEST, "      PCIE_INFO: Number of exerciser cards : %4d \n",
                                                              g_exerciser_info_table.num_exerciser);
   return;
 }
@@ -284,11 +284,6 @@ val_exerciser_execute_tests(uint32_t level)
   uint32_t instance;
   uint32_t num_smmu;
 
-  if (level == 3) {
-    val_print(AVS_PRINT_WARN, "Exerciser Sbsa compliance is only from Level %d \n", 4);
-    return AVS_STATUS_SKIP;
-  }
-
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_EXERCISER_TEST_NUM_BASE) {
           val_print(AVS_PRINT_TEST, "\n USER Override - Skipping the Exerciser tests \n", 0);
@@ -314,6 +309,8 @@ val_exerciser_execute_tests(uint32_t level)
     return AVS_STATUS_SKIP;
   }
 
+  val_print(AVS_PRINT_INFO, "\n      Starting Exerciser Setup\n", 0);
+
   val_exerciser_create_info_table();
   num_instances = val_exerciser_get_info(EXERCISER_NUM_CARDS, 0);
 
@@ -330,7 +327,7 @@ val_exerciser_execute_tests(uint32_t level)
   for (instance = 0; instance < num_smmu; ++instance)
       val_smmu_disable(instance);
 
-  val_print(AVS_PRINT_TEST, "\n      *** Starting PCIe Exerciser tests ***  \n", 0);
+  val_print_test_start("PCIe Exerciser");
 
   g_curr_module = 1 << EXERCISER_MODULE;
   status = e001_entry();

--- a/val/src/avs_gic.c
+++ b/val/src/avs_gic.c
@@ -53,7 +53,7 @@ val_gic_execute_tests(uint32_t level, uint32_t num_pe)
       return AVS_STATUS_SKIP;
   }
 
-  val_print(AVS_PRINT_TEST, "\n      *** Starting GIC tests ***  \n", 0);
+  val_print_test_start("GIC");
   g_curr_module = 1 << GIC_MODULE;
 
   status = g001_entry(num_pe);

--- a/val/src/avs_memory.c
+++ b/val/src/avs_memory.c
@@ -52,7 +52,7 @@ val_memory_execute_tests(uint32_t level, uint32_t num_pe)
       return AVS_STATUS_SKIP;
   }
 
-  val_print(AVS_PRINT_TEST, "\n      *** Starting Memory tests ***  \n", 0);
+  val_print_test_start("Memory");
   g_curr_module = 1 << MEM_MAP_MODULE;
 
   status = m001_entry(num_pe);

--- a/val/src/avs_mpam.c
+++ b/val/src/avs_mpam.c
@@ -60,12 +60,11 @@ val_mpam_execute_tests(uint32_t level, uint32_t num_pe)
       return AVS_STATUS_SKIP;
   }
 
-  val_print(AVS_PRINT_TEST, "\n      *** Starting MPAM tests ***  \n", 0);
+  val_print_test_start("MPAM");
   g_curr_module = 1 << MPAM_MODULE;
 
   /* run tests which don't check MPAM MSCs */
-  if (g_sbsa_level > 6)
-      status = mpam001_entry(num_pe);
+  status = mpam001_entry(num_pe);
 
   msc_node_cnt = val_mpam_get_msc_count();
   if (msc_node_cnt == 0) {
@@ -74,14 +73,12 @@ val_mpam_execute_tests(uint32_t level, uint32_t num_pe)
       return AVS_STATUS_SKIP;
   }
 
-  if (g_sbsa_level > 6) {
-      status |= mpam002_entry(num_pe);
-      status |= mpam003_entry(num_pe);
-      status |= mpam004_entry(num_pe);
-      status |= mpam005_entry(num_pe);
-      status |= mpam006_entry(num_pe);
-      val_print_test_end(status, "MPAM");
-  }
+  status |= mpam002_entry(num_pe);
+  status |= mpam003_entry(num_pe);
+  status |= mpam004_entry(num_pe);
+  status |= mpam005_entry(num_pe);
+  status |= mpam006_entry(num_pe);
+  val_print_test_end(status, "MPAM");
 
   return status;
 }

--- a/val/src/avs_nist.c
+++ b/val/src/avs_nist.c
@@ -46,7 +46,7 @@ val_nist_execute_tests(uint32_t level, uint32_t num_pe)
       return AVS_STATUS_SKIP;
   }
 
-  val_print(AVS_PRINT_TEST, "\n      *** Starting NIST tests ***  \n", 0);
+  val_print_test_start("NIST");
   status = n001_entry(num_pe);
 
   val_print_test_end(status, "NIST");

--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -278,15 +278,13 @@ val_pcie_execute_tests(uint32_t level, uint32_t num_pe)
       return AVS_STATUS_SKIP;
   }
 
-  val_print(AVS_PRINT_TEST, "\n      *** Starting PCIe tests ***  \n", 0);
+  val_print_test_start("PCIe");
   g_curr_module = 1 << PCIE_MODULE;
 
   /* Only the test p062 will be run at L4+ with the test number (AVS_PER_TEST_NUM_BASE + 1) */
-  if (level  > 3) {
   #ifndef TARGET_LINUX
     status = p062_entry(num_pe);
   #endif
-  }
 
   if (level > 5) {
 

--- a/val/src/avs_pe.c
+++ b/val/src/avs_pe.c
@@ -58,7 +58,7 @@ val_pe_execute_tests(uint32_t level, uint32_t num_pe)
       return AVS_STATUS_SKIP;
   }
 
-  val_print(AVS_PRINT_TEST, "\n      *** Starting PE tests ***  \n", 0);
+  val_print_test_start("PE");
   g_curr_module = 1 << PE_MODULE;
 
   status |= c001_entry(num_pe);

--- a/val/src/avs_peripherals.c
+++ b/val/src/avs_peripherals.c
@@ -53,7 +53,7 @@ val_peripheral_execute_tests(uint32_t level, uint32_t num_pe)
       return AVS_STATUS_SKIP;
   }
 
-  val_print(AVS_PRINT_TEST, "\n      *** Starting Peripheral tests ***  \n", 0);
+  val_print_test_start("Peripheral");
 
   return status;
 }

--- a/val/src/avs_pmu.c
+++ b/val/src/avs_pmu.c
@@ -59,16 +59,14 @@ val_pmu_execute_tests(uint32_t level, uint32_t num_pe)
       return AVS_STATUS_SKIP;
   }
 
-  val_print(AVS_PRINT_TEST, "\n      *** Starting PMU tests ***  \n", 0);
+  val_print_test_start("PMU");
   g_curr_module = 1 << PMU_MODULE;
 
   /* run tests which don't check PMU nodes */
-  if (g_sbsa_level > 6) {
-      status  = pmu001_entry(num_pe);
-      status |= pmu002_entry(num_pe);
-      status |= pmu003_entry(num_pe);
-      status |= pmu006_entry(num_pe);
-  }
+  status  = pmu001_entry(num_pe);
+  status |= pmu002_entry(num_pe);
+  status |= pmu003_entry(num_pe);
+  status |= pmu006_entry(num_pe);
 
   pmu_node_count = val_pmu_get_info(PMU_NODE_COUNT, 0);
   if (pmu_node_count == 0) {

--- a/val/src/avs_ras.c
+++ b/val/src/avs_ras.c
@@ -70,22 +70,21 @@ val_ras_execute_tests(uint32_t level, uint32_t num_pe)
   /* set default status to AVS_STATUS_FAIL */
   status = AVS_STATUS_FAIL;
 
-  val_print(AVS_PRINT_TEST, "\n      *** Starting RAS tests ***  \n", 0);
+  val_print_test_start("RAS");
 
-  if (g_sbsa_level > 6) {
-      status = ras001_entry(num_pe);
-      status |= ras002_entry(num_pe);
-      status |= ras003_entry(num_pe);
-      status |= ras004_entry(num_pe);
-      status |= ras005_entry(num_pe);
-      status |= ras006_entry(num_pe);
-      status |= ras007_entry(num_pe);
-      status |= ras008_entry(num_pe);
-      status |= ras009_entry(num_pe);
-      status |= ras010_entry(num_pe);
-      status |= ras011_entry(num_pe);
-      status |= ras012_entry(num_pe);
-  }
+  status = ras001_entry(num_pe);
+  status |= ras002_entry(num_pe);
+  status |= ras003_entry(num_pe);
+  status |= ras004_entry(num_pe);
+  status |= ras005_entry(num_pe);
+  status |= ras006_entry(num_pe);
+  status |= ras007_entry(num_pe);
+  status |= ras008_entry(num_pe);
+  status |= ras009_entry(num_pe);
+  status |= ras010_entry(num_pe);
+  status |= ras011_entry(num_pe);
+  status |= ras012_entry(num_pe);
+
   val_print_test_end(status, "RAS");
 
   return status;

--- a/val/src/avs_smmu.c
+++ b/val/src/avs_smmu.c
@@ -77,13 +77,11 @@ val_smmu_execute_tests(uint32_t level, uint32_t num_pe)
     return AVS_STATUS_SKIP;
   }
 
-  val_print(AVS_PRINT_TEST, "\n      *** Starting SMMU tests ***  \n", 0);
+  val_print_test_start("SMMU");
   g_curr_module = 1 << SMMU_MODULE;
 
 #ifndef TARGET_LINUX
-  if (g_sbsa_level > 3) {
-      status = i001_entry(num_pe) ;
-  }
+  status = i001_entry(num_pe) ;
 
   if (g_sbsa_level > 4) {
       status |= i002_entry(num_pe);

--- a/val/src/avs_test_infra.c
+++ b/val/src/avs_test_infra.c
@@ -40,6 +40,23 @@ val_print(uint32_t level, char8_t *string, uint64_t data)
 
 }
 
+/**
+  @brief  This API prints out module header to the output console.
+          1. Caller       - Application layer
+          2. Prerequisite - None.
+
+  @param string  formatted ASCII string
+
+  @return        None
+ **/
+void
+val_print_test_start(char8_t *string)
+{
+  pal_print("\n      *** Starting ", 0);
+  pal_print(string, 0);
+  pal_print(" tests ***  \n", 0);
+}
+
 void
 val_print_test_end(uint32_t status, char8_t *string)
 {

--- a/val/src/avs_timer.c
+++ b/val/src/avs_timer.c
@@ -52,7 +52,7 @@ val_timer_execute_tests(uint32_t level, uint32_t num_pe)
       return AVS_STATUS_SKIP;
   }
 
-  val_print(AVS_PRINT_TEST, "\n      *** Starting Timer tests ***  \n", 0);
+  val_print_test_start("Timer");
 
   return status;
 }

--- a/val/src/avs_wakeup.c
+++ b/val/src/avs_wakeup.c
@@ -53,7 +53,7 @@ val_wakeup_execute_tests(uint32_t level, uint32_t num_pe)
       return AVS_STATUS_SKIP;
   }
 
-  val_print(AVS_PRINT_TEST, "\n      *** Starting Wakeup tests ***  \n", 0);
+  val_print_test_start("Wakeup");
 
   return status;
 

--- a/val/src/avs_wd.c
+++ b/val/src/avs_wd.c
@@ -50,7 +50,7 @@ val_wd_execute_tests(uint32_t level, uint32_t num_pe)
       return AVS_STATUS_SKIP;
   }
 
-  val_print(AVS_PRINT_TEST, "\n      *** Starting Watchdog tests ***  \n", 0);
+  val_print_test_start("Watchdog");
   g_curr_module = 1 << WD_MODULE;
 
   status |= w001_entry(num_pe);

--- a/val/sys_arch_src/gic/its/sbsa_gic_its.c
+++ b/val/sys_arch_src/gic/its/sbsa_gic_its.c
@@ -517,6 +517,8 @@ uint32_t val_its_init(void)
   uint32_t    Status;
   uint32_t    index;
 
+  val_print(AVS_PRINT_INFO, "\n      Initializing GIC ITS \n", 0);
+
   g_cwriter_ptr = (uint32_t *)pal_aligned_alloc(MEM_ALIGN_4K,
                                            sizeof(uint32_t) * (g_gic_its_info->GicNumIts));
 
@@ -557,12 +559,13 @@ uint32_t val_its_init(void)
 
   g_its_setup_done = 1;
 
-  val_print(AVS_PRINT_INFO, "ITS : Info Block \n", 0);
+  val_print(AVS_PRINT_INFO, "      ITS : Info Block \n", 0);
   for (index = 0; index < g_gic_its_info->GicNumIts; index++)
   {
-      val_print(AVS_PRINT_INFO, "GIC ITS Index : %x\n", index);
-      val_print(AVS_PRINT_INFO, "GIC ITS ID : %x\n", g_gic_its_info->GicIts[index].ID);
-      val_print(AVS_PRINT_INFO, "GIC ITS Base : %llx\n\n", g_gic_its_info->GicIts[index].Base);
+      val_print(AVS_PRINT_INFO, "      GIC ITS Index : %x\n", index);
+      val_print(AVS_PRINT_INFO, "      GIC ITS ID : %x\n", g_gic_its_info->GicIts[index].ID);
+      val_print(AVS_PRINT_INFO,
+                    "      GIC ITS Base : %llx\n\n", g_gic_its_info->GicIts[index].Base);
   }
 
   return 0;

--- a/val/sys_arch_src/smmu_v3/smmu_v3.c
+++ b/val/sys_arch_src/smmu_v3/smmu_v3.c
@@ -829,7 +829,7 @@ static uint32_t smmu_probe(smmu_dev_t *smmu)
     smmu->sid_bits = BITFIELD_GET(IDR1_SIDSIZE, data);
     smmu->ssid_bits = BITFIELD_GET(IDR1_SSIDSIZE, data);
 
-    val_print(AVS_PRINT_INFO, " ssid_bits = %d", smmu->ssid_bits);
+    val_print(AVS_PRINT_INFO, "      ssid_bits = %d", smmu->ssid_bits);
     val_print(AVS_PRINT_INFO, " sid_bits = %d\n", smmu->sid_bits);
 
     if (smmu->sid_bits <= STRTAB_SPLIT)
@@ -846,7 +846,7 @@ static uint32_t smmu_probe(smmu_dev_t *smmu)
     smmu->oas = smmu_oas[BITFIELD_GET(IDR5_OAS, data)];
     smmu->ias = get_max(smmu->ias, smmu->oas);
 
-    val_print(AVS_PRINT_INFO, " ias %d-bit ", smmu->ias);
+    val_print(AVS_PRINT_INFO, "      ias %d-bit ", smmu->ias);
     val_print(AVS_PRINT_INFO, "oas %d-bit\n", smmu->oas);
 
     return 1;


### PR DESCRIPTION
 - Added an else condition in test 846 to not overwrite the skip status.
 - Updated print statements for the reason of tests getting skipped in various PCIe tests.
 - Added new val API to print out the module header on
   output console.
 - Removed repetetive level checks in val/src
 - Aligning PCIe baremetal infra with that of UEFI.
 - Formatting changes for hygiene logs.