### PR TITLE
Added cache-invalidate operation

### DIFF
--- a/val/src/avs_pe_infra.c
+++ b/val/src/avs_pe_infra.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -178,6 +178,9 @@ val_pe_get_index_mpid(uint64_t mpid)
   entry = g_pe_info_table->pe_info;
 
   while (i > 0) {
+    val_data_cache_ops_by_va((addr_t)&entry->mpidr, INVALIDATE);
+    val_data_cache_ops_by_va((addr_t)&entry->pe_num, INVALIDATE);
+
     if (entry->mpidr == mpid) {
       return entry->pe_num;
     }


### PR DESCRIPTION
#348 : Added cache-invalidate operation
 - Secondary cores directly read g_pe_info_table->pe_info ->mpidr/pe_num without cache-invalidate operation in val_pe_get_index_mpid().