### PR TITLE
Enhancements to -t option

### DIFF
--- a/val/src/avs_exerciser.c
+++ b/val/src/avs_exerciser.c
@@ -286,7 +286,7 @@ val_exerciser_execute_tests(uint32_t level)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_EXERCISER_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_TEST, "\n USER Override - Skipping the Exerciser tests \n", 0);
+          val_print(AVS_PRINT_INFO, "\n USER Override - Skipping the Exerciser tests \n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -294,7 +294,7 @@ val_exerciser_execute_tests(uint32_t level)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(AVS_EXERCISER_TEST_NUM_BASE);
   if (status) {
-    val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all Exerciser tests \n", 0);
+    val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all Exerciser tests \n", 0);
     return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_gic.c
+++ b/val/src/avs_gic.c
@@ -40,7 +40,7 @@ val_gic_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_GIC_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_TEST, "      USER Override - Skipping all GIC tests \n", 0);
+          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all GIC tests \n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -49,7 +49,7 @@ val_gic_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   module_skip = val_check_skip_module(AVS_GIC_TEST_NUM_BASE);
   if (module_skip) {
-      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all GIC tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all GIC tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_memory.c
+++ b/val/src/avs_memory.c
@@ -40,7 +40,7 @@ val_memory_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0 ; i < g_num_skip ; i++) {
       if (g_skip_test_num[i] == AVS_MEM_MAP_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_TEST, "      USER Override - Skipping all memory tests \n", 0);
+          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all memory tests \n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -48,7 +48,7 @@ val_memory_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in the current module with user override*/
   status = val_check_skip_module(AVS_MEM_MAP_TEST_NUM_BASE);
   if (status) {
-      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all memory tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all memory tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_mpam.c
+++ b/val/src/avs_mpam.c
@@ -41,7 +41,7 @@ val_mpam_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_MPAM_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_TEST, "      USER Override - Skipping all MPAM tests \n", 0);
+          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all MPAM tests \n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -49,7 +49,7 @@ val_mpam_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in the current module with user override*/
   skip_module = val_check_skip_module(AVS_MPAM_TEST_NUM_BASE);
   if (skip_module) {
-      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all MPAM tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all MPAM tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_nist.c
+++ b/val/src/avs_nist.c
@@ -34,7 +34,7 @@ val_nist_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_NIST_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_TEST, "      USER Override - Skipping all NIST tests \n", 0);
+          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all NIST tests \n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -42,7 +42,7 @@ val_nist_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(AVS_NIST_TEST_NUM_BASE);
   if (status) {
-      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all NIST tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all NIST tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -290,7 +290,7 @@ val_pcie_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_PCIE_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all PCIe tests \n", 0);
+          val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all PCIe tests \n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -298,7 +298,7 @@ val_pcie_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(AVS_PCIE_TEST_NUM_BASE);
   if (status) {
-      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all PCIe tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all PCIe tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_pe.c
+++ b/val/src/avs_pe.c
@@ -46,7 +46,7 @@ val_pe_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_PE_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all PE tests \n", 0);
+          val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all PE tests \n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -54,7 +54,7 @@ val_pe_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(AVS_PE_TEST_NUM_BASE);
   if (status) {
-      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all PE tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all PE tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_peripherals.c
+++ b/val/src/avs_peripherals.c
@@ -41,7 +41,7 @@ val_peripheral_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_PER_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_TEST, "      USER Override - Skipping all Peripheral tests \n", 0);
+          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all Peripheral tests \n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -49,7 +49,7 @@ val_peripheral_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   skip_module = val_check_skip_module(AVS_PER_TEST_NUM_BASE);
   if (skip_module) {
-      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all Peripheral tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all Peripheral tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_pmu.c
+++ b/val/src/avs_pmu.c
@@ -40,7 +40,7 @@ val_pmu_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_PMU_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_TEST, "      USER Override - Skipping all PMU tests \n", 0);
+          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all PMU tests \n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -48,7 +48,7 @@ val_pmu_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   skip_module = val_check_skip_module(AVS_PMU_TEST_NUM_BASE);
   if (skip_module) {
-      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all PMU tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all PMU tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_ras.c
+++ b/val/src/avs_ras.c
@@ -40,7 +40,7 @@ val_ras_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_RAS_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_TEST, "\n      USER Override - Skipping all RAS tests \n", 0);
+          val_print(AVS_PRINT_INFO, "\n      USER Override - Skipping all RAS tests \n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -48,7 +48,7 @@ val_ras_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   skip_module = val_check_skip_module(AVS_RAS_TEST_NUM_BASE);
   if (skip_module) {
-      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all RAS tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all RAS tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_smmu.c
+++ b/val/src/avs_smmu.c
@@ -59,7 +59,7 @@ val_smmu_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_SMMU_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_TEST, "      USER Override - Skipping all SMMU tests \n", 0);
+          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all SMMU tests \n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -67,7 +67,7 @@ val_smmu_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(AVS_SMMU_TEST_NUM_BASE);
   if (status) {
-      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all SMMU tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all SMMU tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_status.c
+++ b/val/src/avs_status.c
@@ -18,6 +18,7 @@
 #include "include/sbsa_avs_val.h"
 #include "include/sbsa_avs_common.h"
 
+extern uint32_t g_override_skip;
 
 /**
   @brief  Parse the input status and print the appropriate information to console
@@ -31,6 +32,10 @@
 void
 val_report_status(uint32_t index, uint32_t status, char8_t *ruleid)
 {
+
+  /* Test stays quiet if it is overridden by any of the user options */
+  if (!g_override_skip)
+    return;
 
   if (IS_TEST_FAIL(status)) {
       val_print(AVS_PRINT_ERR, "\n       Failed on PE - %4d ", index);

--- a/val/src/avs_test_infra.c
+++ b/val/src/avs_test_infra.c
@@ -19,6 +19,8 @@
 #include "include/sbsa_avs_pe.h"
 #include "include/sbsa_avs_common.h"
 
+uint32_t g_override_skip;
+
 /**
   @brief  This API calls PAL layer to print a formatted string
           to the output console.
@@ -295,22 +297,16 @@ val_initialize_test(uint32_t test_num, char8_t *desc, uint32_t num_pe, uint32_t 
 {
 
   uint32_t i;
-  uint32_t override_skip = 0;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
-  val_print(AVS_PRINT_ERR, "%4d : ", test_num); //Always print this
-  val_print(AVS_PRINT_TEST, desc, 0);
-  val_report_status(0, SBSA_AVS_START(level, test_num), ruleid);
-  val_pe_initialize_default_exception_handler(val_pe_default_esr);
-
-  g_sbsa_tests_total++;
+  g_override_skip = 0;
 
   for (i = 0; i < num_pe; i++)
       val_set_status(i, RESULT_PENDING(level, test_num));
 
+  /* Skip the test if it one of the -skip option parameters */
   for (i = 0; i < g_num_skip ; i++) {
       if (g_skip_test_num[i] == test_num) {
-          val_print(AVS_PRINT_TEST, "\n       USER OVERRIDE  - Skip Test        ", 0);
           val_set_status(index, RESULT_SKIP(g_sbsa_level, test_num, 0));
           return AVS_STATUS_SKIP;
       }
@@ -319,7 +315,7 @@ val_initialize_test(uint32_t test_num, char8_t *desc, uint32_t num_pe, uint32_t 
   /* Don't skip if test_num is one of the -t option parameters */
   for (i = 0; i < g_num_tests; i++) {
       if (test_num == g_execute_tests[i]) {
-          override_skip++;
+          g_override_skip++;
       }
   }
 
@@ -328,15 +324,23 @@ val_initialize_test(uint32_t test_num, char8_t *desc, uint32_t num_pe, uint32_t 
       if ((test_num - g_execute_modules[i]) > 0 &&
           (test_num - g_execute_modules[i]) < 100)
       {
-          override_skip++;
+          g_override_skip++;
       }
   }
 
-  if ((!override_skip) && (g_num_tests || g_num_modules)) {
-      val_print(AVS_PRINT_TEST, "\n       USER OVERRIDE VIA SPECIFIC TESTS - Skip Test      ", 0);
+  if ((!g_override_skip) && (g_num_tests || g_num_modules)) {
       val_set_status(index, RESULT_SKIP(g_sbsa_level, test_num, 0));
       return AVS_STATUS_SKIP;
   }
+
+  g_override_skip = 1;
+
+  val_print(AVS_PRINT_ERR, "%4d : ", test_num);
+  val_print(AVS_PRINT_TEST, desc, 0);
+  val_report_status(0, SBSA_AVS_START(level, test_num), ruleid);
+  val_pe_initialize_default_exception_handler(val_pe_default_esr);
+
+  g_sbsa_tests_total++;
 
   return AVS_STATUS_PASS;
 }

--- a/val/src/avs_timer.c
+++ b/val/src/avs_timer.c
@@ -40,7 +40,7 @@ val_timer_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_TIMER_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_TEST, "      USER Override - Skipping all Timer tests \n", 0);
+          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all Timer tests \n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -48,7 +48,7 @@ val_timer_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   skip_module = val_check_skip_module(AVS_TIMER_TEST_NUM_BASE);
   if (skip_module) {
-      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all Timer tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all Timer tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_wakeup.c
+++ b/val/src/avs_wakeup.c
@@ -41,7 +41,7 @@ val_wakeup_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_WAKEUP_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_TEST, "      USER Override - Skipping all Wakeup tests \n", 0);
+          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all Wakeup tests \n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -49,7 +49,7 @@ val_wakeup_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   skip_module = val_check_skip_module(AVS_WAKEUP_TEST_NUM_BASE);
   if (skip_module) {
-      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all Wakeup tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all Wakeup tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_wd.c
+++ b/val/src/avs_wd.c
@@ -38,7 +38,7 @@ val_wd_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_WD_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_TEST, "      USER Override - Skipping all Watchdog tests \n", 0);
+          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all Watchdog tests \n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -46,7 +46,7 @@ val_wd_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(AVS_WD_TEST_NUM_BASE);
   if (status) {
-      val_print(AVS_PRINT_TEST, "\n USER Override - Skipping all Watchdog tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all Watchdog tests \n", 0);
       return AVS_STATUS_SKIP;
   }
 


### PR DESCRIPTION
 - Resolves: #381
 - No console prints for tests not mentioned in -t option.
 - Total test count aligns with the tests that are actually being run with user override options.