### PR TITLE
ATS support check for Root Complex

### DIFF
--- a/val/include/sbsa_avs_iovirt.h
+++ b/val/include/sbsa_avs_iovirt.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,5 +25,6 @@ int val_iovirt_get_device_info(uint32_t rid, uint32_t segment, uint32_t *device_
 uint64_t val_iovirt_get_pcie_rc_info(PCIE_RC_INFO_e type, uint32_t index);
 uint64_t val_iovirt_get_named_comp_info(NAMED_COMP_INFO_e type, uint32_t index);
 uint64_t val_iovirt_get_pmcg_info(PMCG_INFO_e type, uint32_t index);
+uint32_t val_iovirt_get_rc_index(uint32_t rc_seg_num);
 
 #endif

--- a/val/src/avs_iovirt.c
+++ b/val/src/avs_iovirt.c
@@ -141,6 +141,40 @@ val_iovirt_get_pcie_rc_info(PCIE_RC_INFO_e type, uint32_t index)
 
 }
 
+uint32_t
+val_iovirt_get_rc_index(uint32_t rc_seg_num)
+{
+  uint32_t i, j = 0;
+  IOVIRT_BLOCK *block;
+
+  if (g_iovirt_info_table == NULL)
+  {
+      val_print(AVS_PRINT_ERR, "GET_PCIe_RC_INFO: iovirt info table is not created \n", 0);
+      return 0;
+  }
+
+  /* Go through the table to reach a RC with the segment number */
+  block = &g_iovirt_info_table->blocks[0];
+  for (i = 0; i < g_iovirt_info_table->num_blocks; i++, block = IOVIRT_NEXT_BLOCK(block))
+  {
+      if (block->type == IOVIRT_NODE_PCI_ROOT_COMPLEX)
+      {
+          if (block->data.rc.segment == rc_seg_num)
+          {
+             break;
+          }
+          j++;
+      }
+  }
+  if (i >=  g_iovirt_info_table->num_blocks)
+  {
+      val_print(AVS_PRINT_ERR, "GET_PCIe_RC_INFO: segemnt (%d) is not valid \n", rc_seg_num);
+      return AVS_INVALID_INDEX;
+  }
+  return j;
+
+}
+
 /**
   @brief   This API is a single point of entry to retrieve
            Named component info stored in the iovirt info table.


### PR DESCRIPTION
- At Transaction Layer Packet (TLP) level, the ATS packets are handled differently compared to a normal TLP packet.
- If a Root Complex does not support ATS and receives an ATS packet, it may process it incorrectly, leading to potential errors.
- The ACPI table description of "ats_attr" provides the ats information of the RC.
- To ensure a reliable test, it is advisable to retrieve the "ats_attr" information from the "IOVIRT_RC_INFO_BLOCK" and proceed or skip the test accordingly.