### PR TITLE
Fix for print the number of ecam

### DIFF
--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -553,7 +553,8 @@ val_pcie_create_info_table(uint64_t *pcie_info_table)
 
   pal_pcie_create_info_table(g_pcie_info_table);
 
-  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of ECAM regions    :    %lx \n", val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0));
+  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of ECAM regions    :    %ld \n",
+                                      val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0));
 
   val_pcie_enumerate();
 


### PR DESCRIPTION
- The number of ECAM regions is printed in hex. Changed it to %ld to maintain consistency in print messages