### PR TITLE
Bug fixes and formatting changes in PCIe tests.

### DIFF
--- a/platform/pal_baremetal/FVP/src/pal_bm_misc.c
+++ b/platform/pal_baremetal/FVP/src/pal_bm_misc.c
@@ -34,8 +34,6 @@ pal_print(char *string, uint64_t data)
 
 }
 
-}
-
 /**
   @brief   Creates a buffer with length equal to size within the
            address range (mem_base, mem_base + mem_size)

--- a/test_pool/pcie/operating_system/test_p017.c
+++ b/test_pool/pcie/operating_system/test_p017.c
@@ -111,7 +111,8 @@ static void payload(void)
     }
 
     if (!valid_cnt) {
-        val_print(AVS_PRINT_DEBUG, "\n       No RP with P2P support detected. Skipping test.", 0);
+        val_print(AVS_PRINT_DEBUG,
+                 "\n       No RCiEP/ RCEC/ iEPs with P2P support detected. Skipping test.", 0);
         val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 3));
         return;
     }

--- a/test_pool/pcie/operating_system/test_p030.c
+++ b/test_pool/pcie/operating_system/test_p030.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -163,7 +163,8 @@ exception_return:
   }
 
   if (test_skip == 1) {
-      val_print(AVS_PRINT_DEBUG, "\n       Found no PCIe Device with MMIO Bar. Skipping test.", 0);
+      val_print(AVS_PRINT_DEBUG,
+               "\n       Found no RCiEP/ RCEC/ iEP type device with MMIO Bar. Skipping test.", 0);
       val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
   }
   else if (test_fails)

--- a/test_pool/pcie/operating_system/test_p035.c
+++ b/test_pool/pcie/operating_system/test_p035.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -173,7 +173,7 @@ payload(void)
 
   if (test_skip == 1) {
       val_print(AVS_PRINT_DEBUG,
-               "\n       No RCiEP/iEP_EP/ EP with FLR Cap found. Skipping test", 0);
+               "\n       No RCiEP/iEP_EP with FLR Cap found. Skipping test", 0);
       val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
   }
   else if (test_fails)

--- a/test_pool/pcie/operating_system/test_p036.c
+++ b/test_pool/pcie/operating_system/test_p036.c
@@ -85,7 +85,7 @@ payload(void)
 
   if (test_skip == 1) {
       val_print(AVS_PRINT_DEBUG,
-                "\n       No iEP found with ARI Capability Support. Skipping test", 0);
+                "\n       No iEP_EP found with ARI Capability Support. Skipping test", 0);
       val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
   }
   else if (test_fails)

--- a/test_pool/pcie/operating_system/test_p040.c
+++ b/test_pool/pcie/operating_system/test_p040.c
@@ -74,7 +74,7 @@ payload(void)
   }
 
   if (test_skip == 1) {
-      val_print(AVS_PRINT_DEBUG, "\n       No iEP_RP/ RP type device found. Skipping test", 0);
+      val_print(AVS_PRINT_DEBUG, "\n       No iEP_RP type device found. Skipping test", 0);
       val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
   }
   else if (test_fails)

--- a/test_pool/pcie/operating_system/test_p044.c
+++ b/test_pool/pcie/operating_system/test_p044.c
@@ -124,7 +124,7 @@ payload(void)
   }
 
   if (test_skip == 1) {
-      val_print(AVS_PRINT_DEBUG, "\n       No DP/ UP/iEP_EP type device found. Skipping test", 0);
+      val_print(AVS_PRINT_DEBUG, "\n       No iEP_EP type device found. Skipping test", 0);
       val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
   }
   else if (fail_cnt)

--- a/test_pool/pcie/operating_system/test_p045.c
+++ b/test_pool/pcie/operating_system/test_p045.c
@@ -96,7 +96,7 @@ payload(void)
   }
 
   if (test_skip == 1) {
-      val_print(AVS_PRINT_DEBUG, "\n       No RP/ iEP_RP type device found. Skipping test", 0);
+      val_print(AVS_PRINT_DEBUG, "\n       No iEP_RP type device found. Skipping test", 0);
       val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
   }
   else if (test_fail)

--- a/test_pool/pcie/operating_system/test_p046.c
+++ b/test_pool/pcie/operating_system/test_p046.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2020-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -133,10 +133,10 @@ payload(void)
   }
 
   if (test_skip) {
-      val_print(AVS_PRINT_DEBUG, "\n       No RP/ iEP_RP type device found. Skipping test", 0);
+      val_print(AVS_PRINT_DEBUG, "\n       No iEP_RP type device found. Skipping test", 0);
       val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
   }
-  if (test_fail)
+  else if (test_fail)
       val_set_status(pe_index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
   else
       val_set_status(pe_index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));

--- a/test_pool/pcie/operating_system/test_p047.c
+++ b/test_pool/pcie/operating_system/test_p047.c
@@ -89,7 +89,7 @@ payload(void)
   }
 
   if (test_skip == 1) {
-      val_print(AVS_PRINT_DEBUG, "\n       No RP/ iEP_RP type device found. Skipping test", 0);
+      val_print(AVS_PRINT_DEBUG, "\n       No iEP_RP type device found. Skipping test", 0);
       val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
   }
   else if (fail_cnt)

--- a/test_pool/pcie/operating_system/test_p048.c
+++ b/test_pool/pcie/operating_system/test_p048.c
@@ -262,7 +262,7 @@ exception_return:
 
   if (test_skip == 1) {
       val_print(AVS_PRINT_DEBUG,
-        "\n       No RP/ iEP_RP type device found with valid Memory Base/Limit Reg.", 0);
+        "\n       No iEP_RP type device found with valid Memory Base/Limit Reg.", 0);
       val_print(AVS_PRINT_DEBUG, "\n       Skipping Test", 0);
       val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
   }

--- a/test_pool/pcie/operating_system/test_p049.c
+++ b/test_pool/pcie/operating_system/test_p049.c
@@ -293,7 +293,7 @@ exception_return:
 
   if (test_skip == 1) {
       val_print(AVS_PRINT_DEBUG,
-        "\n       No RP/ iEP_RP type device found with valid Memory Base/Limit Reg.", 0);
+        "\n       No iEP_RP type device found with valid Memory Base/Limit Reg.", 0);
       val_print(AVS_PRINT_DEBUG, "\n       Skipping Test", 0);
       val_set_status(pe_index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
   }


### PR DESCRIPTION
- Added an else condition in test 846 to not overwrite the skip status.
- Updated print statements for the reason of tests getting skipped in various PCIe tests.