### PR TITLE
pe/os/test_co16.c: Skip MPAM test if it isn't supported

### DIFF
--- a/test_pool/pe/operating_system/test_c016.c
+++ b/test_pool/pe/operating_system/test_c016.c
@@ -39,6 +39,13 @@ static void payload(void)
         return;
     }
 
+    /* Check if PE implements FEAT_MPAM */
+    if (!((VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64PFR0_EL1), 40, 43) > 0) ||
+        (VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64PFR1_EL1), 16, 19) > 0))) {
+            val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+            return;
+    }
+
     /* Find the LLC cache identifier */
     llc_index = val_cache_get_llc_index();
     if (llc_index == CACHE_TABLE_EMPTY) {
@@ -57,13 +64,6 @@ static void payload(void)
     /* Check in the MPAM table which MSC is attached to the LLC */
     msc_node_cnt = val_mpam_get_msc_count();
     val_print(AVS_PRINT_DEBUG, "\n       MSC count = %d", msc_node_cnt);
-
-    /* Check if PE implements FEAT_MPAM */
-    if (!((VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64PFR0_EL1), 40, 43) > 0) ||
-        (VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64PFR1_EL1), 16, 19) > 0))) {
-            val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 02));
-            return;
-    }
 
     if (msc_node_cnt == 0) {
         val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 03));


### PR DESCRIPTION
The MPAM test was checking PPTT flags even if MPAM is not supported. This caused the test to fail when it should be skipped. This change follows the test description in the SBSA Test Scenario document, Test 16 Page 10, where it check MPAM support first. https://github.com/ARM-software/sbsa-acs/blob/master/docs/ Arm_SBSA_Architecture_Compliance_Test_Scenario.pdf