### PR TITLE
MPAM Resource Select change added

### DIFF
--- a/platform/pal_uefi/include/pal_mpam.h
+++ b/platform/pal_uefi/include/pal_mpam.h
@@ -29,7 +29,8 @@ typedef struct {
 
 typedef struct {
     UINT16 length;
-    UINT16 reserved;
+    UINT8  InterfaceType;
+    UINT8  reserved;
     UINT32 identifier;
     UINT64 base_address;
     UINT32 mmio_size;


### PR DESCRIPTION
MPAM Resource Select change added

 - MPAM Table Structure changed according to MPAM v2.0 ACPI Table
 - Now the test is updated to change RIS_SEL based on the rsrc_index