### PR TITLE
Fix for Issue #320

### DIFF
--- a/baremetal_app/SbsaAvsMain.c
+++ b/baremetal_app/SbsaAvsMain.c
@@ -393,8 +393,7 @@ ShellAppMainsbsa(
     Status |= val_pcie_execute_tests(g_sbsa_level, val_pe_get_num());
 
   /***         Starting Exerciser tests              ***/
-  if (g_sbsa_level > 3)
-    Status |= val_exerciser_execute_tests(g_sbsa_level);
+  Status |= val_exerciser_execute_tests(g_sbsa_level);
 
   /***         Starting MPAM tests                   ***/
   if (g_sbsa_level > 6)

--- a/uefi_app/SbsaAvsMain.c
+++ b/uefi_app/SbsaAvsMain.c
@@ -792,8 +792,7 @@ ShellAppMainsbsa (
     Status |= val_pcie_execute_tests(g_sbsa_level, val_pe_get_num());
 
   /***         Starting Exerciser tests              ***/
-  if (g_sbsa_level > 3)
-    Status |= val_exerciser_execute_tests(g_sbsa_level);
+  Status |= val_exerciser_execute_tests(g_sbsa_level);
 
   /***         Starting MPAM tests                   ***/
   if (g_sbsa_level > 6)


### PR DESCRIPTION
- As e001 is sanity check and not any direct spec rule running it from L3, so that any system with exercisers can have a basic sanity check from L3 onwards