### PR TITLE
Moved ITS Configure to avs_exerciser.c

### DIFF
--- a/baremetal_app/SbsaAvsMain.c
+++ b/baremetal_app/SbsaAvsMain.c
@@ -76,17 +76,6 @@ createGicInfoTable(
 
 }
 
-uint32_t
-configureGicIts(
-)
-{
-  uint32_t Status;
-
-  Status = val_gic_its_configure();
-
-  return Status;
-}
-
 void
 createTimerInfoTable(
 )
@@ -402,12 +391,6 @@ ShellAppMainsbsa(
   /***         Starting PCIe tests                   ***/
   if (g_sbsa_level > 3)
     Status |= val_pcie_execute_tests(g_sbsa_level, val_pe_get_num());
-
-  /*
-   * Configure Gic Redistributor and ITS to support
-   * Generation of LPIs.
-   */
-  configureGicIts();
 
   /***         Starting Exerciser tests              ***/
   if (g_sbsa_level > 3)

--- a/uefi_app/SbsaAvsMain.c
+++ b/uefi_app/SbsaAvsMain.c
@@ -117,17 +117,6 @@ createGicInfoTable (
 }
 
 EFI_STATUS
-configureGicIts (
-)
-{
-  EFI_STATUS Status;
-
-  Status = val_gic_its_configure();
-
-  return Status;
-}
-
-EFI_STATUS
 createTimerInfoTable(
 )
 {
@@ -801,12 +790,6 @@ ShellAppMainsbsa (
   /***         Starting PCIe tests                   ***/
   if (g_sbsa_level > 3)
     Status |= val_pcie_execute_tests(g_sbsa_level, val_pe_get_num());
-
-  /*
-   * Configure Gic Redistributor and ITS to support
-   * Generation of LPIs.
-   */
-  configureGicIts();
 
   /***         Starting Exerciser tests              ***/
   if (g_sbsa_level > 3)

--- a/val/src/avs_exerciser.c
+++ b/val/src/avs_exerciser.c
@@ -319,13 +319,16 @@ val_exerciser_execute_tests(uint32_t level)
       return AVS_STATUS_SKIP;
   }
 
-
+  val_print(AVS_PRINT_INFO, "\n      Initializing SMMU\n", 0);
   num_smmu = val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);
   val_smmu_init();
 
   /* Disable All SMMU's */
   for (instance = 0; instance < num_smmu; ++instance)
       val_smmu_disable(instance);
+
+  val_print(AVS_PRINT_INFO, "\n      Initializing ITS\n", 0);
+  val_gic_its_configure();
 
   val_print_test_start("PCIe Exerciser");
 


### PR DESCRIPTION
Rearranged ITS Setup Call
 - Calling val_gic_its_configure function from val_exerciser_execute_tests as this is being used only for exerciser tests. This reduces the overhead of allocating/setting up ITS.