### PR TITLE
Each HandleBuffer needs FreePool

### DIFF
--- a/platform/pal_uefi/include/pal_uefi.h
+++ b/platform/pal_uefi/include/pal_uefi.h
@@ -469,7 +469,8 @@ VOID    *pal_mem_virt_to_phys(VOID *va);
 VOID    *pal_mem_phys_to_virt(UINT64 pa);
 UINT64  pal_memory_get_unpopulated_addr(UINT64 *addr, UINT32 instance);
 
-UINT32 pal_pe_get_num();
+VOID    pal_mem_free(VOID *buffer);
+UINT32  pal_pe_get_num();
 
 /**
   @brief  Instance of system pmu info

--- a/platform/pal_uefi/src/pal_pcie.c
+++ b/platform/pal_uefi/src/pal_pcie.c
@@ -155,6 +155,7 @@ pal_pcie_io_read_cfg(UINT32 Bdf, UINT32 offset, UINT32 *data)
       Pci->GetLocation (Pci, &Seg, &Bus, &Dev, &Func);
       if (InputSeg == Seg && InputBus == Bus && InputDev == Dev && InputFunc == Func) {
           Status = Pci->Pci.Read (Pci, EfiPciIoWidthUint32, offset, 1, data);
+          pal_mem_free(HandleBuffer);
           if (!EFI_ERROR (Status))
             return 0;
           else
@@ -162,6 +163,8 @@ pal_pcie_io_read_cfg(UINT32 Bdf, UINT32 offset, UINT32 *data)
       }
     }
   }
+
+  pal_mem_free(HandleBuffer);
   return PCIE_NO_MAPPING;
 }
 
@@ -207,6 +210,8 @@ pal_pcie_io_write_cfg(UINT32 Bdf, UINT32 offset, UINT32 data)
       }
     }
   }
+
+  pal_mem_free(HandleBuffer);
 }
 
 /**
@@ -243,6 +248,7 @@ pal_pcie_bar_mem_read(UINT32 Bdf, UINT64 address, UINT32 *data)
     if (!EFI_ERROR (Status)) {
       if (Pci->SegmentNumber == InputSeg) {
           Status = Pci->Mem.Read (Pci, EfiPciIoWidthUint32, address, 1, data);
+          pal_mem_free(HandleBuffer);
           if (!EFI_ERROR (Status))
             return 0;
           else
@@ -250,6 +256,8 @@ pal_pcie_bar_mem_read(UINT32 Bdf, UINT64 address, UINT32 *data)
       }
     }
   }
+
+  pal_mem_free(HandleBuffer);
   return PCIE_NO_MAPPING;
 }
 
@@ -288,6 +296,7 @@ pal_pcie_bar_mem_write(UINT32 Bdf, UINT64 address, UINT32 data)
     if (!EFI_ERROR (Status)) {
       if (Pci->SegmentNumber == InputSeg) {
           Status = Pci->Mem.Write (Pci, EfiPciIoWidthUint32, address, 1, &data);
+          pal_mem_free(HandleBuffer);
           if (!EFI_ERROR (Status))
             return 0;
           else
@@ -295,6 +304,8 @@ pal_pcie_bar_mem_write(UINT32 Bdf, UINT64 address, UINT32 data)
       }
     }
   }
+
+  pal_mem_free(HandleBuffer);
   return PCIE_NO_MAPPING;
 }
 

--- a/platform/pal_uefi/src/pal_pcie_enumeration.c
+++ b/platform/pal_uefi/src/pal_pcie_enumeration.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2019, 2021-2022 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019, 2021-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -114,14 +114,17 @@ palPcieGetBdf(UINT32 ClassCode, UINT32 StartBdf)
               if (Hdr->ClassCode[1] == ((ClassCode >> 8) & 0xFF)) {
                  /* Found our device */
                  /* Return the BDF   */
+                 pal_mem_free(HandleBuffer);
                  return (UINT32)(PCIE_CREATE_BDF(Seg, Bus, Dev, Func));
               }
             }
-           }
-         }
-       }
-     }
-   }
+          }
+        }
+      }
+    }
+  }
+
+  pal_mem_free(HandleBuffer);
   return 0;
 }
 
@@ -188,6 +191,7 @@ palPcieGetBase(UINT32 bdf, UINT32 bar_index)
           Status = Pci->Pci.Read (Pci, EfiPciIoWidthUint32, 0, sizeof (PciHeader)/sizeof (UINT32), &PciHeader);
           if (!EFI_ERROR (Status)) {
             Device = &PciHeader.Device.Device;
+            pal_mem_free(HandleBuffer);
             if ((((Device->Bar[bar_index]) >> BAR_MDT_SHIFT) & BAR_MDT_MASK) == BITS_64)
             {
                 bar_value = Device->Bar[bar_index + 1];
@@ -203,6 +207,7 @@ palPcieGetBase(UINT32 bdf, UINT32 bar_index)
     }
   }
 
+  pal_mem_free(HandleBuffer);
   return 0;
 }
 


### PR DESCRIPTION
- Each HandleBuffer allocated by LocateHandleBuffer() needs a FreePool(HandleBuffer) to free the memory avoid any memory leaks
- Freed HandleBuffer in the API's that allocated the same using LocateHandleBuffer()