### PR TITLE
Removing unwanted whitespaces in console prints

### DIFF
--- a/baremetal_app/SbsaAvsMain.c
+++ b/baremetal_app/SbsaAvsMain.c
@@ -329,15 +329,15 @@ ShellAppMainsbsa(
       g_sbsa_level = SBSA_MAX_LEVEL_SUPPORTED;
   }
 
-  val_print(AVS_PRINT_TEST, "\n\n SBSA Architecture Compliance Suite \n", 0);
+  val_print(AVS_PRINT_TEST, "\n\n SBSA Architecture Compliance Suite\n", 0);
   val_print(AVS_PRINT_TEST, "    Version %d.", SBSA_ACS_MAJOR_VER);
   val_print(AVS_PRINT_TEST, "%d.", SBSA_ACS_MINOR_VER);
-  val_print(AVS_PRINT_TEST, "%d  \n", SBSA_ACS_SUBMINOR_VER);
+  val_print(AVS_PRINT_TEST, "%d\n", SBSA_ACS_SUBMINOR_VER);
 
   val_print(AVS_PRINT_TEST, "\n Starting tests for level %2d", g_sbsa_level);
   val_print(AVS_PRINT_TEST, " (Print level is %2d)\n\n", g_print_level);
 
-  val_print(AVS_PRINT_TEST, " Creating Platform Information Tables \n", 0);
+  val_print(AVS_PRINT_TEST, " Creating Platform Information Tables\n", 0);
 
   g_skip_test_num   = &g_skip_array[0];
   if (g_num_tests) {
@@ -434,17 +434,17 @@ ShellAppMainsbsa(
     Status |= val_ras_execute_tests(g_sbsa_level, val_pe_get_num());
 
 print_test_status:
-  val_print(AVS_PRINT_TEST, "\n     ------------------------------------------------------- \n", 0);
+  val_print(AVS_PRINT_TEST, "\n     -------------------------------------------------------\n", 0);
   val_print(AVS_PRINT_TEST, "     Total Tests run  = %4d;", g_sbsa_tests_total);
   val_print(AVS_PRINT_TEST, "  Tests Passed  = %4d", g_sbsa_tests_pass);
   val_print(AVS_PRINT_TEST, "  Tests Failed = %4d\n", g_sbsa_tests_fail);
-  val_print(AVS_PRINT_TEST, "     --------------------------------------------------------- \n", 0);
+  val_print(AVS_PRINT_TEST, "     ---------------------------------------------------------\n", 0);
 
   freeSbsaAvsMem();
 
   val_print(AVS_PRINT_TEST, "\n      **  For complete SBSA test coverage, it is ", 0);
-  val_print(AVS_PRINT_TEST, "\n            necessary to also run the BSA test    ** \n\n", 0);
-  val_print(AVS_PRINT_TEST, "\n      *** SBSA tests complete. Reset the system. *** \n\n", 0);
+  val_print(AVS_PRINT_TEST, "\n            necessary to also run the BSA test    **\n\n", 0);
+  val_print(AVS_PRINT_TEST, "\n      *** SBSA tests complete. Reset the system. ***\n\n", 0);
 
 
   val_pe_context_restore(AA64WriteSp(g_stack_pointer));

--- a/linux_app/sbsa-acs-app/sbsa_app_main.c
+++ b/linux_app/sbsa-acs-app/sbsa_app_main.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -119,35 +119,35 @@ main (int argc, char **argv)
     }
 
 
-    printf ("\n ************ SBSA Architecture Compliance Suite ********* \n");
+    printf ("\n ************ SBSA Architecture Compliance Suite *********\n");
     printf ("                        Version %d.%d.%d\n", SBSA_APP_VERSION_MAJOR,
             SBSA_APP_VERSION_MINOR, SBSA_APP_VERSION_SUBMINOR);
 
 
     printf ("\n Starting tests for level %2d (Print level is %2d)\n\n", g_sbsa_level, g_print_level);
 
-    printf (" Gathering system information.... \n");
+    printf (" Gathering system information....\n");
     status = initialize_test_environment(g_print_level);
     if (status) {
-        printf ("Cannot initialize test environment. Exiting.... \n");
+        printf ("Cannot initialize test environment. Exiting....\n");
         return 0;
     }
 
     if (g_sbsa_level > 6)
     {
-        printf("\n      *** Starting SMMU tests ***  \n");
+        printf("\n      *** Starting SMMU tests ***\n");
         execute_tests_smmu(1, g_sbsa_level, g_print_level);
     }
-    printf("\n      *** Starting PCIe tests ***  \n");
+    printf("\n      *** Starting PCIe tests ***\n");
     execute_tests_pcie(1, g_sbsa_level, g_print_level);
 
     if (run_exerciser) {
-        printf("\n      *** PCIe Exerciser tests only runs on UEFI ***  \n");
+        printf("\n      *** PCIe Exerciser tests only runs on UEFI ***\n");
         //execute_tests_exerciser(1, g_sbsa_level, g_print_level);
     }
     printf("\n                    **  For complete SBSA test coverage, it is ");
     printf("\n                          necessary to also run the BSA test  **\n\n");
-    printf("\n                    *** SBSA tests complete *** \n\n");
+    printf("\n                    *** SBSA tests complete ***\n\n");
 
     cleanup_test_environment();
 

--- a/linux_app/sbsa-acs-app/sbsa_app_main.c
+++ b/linux_app/sbsa-acs-app/sbsa_app_main.c
@@ -119,17 +119,17 @@ main (int argc, char **argv)
     }
 
 
-    printf ("\n ************ SBSA Architecture Compliance Suite *********\n");
-    printf ("                        Version %d.%d.%d\n", SBSA_APP_VERSION_MAJOR,
+    printf("\n ************ SBSA Architecture Compliance Suite *********\n");
+    printf("                        Version %d.%d.%d\n", SBSA_APP_VERSION_MAJOR,
             SBSA_APP_VERSION_MINOR, SBSA_APP_VERSION_SUBMINOR);
 
 
-    printf ("\n Starting tests for level %2d (Print level is %2d)\n\n", g_sbsa_level, g_print_level);
+    printf("\n Starting tests for level %2d (Print level is %2d)\n\n", g_sbsa_level, g_print_level);
 
-    printf (" Gathering system information....\n");
+    printf(" Gathering system information....\n");
     status = initialize_test_environment(g_print_level);
     if (status) {
-        printf ("Cannot initialize test environment. Exiting....\n");
+        printf("Cannot initialize test environment. Exiting....\n");
         return 0;
     }
 

--- a/linux_app/sbsa-acs-app/sbsa_drv_intf.c
+++ b/linux_app/sbsa-acs-app/sbsa_drv_intf.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,12 +46,12 @@ call_drv_get_status(unsigned long int *arg0, unsigned long int *arg1, unsigned l
 
     if (NULL == fd)
     {
-        printf("fopen failed \n");
+        printf("fopen failed\n");
         return 1;
     }
   fread(&test_params,1,sizeof(test_params),fd);
 
-  //printf("read back value is %x %lx \n", test_params.api_num, test_params.arg1);
+  //printf("read back value is %x %lx\n", test_params.api_num, test_params.arg1);
 
   fclose(fd);
 
@@ -89,7 +89,7 @@ call_drv_init_test_env(unsigned int print_level)
 
     if (NULL == fd)
     {
-        printf("fopen failed \n");
+        printf("fopen failed\n");
         return 1;
     }
 
@@ -116,7 +116,7 @@ call_drv_clean_test_env()
 
     if (NULL == fd)
     {
-        printf("fopen failed \n");
+        printf("fopen failed\n");
         return 1;
     }
 
@@ -142,7 +142,7 @@ call_drv_execute_test(unsigned int api_num, unsigned int num_pe,
 
     if (NULL == fd)
     {
-        printf("fopen failed \n");
+        printf("fopen failed\n");
         return 1;
     }
 
@@ -169,7 +169,7 @@ call_update_skip_list(unsigned int api_num, int *p_skip_test_num)
 
     if (NULL == fd)
     {
-        printf("fopen failed \n");
+        printf("fopen failed\n");
         return 1;
     }
 
@@ -201,7 +201,7 @@ int read_from_proc_sbsa_msg() {
   fd = fopen("/proc/sbsa_msg", "r");
 
   if (NULL == fd) {
-    printf("fopen failed \n");
+    printf("fopen failed\n");
     return 1;
   }
 

--- a/platform/pal_baremetal/common/src/pal_hmat.c
+++ b/platform/pal_baremetal/common/src/pal_hmat.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -64,7 +64,7 @@ void pal_hmat_create_info_table(HMAT_INFO_TABLE *HmatTable)
   HMAT_BW_ENTRY *curr_info_entry;
 
   if (HmatTable == NULL) {
-      print(AVS_PRINT_ERR, " Unable to create HMAT info table, input pointer is NULL \n");
+      print(AVS_PRINT_ERR, " Unable to create HMAT info table, input pointer is NULL\n");
       return;
   }
 

--- a/platform/pal_baremetal/common/src/pal_misc.c
+++ b/platform/pal_baremetal/common/src/pal_misc.c
@@ -50,7 +50,7 @@ pal_mmio_read8(uint64_t addr)
 
   data = (*(volatile uint8_t *)addr);
   if (g_print_mmio || (g_curr_module & g_enable_module))
-      print(AVS_PRINT_INFO, " pal_mmio_read8 Address = %llx  Data = %lx \n", addr, data);
+      print(AVS_PRINT_INFO, " pal_mmio_read8 Address = %llx  Data = %lx\n", addr, data);
 
   return data;
 }
@@ -70,7 +70,7 @@ pal_mmio_read16(uint64_t addr)
 
   data = (*(volatile uint16_t *)addr);
   if (g_print_mmio || (g_curr_module & g_enable_module))
-      print(AVS_PRINT_INFO, " pal_mmio_read16 Address = %llx  Data = %lx \n", addr, data);
+      print(AVS_PRINT_INFO, " pal_mmio_read16 Address = %llx  Data = %lx\n", addr, data);
 
   return data;
 }
@@ -90,7 +90,7 @@ pal_mmio_read64(uint64_t addr)
 
   data = (*(volatile uint64_t *)addr);
   if (g_print_mmio || (g_curr_module & g_enable_module))
-      print(AVS_PRINT_INFO, " pal_mmio_read64 Address = %llx  Data = %llx \n", addr, data);
+      print(AVS_PRINT_INFO, " pal_mmio_read64 Address = %llx  Data = %llx\n", addr, data);
 
   return data;
 }
@@ -116,7 +116,7 @@ pal_mmio_read(uint64_t addr)
 
   data = (*(volatile uint32_t *)addr);
   if (g_print_mmio || (g_curr_module & g_enable_module))
-      print(AVS_PRINT_INFO, " pal_mmio_read Address = %8x  Data = %x \n", addr, data);
+      print(AVS_PRINT_INFO, " pal_mmio_read Address = %8x  Data = %x\n", addr, data);
 
   return data;
 
@@ -135,7 +135,7 @@ void
 pal_mmio_write8(uint64_t addr, uint8_t data)
 {
   if (g_print_mmio || (g_curr_module & g_enable_module))
-      print(AVS_PRINT_INFO, " pal_mmio_write8 Address = %llx  Data = %lx \n", addr, data);
+      print(AVS_PRINT_INFO, " pal_mmio_write8 Address = %llx  Data = %lx\n", addr, data);
 
   *(volatile uint8_t *)addr = data;
 }
@@ -153,7 +153,7 @@ void
 pal_mmio_write16(uint64_t addr, uint16_t data)
 {
   if (g_print_mmio || (g_curr_module & g_enable_module))
-      print(AVS_PRINT_INFO, " pal_mmio_write16 Address = %llx  Data = %lx \n", addr, data);
+      print(AVS_PRINT_INFO, " pal_mmio_write16 Address = %llx  Data = %lx\n", addr, data);
 
   *(volatile uint16_t *)addr = data;
 }
@@ -171,7 +171,7 @@ void
 pal_mmio_write64(uint64_t addr, uint64_t data)
 {
   if (g_print_mmio || (g_curr_module & g_enable_module))
-      print(AVS_PRINT_INFO, " pal_mmio_write64 Address = %llx  Data = %llx \n", addr, data);
+      print(AVS_PRINT_INFO, " pal_mmio_write64 Address = %llx  Data = %llx\n", addr, data);
 
   *(volatile uint64_t *)addr = data;
 }
@@ -190,12 +190,12 @@ pal_mmio_write(uint64_t addr, uint32_t data)
 {
 
   if (addr & 0x3) {
-      print(AVS_PRINT_WARN, "\n  Error-Input address is not aligned. Masking the last 2 bits \n");
+      print(AVS_PRINT_WARN, "\n  Error-Input address is not aligned. Masking the last 2 bits\n");
       addr = addr & ~(0x3);  //make sure addr is aligned to 4 bytes
   }
 
   if (g_print_mmio || (g_curr_module & g_enable_module))
-      print(AVS_PRINT_INFO, " pal_mmio_write Address = %8x  Data = %x \n", addr, data);
+      print(AVS_PRINT_INFO, " pal_mmio_write Address = %8x  Data = %x\n", addr, data);
 
     *(volatile uint32_t *)addr = data;
 }

--- a/platform/pal_baremetal/common/src/pal_mpam.c
+++ b/platform/pal_baremetal/common/src/pal_mpam.c
@@ -118,7 +118,7 @@ pal_mpam_create_info_table(MPAM_INFO_TABLE *MpamTable)
   MPAM_MSC_NODE *curr_entry;
 
   if (MpamTable == NULL) {
-      print(AVS_PRINT_ERR, " Input MPAM Table Pointer is NULL \n");
+      print(AVS_PRINT_ERR, " Input MPAM Table Pointer is NULL\n");
       return;
   }
 
@@ -168,7 +168,7 @@ pal_srat_create_info_table(SRAT_INFO_TABLE *SratTable)
   uint32_t Index, mem_index = 0, gicc_index = 0;
 
   if (SratTable == NULL) {
-      print(AVS_PRINT_ERR, " Input SRAT Table Pointer is NULL \n");
+      print(AVS_PRINT_ERR, " Input SRAT Table Pointer is NULL\n");
       return;
   }
 

--- a/platform/pal_baremetal/common/src/pal_pcie.c
+++ b/platform/pal_baremetal/common/src/pal_pcie.c
@@ -40,14 +40,14 @@ pal_pcie_create_info_table(PCIE_INFO_TABLE *PcieTable)
   uint32_t i = 0;
 
   if (PcieTable == NULL) {
-    print(AVS_PRINT_ERR, "Input PCIe Table Pointer is NULL. Cannot create PCIe INFO \n");
+    print(AVS_PRINT_ERR, "Input PCIe Table Pointer is NULL. Cannot create PCIe INFO\n");
     return;
   }
 
   PcieTable->num_entries = 0;
 
   if(platform_pcie_cfg.num_entries == 0) {
-    print(AVS_PRINT_ERR, "Number of ECAM is 0. Cannot create PCIe INFO \n");
+    print(AVS_PRINT_ERR, "Number of ECAM is 0. Cannot create PCIe INFO\n");
     return;
   }
 

--- a/platform/pal_baremetal/common/src/pal_pcie_enumeration.c
+++ b/platform/pal_baremetal/common/src/pal_pcie_enumeration.c
@@ -560,7 +560,7 @@ void pal_pcie_enumerate(void)
          return;
     }
 
-    print(AVS_PRINT_INFO, "\nStarting Enumeration \n", 0);
+    print(AVS_PRINT_INFO, "\nStarting Enumeration\n", 0);
     while (pcie_index < g_pcie_info_table->num_entries)
     {
        pri_bus = g_pcie_info_table->block[pcie_index].start_bus_num;

--- a/platform/pal_baremetal/common/src/pal_pe.c
+++ b/platform/pal_baremetal/common/src/pal_pe.c
@@ -88,7 +88,7 @@ PalAllocateSecondaryStack(uint64_t mpidr)
   {
       gSecondaryPeStack = pal_aligned_alloc(MEM_ALIGN_4K, NumPe * SIZE_STACK_SECONDARY_PE);
       if (gSecondaryPeStack == NULL){
-          print(AVS_PRINT_ERR, "FATAL - Allocation for Secondary stack failed \n", 0);
+          print(AVS_PRINT_ERR, "FATAL - Allocation for Secondary stack failed\n", 0);
       }
       pal_pe_data_cache_ops_by_va((uint64_t)&gSecondaryPeStack, CLEAN_AND_INVALIDATE);
   }
@@ -328,7 +328,7 @@ pal_cache_create_info_table(CACHE_INFO_TABLE *CacheTable, PE_INFO_TABLE *PeTable
   uint32_t i;
 
   if (CacheTable == NULL) {
-    print(AVS_PRINT_ERR, " Unable to create cache info table, input pointer is NULL \n");
+    print(AVS_PRINT_ERR, " Unable to create cache info table, input pointer is NULL\n");
     return;
   }
 

--- a/platform/pal_baremetal/common/src/pal_peripherals.c
+++ b/platform/pal_baremetal/common/src/pal_peripherals.c
@@ -49,7 +49,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
   PERIPHERAL_INFO_BLOCK *per_info = NULL;
 
   if (peripheralInfoTable == NULL) {
-    print(AVS_PRINT_ERR, "Input Peripheral Table Pointer is NULL. Cannot create Peripheral INFO \n");
+    print(AVS_PRINT_ERR, "Input Peripheral Table Pointer is NULL. Cannot create Peripheral INFO\n");
     return;
   }
 
@@ -64,7 +64,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
   /* check for any USB Controllers */
   do {
 
-       print(AVS_PRINT_INFO, "Entered USB loop \n");
+       print(AVS_PRINT_INFO, "Entered USB loop\n");
        DeviceBdf = pal_pcie_get_bdf(USB_CLASSCODE, StartBdf);
        if (DeviceBdf != 0) {
           per_info->type  = PERIPHERAL_TYPE_USB;
@@ -75,7 +75,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
                   break;
           }
           per_info->bdf   = DeviceBdf;
-          print(AVS_PRINT_INFO, "Found a USB controller %4x \n", per_info->base0);
+          print(AVS_PRINT_INFO, "Found a USB controller %4x\n", per_info->base0);
           peripheralInfoTable->header.num_usb++;
           peripheralInfoTable->header.num_all++;
           per_info++;
@@ -88,7 +88,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
   /* check for any SATA Controllers */
   do {
 
-       print(AVS_PRINT_INFO, "Entered SATA loop \n");
+       print(AVS_PRINT_INFO, "Entered SATA loop\n");
        DeviceBdf = pal_pcie_get_bdf(SATA_CLASSCODE, StartBdf);
        if (DeviceBdf != 0) {
           per_info->type  = PERIPHERAL_TYPE_SATA;
@@ -99,7 +99,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
                   break;
           }
           per_info->bdf   = DeviceBdf;
-          print(AVS_PRINT_INFO, "Found a SATA controller %4x \n", per_info->base0);
+          print(AVS_PRINT_INFO, "Found a SATA controller %4x\n", per_info->base0);
           peripheralInfoTable->header.num_sata++;
           peripheralInfoTable->header.num_all++;
           per_info++;

--- a/platform/pal_uefi/src/pal_acpi.c
+++ b/platform/pal_uefi/src/pal_acpi.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2020-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2020-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -89,7 +89,7 @@ pal_get_acpi_table_ptr(UINT32 table_signature)
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      sbsa_print(AVS_PRINT_ERR, L" XSDT not found \n");
+      sbsa_print(AVS_PRINT_ERR, L" XSDT not found\n");
       return 0;
   }
 
@@ -122,7 +122,7 @@ pal_get_madt_ptr()
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      sbsa_print(AVS_PRINT_ERR, L" XSDT not found \n");
+      sbsa_print(AVS_PRINT_ERR, L" XSDT not found\n");
       return 0;
   }
 
@@ -156,7 +156,7 @@ pal_get_gtdt_ptr()
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      sbsa_print(AVS_PRINT_ERR, L" XSDT not found \n");
+      sbsa_print(AVS_PRINT_ERR, L" XSDT not found\n");
       return 0;
   }
 
@@ -189,7 +189,7 @@ pal_get_mcfg_ptr()
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      sbsa_print(AVS_PRINT_ERR, L" XSDT not found \n");
+      sbsa_print(AVS_PRINT_ERR, L" XSDT not found\n");
       return 0;
   }
 
@@ -222,7 +222,7 @@ pal_get_spcr_ptr()
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      sbsa_print(AVS_PRINT_ERR, L" XSDT not found \n");
+      sbsa_print(AVS_PRINT_ERR, L" XSDT not found\n");
       return 0;
   }
 
@@ -255,7 +255,7 @@ pal_get_iort_ptr()
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      sbsa_print(AVS_PRINT_ERR, L" XSDT not found \n");
+      sbsa_print(AVS_PRINT_ERR, L" XSDT not found\n");
       return 0;
   }
 
@@ -292,7 +292,7 @@ pal_get_aest_ptr()
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      sbsa_print(AVS_PRINT_ERR, L" XSDT not found \n");
+      sbsa_print(AVS_PRINT_ERR, L" XSDT not found\n");
       return 0;
   }
 
@@ -324,7 +324,7 @@ pal_get_apmt_ptr()
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      sbsa_print(AVS_PRINT_ERR, L" XSDT not found \n");
+      sbsa_print(AVS_PRINT_ERR, L" XSDT not found\n");
       return 0;
   }
 
@@ -357,7 +357,7 @@ pal_get_hmat_ptr(void)
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      sbsa_print(AVS_PRINT_ERR, L" XSDT not found \n");
+      sbsa_print(AVS_PRINT_ERR, L" XSDT not found\n");
       return 0;
   }
 
@@ -390,7 +390,7 @@ pal_get_mpam_ptr()
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      sbsa_print(AVS_PRINT_ERR, L" XSDT not found \n");
+      sbsa_print(AVS_PRINT_ERR, L" XSDT not found\n");
       return 0;
   }
 
@@ -424,7 +424,7 @@ pal_get_pptt_ptr(void)
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      sbsa_print(AVS_PRINT_ERR, L" XSDT not found \n");
+      sbsa_print(AVS_PRINT_ERR, L" XSDT not found\n");
       return 0;
   }
 
@@ -458,7 +458,7 @@ pal_get_srat_ptr(void)
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      sbsa_print(AVS_PRINT_ERR, L" XSDT not found \n");
+      sbsa_print(AVS_PRINT_ERR, L" XSDT not found\n");
       return 0;
   }
 
@@ -494,7 +494,7 @@ pal_get_fadt_ptr (
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      sbsa_print(AVS_PRINT_ERR, L" XSDT not found \n");
+      sbsa_print(AVS_PRINT_ERR, L" XSDT not found\n");
       return 0;
   }
 

--- a/platform/pal_uefi/src/pal_gic.c
+++ b/platform/pal_uefi/src/pal_gic.c
@@ -53,7 +53,7 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
   UINT32                         TableLength;
 
   if (GicTable == NULL) {
-    sbsa_print(AVS_PRINT_ERR, L" Input GIC Table Pointer is NULL. Cannot create GIC INFO \n");
+    sbsa_print(AVS_PRINT_ERR, L" Input GIC Table Pointer is NULL. Cannot create GIC INFO\n");
     return;
   }
 
@@ -67,9 +67,9 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
 
   if (gMadtHdr != NULL) {
     TableLength =  gMadtHdr->Header.Length;
-    sbsa_print(AVS_PRINT_INFO, L" MADT is at %x and length is %x \n", gMadtHdr, TableLength);
+    sbsa_print(AVS_PRINT_INFO, L" MADT is at %x and length is %x\n", gMadtHdr, TableLength);
   } else {
-    sbsa_print(AVS_PRINT_ERR, L" MADT not found \n");
+    sbsa_print(AVS_PRINT_ERR, L" MADT not found\n");
     return;
   }
 
@@ -83,7 +83,7 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
       if (Entry->PhysicalBaseAddress != 0) {
         GicEntry->type = ENTRY_TYPE_CPUIF;
         GicEntry->base = Entry->PhysicalBaseAddress;
-        sbsa_print(AVS_PRINT_INFO, L" GIC CPUIF base %x \n", GicEntry->base);
+        sbsa_print(AVS_PRINT_INFO, L" GIC CPUIF base %x\n", GicEntry->base);
         GicEntry++;
       }
 
@@ -91,7 +91,7 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->type = ENTRY_TYPE_GICC_GICRD;
         GicEntry->base = Entry->GICRBaseAddress;
         GicEntry->length = 0;
-        sbsa_print(AVS_PRINT_INFO, L" GIC RD base %x \n", GicEntry->base);
+        sbsa_print(AVS_PRINT_INFO, L" GIC RD base %x\n", GicEntry->base);
         GicTable->header.num_gicrd++;
         GicEntry++;
       }
@@ -100,7 +100,7 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->type = ENTRY_TYPE_GICH;
         GicEntry->base = Entry->GICH;
         GicEntry->length = 0;
-        sbsa_print(AVS_PRINT_INFO, L" GICH base %x \n", GicEntry->base);
+        sbsa_print(AVS_PRINT_INFO, L" GICH base %x\n", GicEntry->base);
         GicEntry++;
       }
     }
@@ -109,7 +109,7 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->type = ENTRY_TYPE_GICD;
         GicEntry->base = ((EFI_ACPI_6_1_GIC_DISTRIBUTOR_STRUCTURE *)Entry)->PhysicalBaseAddress;
         GicTable->header.gic_version = ((EFI_ACPI_6_1_GIC_DISTRIBUTOR_STRUCTURE *)Entry)->GicVersion;
-        sbsa_print(AVS_PRINT_INFO, L" GIC DIS base %x \n", GicEntry->base);
+        sbsa_print(AVS_PRINT_INFO, L" GIC DIS base %x\n", GicEntry->base);
         GicTable->header.num_gicd++;
         GicEntry++;
     }
@@ -118,7 +118,7 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->type = ENTRY_TYPE_GICR_GICRD;
         GicEntry->base = ((EFI_ACPI_6_1_GICR_STRUCTURE *)Entry)->DiscoveryRangeBaseAddress;
         GicEntry->length = ((EFI_ACPI_6_1_GICR_STRUCTURE *)Entry)->DiscoveryRangeLength;
-        sbsa_print(AVS_PRINT_INFO, L" GIC RD base Structure %x \n", GicEntry->base);
+        sbsa_print(AVS_PRINT_INFO, L" GIC RD base Structure %x\n", GicEntry->base);
         GicTable->header.num_gicrd++;
         GicEntry++;
     }
@@ -127,8 +127,8 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->type = ENTRY_TYPE_GICITS;
         GicEntry->base = ((EFI_ACPI_6_1_GIC_ITS_STRUCTURE *)Entry)->PhysicalBaseAddress;
         GicEntry->entry_id = ((EFI_ACPI_6_1_GIC_ITS_STRUCTURE *)Entry)->GicItsId;
-        sbsa_print(AVS_PRINT_INFO, L" GIC ITS base %x \n", GicEntry->base);
-        sbsa_print(AVS_PRINT_INFO, L" GIC ITS ID%x \n", GicEntry->entry_id);
+        sbsa_print(AVS_PRINT_INFO, L" GIC ITS base %x\n", GicEntry->base);
+        sbsa_print(AVS_PRINT_INFO, L" GIC ITS ID%x\n", GicEntry->entry_id);
         GicTable->header.num_its++;
         GicEntry++;
     }
@@ -140,9 +140,9 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->flags = ((EFI_ACPI_6_1_GIC_MSI_FRAME_STRUCTURE *)Entry)->Flags;
         GicEntry->spi_count = ((EFI_ACPI_6_1_GIC_MSI_FRAME_STRUCTURE *)Entry)->SPICount;
         GicEntry->spi_base = ((EFI_ACPI_6_1_GIC_MSI_FRAME_STRUCTURE *)Entry)->SPIBase;
-        sbsa_print(AVS_PRINT_INFO, L" GIC MSI Frame base %x \n", GicEntry->base);
-        sbsa_print(AVS_PRINT_INFO, L" GIC MSI SPI base %x \n", GicEntry->spi_base);
-        sbsa_print(AVS_PRINT_INFO, L" GIC MSI SPI Count %x \n", GicEntry->spi_count);
+        sbsa_print(AVS_PRINT_INFO, L" GIC MSI Frame base %x\n", GicEntry->base);
+        sbsa_print(AVS_PRINT_INFO, L" GIC MSI SPI base %x\n", GicEntry->spi_base);
+        sbsa_print(AVS_PRINT_INFO, L" GIC MSI SPI Count %x\n", GicEntry->spi_count);
         GicTable->header.num_msi_frame++;
         GicEntry++;
     }

--- a/platform/pal_uefi/src/pal_hmat.c
+++ b/platform/pal_uefi/src/pal_hmat.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -210,7 +210,7 @@ VOID pal_hmat_create_info_table(HMAT_INFO_TABLE *HmatTable)
   UINT32 TableLength = 0;
 
   if (HmatTable == NULL) {
-      sbsa_print(AVS_PRINT_ERR, L" Unable to create HMAT info table, input pointer is NULL \n");
+      sbsa_print(AVS_PRINT_ERR, L" Unable to create HMAT info table, input pointer is NULL\n");
       return;
   }
 

--- a/platform/pal_uefi/src/pal_iovirt.c
+++ b/platform/pal_uefi/src/pal_iovirt.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2019, 2021-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019, 2021-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -157,13 +157,13 @@ check_mapping_overlap(IOVIRT_INFO_TABLE *iovirt)
             if(tmp->type == IOVIRT_NODE_ITS_GROUP) {
                key_block->flags |= (1 << IOVIRT_FLAG_DEVID_OVERLAP_SHIFT);
                block->flags |= (1 << IOVIRT_FLAG_DEVID_OVERLAP_SHIFT);
-               sbsa_print(AVS_PRINT_INFO, L"\n Overlapping device ids %x-%x and %x-%x \n",
+               sbsa_print(AVS_PRINT_INFO, L"\n Overlapping device ids %x-%x and %x-%x\n",
                           key_start, key_end, start, end);
             }
             else {
                key_block->flags |= (1 << IOVIRT_FLAG_STRID_OVERLAP_SHIFT);
                block->flags |= (1 << IOVIRT_FLAG_STRID_OVERLAP_SHIFT);
-               sbsa_print(AVS_PRINT_INFO, L"\n Overlapping stream ids %x-%x and %x-%x \n",
+               sbsa_print(AVS_PRINT_INFO, L"\n Overlapping stream ids %x-%x and %x-%x\n",
                           key_start, key_end, start, end);
             }
           }
@@ -414,7 +414,7 @@ pal_iovirt_create_info_table(IOVIRT_INFO_TABLE *IoVirtTable)
   /* Create iovirt block for each IORT node*/
   for (i = 0; i < iort->node_count; i++) {
     if (iort_node >= iort_end) {
-      sbsa_print(AVS_PRINT_ERR, L" Bad IORT table \n");
+      sbsa_print(AVS_PRINT_ERR, L" Bad IORT table\n");
       return;
     }
     iort_add_block(iort, iort_node, IoVirtTable, &next_block);

--- a/platform/pal_uefi/src/pal_misc.c
+++ b/platform/pal_uefi/src/pal_misc.c
@@ -41,7 +41,7 @@ pal_mmio_write8(UINT64 addr, UINT8 data)
 {
 
   if (g_print_mmio || (g_curr_module & g_enable_module))
-      sbsa_print(AVS_PRINT_INFO, L" pal_mmio_write8 Address = %llx  Data = %lx \n", addr, data);
+      sbsa_print(AVS_PRINT_INFO, L" pal_mmio_write8 Address = %llx  Data = %lx\n", addr, data);
 
   *(volatile UINT8 *)addr = data;
 }
@@ -60,7 +60,7 @@ pal_mmio_write16(UINT64 addr, UINT16 data)
 {
 
   if (g_print_mmio || (g_curr_module & g_enable_module))
-      sbsa_print(AVS_PRINT_INFO, L" pal_mmio_write16 Address = %llx  Data = %lx \n", addr, data);
+      sbsa_print(AVS_PRINT_INFO, L" pal_mmio_write16 Address = %llx  Data = %lx\n", addr, data);
 
   *(volatile UINT16 *)addr = data;
 }
@@ -79,7 +79,7 @@ pal_mmio_write64(UINT64 addr, UINT64 data)
 {
 
   if (g_print_mmio || (g_curr_module & g_enable_module))
-      sbsa_print(AVS_PRINT_INFO, L" pal_mmio_write64 Address = %llx  Data = %lx \n", addr, data);
+      sbsa_print(AVS_PRINT_INFO, L" pal_mmio_write64 Address = %llx  Data = %lx\n", addr, data);
 
   *(volatile UINT64 *)addr = data;
 }
@@ -99,7 +99,7 @@ pal_mmio_read8(UINT64 addr)
 
   data = (*(volatile UINT8 *)addr);
   if (g_print_mmio || (g_curr_module & g_enable_module))
-      sbsa_print(AVS_PRINT_INFO, L" pal_mmio_read8 Address = %llx  Data = %lx \n", addr, data);
+      sbsa_print(AVS_PRINT_INFO, L" pal_mmio_read8 Address = %llx  Data = %lx\n", addr, data);
 
   return data;
 }
@@ -119,7 +119,7 @@ pal_mmio_read16(UINT64 addr)
 
   data = (*(volatile UINT16 *)addr);
   if (g_print_mmio || (g_curr_module & g_enable_module))
-      sbsa_print(AVS_PRINT_INFO, L" pal_mmio_read16 Address = %llx  Data = %lx \n", addr, data);
+      sbsa_print(AVS_PRINT_INFO, L" pal_mmio_read16 Address = %llx  Data = %lx\n", addr, data);
 
   return data;
 }
@@ -139,7 +139,7 @@ pal_mmio_read64(UINT64 addr)
 
   data = (*(volatile UINT64 *)addr);
   if (g_print_mmio || (g_curr_module & g_enable_module))
-      sbsa_print(AVS_PRINT_INFO, L" pal_mmio_read64 Address = %llx  Data = %lx \n", addr, data);
+      sbsa_print(AVS_PRINT_INFO, L" pal_mmio_read64 Address = %llx  Data = %lx\n", addr, data);
 
   return data;
 }
@@ -158,13 +158,13 @@ pal_mmio_read(UINT64 addr)
   UINT32 data;
 
   if (addr & 0x3) {
-      sbsa_print(AVS_PRINT_WARN, L"\n  Error-Input address is not aligned. Masking the last 2 bits \n");
+      sbsa_print(AVS_PRINT_WARN, L"\n  Error-Input address is not aligned. Masking the last 2 bits\n");
       addr = addr & ~(0x3);  //make sure addr is aligned to 4 bytes
   }
   data = (*(volatile UINT32 *)addr);
 
   if (g_print_mmio || (g_curr_module & g_enable_module))
-      sbsa_print(AVS_PRINT_INFO, L" pal_mmio_read Address = %llx  Data = %x \n", addr, data);
+      sbsa_print(AVS_PRINT_INFO, L" pal_mmio_read Address = %llx  Data = %x\n", addr, data);
 
   return data;
 }
@@ -182,7 +182,7 @@ VOID
 pal_mmio_write(UINT64 addr, UINT32 data)
 {
   if (g_print_mmio || (g_curr_module & g_enable_module))
-    sbsa_print(AVS_PRINT_INFO, L" pal_mmio_write Address = %llx  Data = %x \n", addr, data);
+    sbsa_print(AVS_PRINT_INFO, L" pal_mmio_write Address = %llx  Data = %x\n", addr, data);
 
   *(volatile UINT32 *)addr = data;
 }
@@ -325,10 +325,10 @@ pal_mem_allocate_shared(UINT32 num_pe, UINT32 sizeofentry)
                                (num_pe * sizeofentry),
                                (VOID **) &gSharedMemory );
 
-  sbsa_print(AVS_PRINT_INFO, L" Shared memory is %llx \n", gSharedMemory);
+  sbsa_print(AVS_PRINT_INFO, L" Shared memory is %llx\n", gSharedMemory);
 
   if (EFI_ERROR(Status)) {
-    sbsa_print(AVS_PRINT_ERR, L" Allocate Pool shared memory failed %x \n", Status);
+    sbsa_print(AVS_PRINT_ERR, L" Allocate Pool shared memory failed %x\n", Status);
   }
   pal_pe_data_cache_ops_by_va((UINT64)&gSharedMemory, CLEAN_AND_INVALIDATE);
 
@@ -387,7 +387,7 @@ pal_mem_alloc (
                               (VOID **) &Buffer);
   if (EFI_ERROR(Status))
   {
-    sbsa_print(AVS_PRINT_ERR, L" Allocate Pool failed %x \n", Status);
+    sbsa_print(AVS_PRINT_ERR, L" Allocate Pool failed %x\n", Status);
     return NULL;
   }
 
@@ -418,7 +418,7 @@ pal_mem_calloc (
                               (VOID **) &Buffer);
   if (EFI_ERROR(Status))
   {
-    sbsa_print(AVS_PRINT_ERR, L" Allocate Pool failed %x \n", Status);
+    sbsa_print(AVS_PRINT_ERR, L" Allocate Pool failed %x\n", Status);
     return NULL;
   }
 
@@ -453,7 +453,7 @@ pal_mem_alloc_at_address (
                                &PageBase);
   if (EFI_ERROR(Status))
   {
-    sbsa_print(AVS_PRINT_ERR, L" Allocate Pages failed %x \n", Status);
+    sbsa_print(AVS_PRINT_ERR, L" Allocate Pages failed %x\n", Status);
     return NULL;
   }
 
@@ -501,14 +501,14 @@ pal_mem_alloc_cacheable (
                                EFI_SIZE_TO_PAGES(Size),
                                &Address);
   if (EFI_ERROR(Status)) {
-    sbsa_print(AVS_PRINT_ERR, L" Allocate Pool failed %x \n", Status);
+    sbsa_print(AVS_PRINT_ERR, L" Allocate Pool failed %x\n", Status);
     return NULL;
   }
 
   /* Check Whether Cpu architectural protocol is installed */
   Status = gBS->LocateProtocol (&gEfiCpuArchProtocolGuid, NULL, (VOID **)&Cpu);
   if (EFI_ERROR(Status)) {
-    sbsa_print(AVS_PRINT_ERR, L" Could not get Cpu Arch Protocol %x \n", Status);
+    sbsa_print(AVS_PRINT_ERR, L" Could not get Cpu Arch Protocol %x\n", Status);
     return NULL;
   }
 
@@ -518,7 +518,7 @@ pal_mem_alloc_cacheable (
                                      Size,
                                      EFI_MEMORY_WB);
   if (EFI_ERROR (Status)) {
-    sbsa_print(AVS_PRINT_ERR, L" Could not Set Memory Attribute %x \n", Status);
+    sbsa_print(AVS_PRINT_ERR, L" Could not Set Memory Attribute %x\n", Status);
     return NULL;
   }
 
@@ -653,7 +653,7 @@ pal_mem_alloc_pages (
                                &PageBase);
   if (EFI_ERROR(Status))
   {
-    sbsa_print(AVS_PRINT_ERR, L" Allocate Pages failed %x \n", Status);
+    sbsa_print(AVS_PRINT_ERR, L" Allocate Pages failed %x\n", Status);
     return NULL;
   }
 

--- a/platform/pal_uefi/src/pal_mpam.c
+++ b/platform/pal_uefi/src/pal_mpam.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -124,7 +124,7 @@ pal_mpam_create_info_table(MPAM_INFO_TABLE *MpamTable)
   MPAM_MSC_NODE *curr_entry;
 
   if (MpamTable == NULL) {
-      sbsa_print(AVS_PRINT_ERR, L" Input MPAM Table Pointer is NULL \n");
+      sbsa_print(AVS_PRINT_ERR, L" Input MPAM Table Pointer is NULL\n");
       return;
   }
 
@@ -197,7 +197,7 @@ pal_srat_create_info_table(SRAT_INFO_TABLE *SratTable)
   UINT32  Length = 0;
 
   if (SratTable == NULL) {
-      sbsa_print(AVS_PRINT_ERR, L" Input SRAT Table Pointer is NULL \n");
+      sbsa_print(AVS_PRINT_ERR, L" Input SRAT Table Pointer is NULL\n");
       return;
   }
 
@@ -209,9 +209,9 @@ pal_srat_create_info_table(SRAT_INFO_TABLE *SratTable)
 
   if (SratHdr != NULL) {
     TableLength =  SratHdr->Header.Length;
-    sbsa_print(AVS_PRINT_INFO, L" SRAT is at %x and length is %x \n", SratHdr, TableLength);
+    sbsa_print(AVS_PRINT_INFO, L" SRAT is at %x and length is %x\n", SratHdr, TableLength);
   } else {
-    sbsa_print(AVS_PRINT_DEBUG, L" SRAT not found \n");
+    sbsa_print(AVS_PRINT_DEBUG, L" SRAT not found\n");
     return;
   }
 
@@ -231,9 +231,9 @@ pal_srat_create_info_table(SRAT_INFO_TABLE *SratTable)
       Ptr->node_data.mem_aff.addr_len    = ((UINT64) Mem_Aff_Entry->LengthHigh << 32) |
                                                               Mem_Aff_Entry->LengthLow;
       Ptr->node_data.mem_aff.flags       = Mem_Aff_Entry->Flags;
-      sbsa_print(AVS_PRINT_DEBUG, L" Proximity Domain %x \n", Ptr->node_data.mem_aff.prox_domain);
-      sbsa_print(AVS_PRINT_DEBUG, L" Address %x  \n", Ptr->node_data.mem_aff.addr_base);
-      sbsa_print(AVS_PRINT_DEBUG, L" Length %x  \n", Ptr->node_data.mem_aff.addr_len);
+      sbsa_print(AVS_PRINT_DEBUG, L" Proximity Domain %x\n", Ptr->node_data.mem_aff.prox_domain);
+      sbsa_print(AVS_PRINT_DEBUG, L" Address %x\n", Ptr->node_data.mem_aff.addr_base);
+      sbsa_print(AVS_PRINT_DEBUG, L" Length %x\n", Ptr->node_data.mem_aff.addr_len);
       pal_pe_data_cache_ops_by_va((UINT64)Ptr, CLEAN_AND_INVALIDATE);
       Ptr++;
       SratTable->num_of_mem_ranges++;
@@ -247,9 +247,9 @@ pal_srat_create_info_table(SRAT_INFO_TABLE *SratTable)
       Ptr->node_data.gicc_aff.proc_uid = Gicc_Aff_Entry->AcpiProcessorUid;
       Ptr->node_data.gicc_aff.flags = Gicc_Aff_Entry->Flags;
       Ptr->node_data.gicc_aff.clk_domain = Gicc_Aff_Entry->ClockDomain;
-      sbsa_print(AVS_PRINT_DEBUG, L" Proximity Domain %x \n", Ptr->node_data.gicc_aff.prox_domain);
-      sbsa_print(AVS_PRINT_DEBUG, L" Processor UID %x  \n", Ptr->node_data.gicc_aff.proc_uid);
-      sbsa_print(AVS_PRINT_DEBUG, L" Clock Domain %x  \n", Ptr->node_data.gicc_aff.clk_domain);
+      sbsa_print(AVS_PRINT_DEBUG, L" Proximity Domain %x\n", Ptr->node_data.gicc_aff.prox_domain);
+      sbsa_print(AVS_PRINT_DEBUG, L" Processor UID %x\n", Ptr->node_data.gicc_aff.proc_uid);
+      sbsa_print(AVS_PRINT_DEBUG, L" Clock Domain %x\n", Ptr->node_data.gicc_aff.clk_domain);
       pal_pe_data_cache_ops_by_va((UINT64)Ptr, CLEAN_AND_INVALIDATE);
       Ptr++;
       SratTable->num_of_srat_entries++;

--- a/platform/pal_uefi/src/pal_pcie.c
+++ b/platform/pal_uefi/src/pal_pcie.c
@@ -51,7 +51,7 @@ pal_pcie_get_mcfg_ecam()
   gMcfgHdr = (EFI_ACPI_MEMORY_MAPPED_CONFIGURATION_BASE_ADDRESS_TABLE_HEADER *) pal_get_mcfg_ptr();
 
   if (gMcfgHdr == NULL) {
-      sbsa_print(AVS_PRINT_WARN, L" ACPI - MCFG Table not found. Setting ECAM Base to 0. \n");
+      sbsa_print(AVS_PRINT_WARN, L" ACPI - MCFG Table not found. Setting ECAM Base to 0.\n");
       return 0x0;
   }
 
@@ -77,7 +77,7 @@ pal_pcie_create_info_table(PCIE_INFO_TABLE *PcieTable)
   UINT32 i = 0;
 
   if (PcieTable == NULL) {
-    sbsa_print(AVS_PRINT_ERR, L" Input PCIe Table Pointer is NULL. Cannot create PCIe INFO \n");
+    sbsa_print(AVS_PRINT_ERR, L" Input PCIe Table Pointer is NULL. Cannot create PCIe INFO\n");
     return;
   }
 
@@ -86,7 +86,7 @@ pal_pcie_create_info_table(PCIE_INFO_TABLE *PcieTable)
   gMcfgHdr = (EFI_ACPI_MEMORY_MAPPED_CONFIGURATION_BASE_ADDRESS_TABLE_HEADER *) pal_get_mcfg_ptr();
 
   if (gMcfgHdr == NULL) {
-      sbsa_print(AVS_PRINT_DEBUG, L" ACPI - MCFG Table not found. \n");
+      sbsa_print(AVS_PRINT_DEBUG, L" ACPI - MCFG Table not found.\n");
       return;
   }
 

--- a/platform/pal_uefi/src/pal_pe.c
+++ b/platform/pal_uefi/src/pal_pe.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -158,7 +158,7 @@ PalAllocateSecondaryStack(UINT64 mpidr)
                     StackSize,
                     (VOID **) &Buffer);
       if (EFI_ERROR(Status)) {
-          sbsa_print(AVS_PRINT_ERR, L"\n FATAL - Allocation for Seconday stack failed %x \n", Status);
+          sbsa_print(AVS_PRINT_ERR, L"\n FATAL - Allocation for Seconday stack failed %x\n", Status);
       }
       pal_pe_data_cache_ops_by_va((UINT64)&Buffer, CLEAN_AND_INVALIDATE);
 
@@ -195,7 +195,7 @@ pal_pe_create_info_table(PE_INFO_TABLE *PeTable)
   UINT32                        Flags;
 
   if (PeTable == NULL) {
-    sbsa_print(AVS_PRINT_ERR, L" Input PE Table Pointer is NULL. Cannot create PE INFO \n");
+    sbsa_print(AVS_PRINT_ERR, L" Input PE Table Pointer is NULL. Cannot create PE INFO\n");
     return;
   }
 
@@ -203,9 +203,9 @@ pal_pe_create_info_table(PE_INFO_TABLE *PeTable)
 
   if (gMadtHdr != NULL) {
     TableLength =  gMadtHdr->Header.Length;
-    sbsa_print(AVS_PRINT_INFO, L" MADT is at %x and length is %x \n", gMadtHdr, TableLength);
+    sbsa_print(AVS_PRINT_INFO, L" MADT is at %x and length is %x\n", gMadtHdr, TableLength);
   } else {
-    sbsa_print(AVS_PRINT_ERR, L" MADT not found \n");
+    sbsa_print(AVS_PRINT_ERR, L" MADT not found\n");
     return;
   }
 
@@ -220,7 +220,7 @@ pal_pe_create_info_table(PE_INFO_TABLE *PeTable)
     if (Entry->Type == EFI_ACPI_6_1_GIC) {
       //Fill in the cpu num and the mpidr in pe info table
       Flags           = Entry->Flags;
-      sbsa_print(AVS_PRINT_INFO, L"  Flags %x \n", Flags);
+      sbsa_print(AVS_PRINT_INFO, L"  Flags %x\n", Flags);
       sbsa_print(AVS_PRINT_DEBUG, L"  PE Enabled %d, Online Capable %d\n", ENABLED_BIT(Flags), ONLINE_CAP_BIT(Flags));
 
       /* As per MADT (GICC CPU Interface Flags) Processor is usable when
@@ -237,7 +237,7 @@ pal_pe_create_info_table(PE_INFO_TABLE *PeTable)
           Ptr->acpi_proc_uid = Entry->AcpiProcessorUid;
           for (i = 0; i < MAX_L1_CACHE_RES; i++)
               Ptr->level_1_res[i] = DEFAULT_CACHE_IDX; //initialize cache index fields with all 1's
-          sbsa_print(AVS_PRINT_DEBUG, L" MPIDR %llx PE num %x \n", Ptr->mpidr, Ptr->pe_num);
+          sbsa_print(AVS_PRINT_DEBUG, L" MPIDR %llx PE num %x\n", Ptr->mpidr, Ptr->pe_num);
           pal_pe_data_cache_ops_by_va((UINT64)Ptr, CLEAN_AND_INVALIDATE);
           Ptr++;
           PeTable->header.num_of_pe++;
@@ -563,7 +563,7 @@ pal_cache_create_info_table(CACHE_INFO_TABLE *CacheTable, PE_INFO_TABLE *PeTable
   UINT32 next_index;
 
   if (CacheTable == NULL) {
-    sbsa_print(AVS_PRINT_ERR, L" Unable to create cache info table, input pointer is NULL \n");
+    sbsa_print(AVS_PRINT_ERR, L" Unable to create cache info table, input pointer is NULL\n");
     return;
   }
 

--- a/platform/pal_uefi/src/pal_peripherals.c
+++ b/platform/pal_uefi/src/pal_peripherals.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2020-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2020-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,7 +56,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
 
   if (peripheralInfoTable == NULL) {
     sbsa_print(AVS_PRINT_ERR,
-               L" Input Peripheral Table Pointer is NULL. Cannot create Peripheral INFO \n");
+               L" Input Peripheral Table Pointer is NULL. Cannot create Peripheral INFO\n");
     return;
   }
 
@@ -81,7 +81,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
                   break;
           }
           per_info->bdf   = DeviceBdf;
-          sbsa_print(AVS_PRINT_INFO, L" Found a USB controller %4x \n", per_info->base0);
+          sbsa_print(AVS_PRINT_INFO, L" Found a USB controller %4x\n", per_info->base0);
           peripheralInfoTable->header.num_usb++;
           peripheralInfoTable->header.num_all++;
           per_info++;
@@ -104,7 +104,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
                   break;
           }
           per_info->bdf   = DeviceBdf;
-          sbsa_print(AVS_PRINT_INFO, L" Found a SATA controller %4x \n", per_info->base0);
+          sbsa_print(AVS_PRINT_INFO, L" Found a SATA controller %4x\n", per_info->base0);
           peripheralInfoTable->header.num_sata++;
           peripheralInfoTable->header.num_all++;
           per_info++;
@@ -256,7 +256,7 @@ pal_memory_create_info_table(MEMORY_INFO_TABLE *memoryInfoTable)
   UINT32                Index, i = 0;
 
   if (memoryInfoTable == NULL) {
-    sbsa_print(AVS_PRINT_ERR, L" Input Memory Table Pointer is NULL. Cannot create Memory INFO \n");
+    sbsa_print(AVS_PRINT_ERR, L" Input Memory Table Pointer is NULL. Cannot create Memory INFO\n");
     return;
   }
 

--- a/platform/pal_uefi/src/pal_timer_wd.c
+++ b/platform/pal_uefi/src/pal_timer_wd.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2019, 2021-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2019, 2021-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -67,7 +67,7 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
   UINT32                      num_of_entries;
 
   if (TimerTable == NULL) {
-    sbsa_print(AVS_PRINT_ERR, L" Input Timer Table Pointer is NULL. Cannot create Timer INFO \n");
+    sbsa_print(AVS_PRINT_ERR, L" Input Timer Table Pointer is NULL. Cannot create Timer INFO\n");
     return;
   }
 
@@ -77,10 +77,10 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
   gGtdtHdr = (EFI_ACPI_6_1_GENERIC_TIMER_DESCRIPTION_TABLE *) pal_get_gtdt_ptr();
 
   if (gGtdtHdr == NULL) {
-    sbsa_print(AVS_PRINT_ERR, L" GTDT not found \n");
+    sbsa_print(AVS_PRINT_ERR, L" GTDT not found\n");
     return;
   }
-  sbsa_print(AVS_PRINT_INFO, L" GTDT is at %x and length is %x \n", gGtdtHdr, gGtdtHdr->Header.Length);
+  sbsa_print(AVS_PRINT_INFO, L" GTDT is at %x and length is %x\n", gGtdtHdr, gGtdtHdr->Header.Length);
 
   //Fill in our internal table
   TimerTable->header.s_el1_timer_flag  = gGtdtHdr->SecurePL1TimerFlags;
@@ -100,14 +100,14 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
   while(num_of_entries) {
 
     if (Entry->Type == EFI_ACPI_6_1_GTDT_GT_BLOCK) {
-      sbsa_print(AVS_PRINT_INFO, L" Found block entry \n");
+      sbsa_print(AVS_PRINT_INFO, L" Found block entry\n");
       GtEntry->type = TIMER_TYPE_SYS_TIMER;
       GtEntry->block_cntl_base = Entry->CntCtlBase;
       GtEntry->timer_count     = Entry->GTBlockTimerCount;
-      sbsa_print(AVS_PRINT_DEBUG, L" CNTCTLBase = %llx \n", GtEntry->block_cntl_base);
+      sbsa_print(AVS_PRINT_DEBUG, L" CNTCTLBase = %llx\n", GtEntry->block_cntl_base);
       GtBlockTimer = (EFI_ACPI_6_1_GTDT_GT_BLOCK_TIMER_STRUCTURE *)(((UINT8 *)Entry) + Entry->GTBlockTimerOffset);
       for (i = 0; i < GtEntry->timer_count; i++) {
-        sbsa_print(AVS_PRINT_INFO, L" Found timer entry \n");
+        sbsa_print(AVS_PRINT_INFO, L" Found timer entry\n");
         GtEntry->frame_num[i]    = GtBlockTimer->GTFrameNumber;
         GtEntry->GtCntBase[i]    = GtBlockTimer->CntBaseX;
         GtEntry->GtCntEl0Base[i] = GtBlockTimer->CntEL0BaseX;
@@ -185,7 +185,7 @@ pal_wd_create_info_table(WD_INFO_TABLE *WdTable)
 
   if (WdTable == NULL) {
     sbsa_print(AVS_PRINT_ERR,
-               L" Input Watchdog Table Pointer is NULL. Cannot create Watchdog INFO \n");
+               L" Input Watchdog Table Pointer is NULL. Cannot create Watchdog INFO\n");
     return;
   }
 
@@ -194,7 +194,7 @@ pal_wd_create_info_table(WD_INFO_TABLE *WdTable)
   gGtdtHdr = (EFI_ACPI_6_1_GENERIC_TIMER_DESCRIPTION_TABLE *) pal_get_gtdt_ptr();
 
   if (gGtdtHdr == NULL) {
-    sbsa_print(AVS_PRINT_ERR, L" GTDT not found \n");
+    sbsa_print(AVS_PRINT_ERR, L" GTDT not found\n");
     return;
   }
 
@@ -217,7 +217,7 @@ pal_wd_create_info_table(WD_INFO_TABLE *WdTable)
       WdEntry->wd_flags        = Entry->WatchdogTimerFlags;
       WdTable->header.num_wd++;
       sbsa_print(AVS_PRINT_DEBUG,
-                 L" Watchdog base = 0x%llx INTID = 0x%x \n", WdEntry->wd_ctrl_base,
+                 L" Watchdog base = 0x%llx INTID = 0x%x\n", WdEntry->wd_ctrl_base,
                  WdEntry->wd_gsiv);
       WdEntry++;
     }

--- a/test_pool/nist_sts/test_n001.c
+++ b/test_pool/nist_sts/test_n001.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2020, 2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +26,7 @@
 
 #define TEST_NUM   (AVS_NIST_TEST_NUM_BASE + 1)
 #define TEST_RULE "S_L7ENT_1"
-#define TEST_DESC  "NIST Statistical Test Suite      \n "
+#define TEST_DESC  "NIST Statistical Test Suite       "
 
 #define BUFFER_SIZE     1000
 #define RND_FILE_SIZE   36428
@@ -99,7 +99,7 @@ print_nist_result(void)
   fptr = fopen(filename, "r");
   if (fptr == NULL)
   {
-      val_print(AVS_PRINT_ERR, "Cannot open file \n", 0);
+      val_print(AVS_PRINT_ERR, "Cannot open file\n", 0);
       return AVS_STATUS_FAIL;
   }
 

--- a/test_pool/ras/operating_system/test_ras012.c
+++ b/test_pool/ras/operating_system/test_ras012.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -91,7 +91,7 @@ payload()
     /* Setup an error in an implementation defined way */
     status = val_ras_setup_error(err_in_params, &err_out_params);
     if (status == NOT_IMPLEMENTED) {
-        val_print(AVS_PRINT_ERR, "\n      ras_setup_error API unimplemented", 0);
+        val_print(AVS_PRINT_ERR, "\n       ras_setup_error API unimplemented", 0);
         val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
         return;
     }

--- a/uefi_app/SbsaAvsMain.c
+++ b/uefi_app/SbsaAvsMain.c
@@ -83,7 +83,7 @@ createPeInfoTable (
 
   if (EFI_ERROR(Status))
   {
-    Print(L"Allocate Pool failed %x \n", Status);
+    Print(L"Allocate Pool failed %x\n", Status);
     return Status;
   }
 
@@ -106,7 +106,7 @@ createGicInfoTable (
 
   if (EFI_ERROR(Status))
   {
-    Print(L"Allocate Pool failed %x \n", Status);
+    Print(L"Allocate Pool failed %x\n", Status);
     return Status;
   }
 
@@ -129,7 +129,7 @@ createTimerInfoTable(
 
   if (EFI_ERROR(Status))
   {
-    Print(L"Allocate Pool failed %x \n", Status);
+    Print(L"Allocate Pool failed %x\n", Status);
     return Status;
   }
   val_timer_create_info_table(TimerInfoTable);
@@ -150,7 +150,7 @@ createWatchdogInfoTable(
 
   if (EFI_ERROR(Status))
   {
-    Print(L"Allocate Pool failed %x \n", Status);
+    Print(L"Allocate Pool failed %x\n", Status);
     return Status;
   }
   val_wd_create_info_table(WdInfoTable);
@@ -175,7 +175,7 @@ createPcieVirtInfoTable(
 
   if (EFI_ERROR(Status))
   {
-    Print(L"Allocate Pool failed %x \n", Status);
+    Print(L"Allocate Pool failed %x\n", Status);
     return Status;
   }
   val_pcie_create_info_table(PcieInfoTable);
@@ -186,7 +186,7 @@ createPcieVirtInfoTable(
 
   if (EFI_ERROR(Status))
   {
-    Print(L"Allocate Pool failed %x \n", Status);
+    Print(L"Allocate Pool failed %x\n", Status);
     return Status;
   }
   val_iovirt_create_info_table(IoVirtInfoTable);
@@ -209,7 +209,7 @@ createPeripheralInfoTable(
 
   if (EFI_ERROR(Status))
   {
-    Print(L"Allocate Pool failed %x \n", Status);
+    Print(L"Allocate Pool failed %x\n", Status);
     return Status;
   }
   val_peripheral_create_info_table(PeripheralInfoTable);
@@ -220,7 +220,7 @@ createPeripheralInfoTable(
 
   if (EFI_ERROR(Status))
   {
-    Print(L"Allocate Pool failed %x \n", Status);
+    Print(L"Allocate Pool failed %x\n", Status);
     return Status;
   }
 
@@ -242,7 +242,7 @@ createPmuInfoTable(
 
   if (EFI_ERROR(Status))
   {
-    Print(L"Allocate Pool failed %x \n", Status);
+    Print(L"Allocate Pool failed %x\n", Status);
     return Status;
   }
   val_pmu_create_info_table(PmuInfoTable);
@@ -264,7 +264,7 @@ createRasInfoTable(
 
   if (EFI_ERROR(Status))
   {
-    Print(L"Allocate Pool failed %x \n", Status);
+    Print(L"Allocate Pool failed %x\n", Status);
     return Status;
   }
   val_ras_create_info_table(RasInfoTable);
@@ -286,7 +286,7 @@ createCacheInfoTable(
 
   if (EFI_ERROR(Status))
   {
-    Print(L"Allocate Pool failed %x \n", Status);
+    Print(L"Allocate Pool failed %x\n", Status);
     return Status;
   }
   val_cache_create_info_table(CacheInfoTable);
@@ -307,7 +307,7 @@ createMpamInfoTable(
 
   if (EFI_ERROR(Status))
   {
-    Print(L"Allocate Pool failed %x \n", Status);
+    Print(L"Allocate Pool failed %x\n", Status);
     return Status;
   }
   val_mpam_create_info_table(MpamInfoTable);
@@ -328,7 +328,7 @@ createHmatInfoTable(
 
   if (EFI_ERROR(Status))
   {
-    Print(L"Allocate Pool failed %x \n", Status);
+    Print(L"Allocate Pool failed %x\n", Status);
     return Status;
   }
   val_hmat_create_info_table(HmatInfoTable);
@@ -349,7 +349,7 @@ createSratInfoTable(
 
   if (EFI_ERROR(Status))
   {
-    Print(L"Allocate Pool failed %x \n", Status);
+    Print(L"Allocate Pool failed %x\n", Status);
     return Status;
   }
   val_srat_create_info_table(SratInfoTable);
@@ -517,7 +517,7 @@ ShellAppMainsbsa (
                                  (VOID **) &g_skip_test_num);
       if (EFI_ERROR(Status))
       {
-        Print(L"Allocate memory for -skip failed \n", 0);
+        Print(L"Allocate memory for -skip failed\n", 0);
         return 0;
       }
 
@@ -646,7 +646,7 @@ ShellAppMainsbsa (
                                      (VOID **) &g_execute_tests);
           if (EFI_ERROR(Status))
           {
-              Print(L"Allocate memory for -t failed \n", 0);
+              Print(L"Allocate memory for -t failed\n", 0);
               return 0;
           }
 
@@ -685,7 +685,7 @@ ShellAppMainsbsa (
                                      (VOID **) &g_execute_modules);
           if (EFI_ERROR(Status))
           {
-              Print(L"Allocate memory for -m failed \n", 0);
+              Print(L"Allocate memory for -m failed\n", 0);
               return 0;
           }
 
@@ -715,15 +715,15 @@ ShellAppMainsbsa (
   g_sbsa_tests_pass  = 0;
   g_sbsa_tests_fail  = 0;
 
-  val_print(AVS_PRINT_TEST, "\n\n SBSA Architecture Compliance Suite \n", 0);
+  val_print(AVS_PRINT_TEST, "\n\n SBSA Architecture Compliance Suite\n", 0);
   val_print(AVS_PRINT_TEST, "    Version %d.", SBSA_ACS_MAJOR_VER);
   val_print(AVS_PRINT_TEST, "%d.", SBSA_ACS_MINOR_VER);
-  val_print(AVS_PRINT_TEST, "%d  \n", SBSA_ACS_SUBMINOR_VER);
+  val_print(AVS_PRINT_TEST, "%d\n", SBSA_ACS_SUBMINOR_VER);
 
   val_print(AVS_PRINT_TEST, "\n Starting tests for level %2d", g_sbsa_level);
   val_print(AVS_PRINT_TEST, " (Print level is %2d)\n\n", g_print_level);
 
-  val_print(AVS_PRINT_TEST, " Creating Platform Information Tables \n", 0);
+  val_print(AVS_PRINT_TEST, " Creating Platform Information Tables\n", 0);
 
   Status = createPeInfoTable();
   if (Status)
@@ -738,23 +738,23 @@ ShellAppMainsbsa (
 
   Status = createCacheInfoTable();
   if (Status)
-    Print(L" Failed to created Cache info table \n");
+    Print(L" Failed to created Cache info table\n");
 
   Status = createMpamInfoTable();
   if (Status)
-    Print(L" Failed to created Mpam info table \n");
+    Print(L" Failed to created Mpam info table\n");
 
   Status = createHmatInfoTable();
   if (Status)
-    Print(L" Failed to created HMAT info table \n");
+    Print(L" Failed to created HMAT info table\n");
 
   Status = createSratInfoTable();
   if (Status)
-    Print(L" Failed to created SRAT info table \n");
+    Print(L" Failed to created SRAT info table\n");
 
   Status = createInfoTable(val_ras2_create_info_table, RAS2_FEAT_INFO_TBL_SZ, "RAS2");
   if (Status)
-    Print(L" Failed to created RAS2 feature info table \n");
+    Print(L" Failed to created RAS2 feature info table\n");
 
   createPcieVirtInfoTable();
   createPeripheralInfoTable();
@@ -812,17 +812,17 @@ ShellAppMainsbsa (
 #endif
 
 print_test_status:
-  val_print(AVS_PRINT_TEST, "\n     ------------------------------------------------------- \n", 0);
+  val_print(AVS_PRINT_TEST, "\n     -------------------------------------------------------\n", 0);
   val_print(AVS_PRINT_TEST, "     Total Tests run  = %4d;", g_sbsa_tests_total);
   val_print(AVS_PRINT_TEST, "  Tests Passed  = %4d", g_sbsa_tests_pass);
   val_print(AVS_PRINT_TEST, "  Tests Failed = %4d\n", g_sbsa_tests_fail);
-  val_print(AVS_PRINT_TEST, "     --------------------------------------------------------- \n", 0);
+  val_print(AVS_PRINT_TEST, "     ---------------------------------------------------------\n", 0);
 
   freeSbsaAvsMem();
 
   val_print(AVS_PRINT_TEST, "\n      **  For complete SBSA test coverage, it is ", 0);
-  val_print(AVS_PRINT_TEST, "\n            necessary to also run the BSA test    ** \n\n", 0);
-  val_print(AVS_PRINT_TEST, "\n      *** SBSA tests complete. Reset the system. *** \n\n", 0);
+  val_print(AVS_PRINT_TEST, "\n            necessary to also run the BSA test    **\n\n", 0);
+  val_print(AVS_PRINT_TEST, "\n      *** SBSA tests complete. Reset the system. ***\n\n", 0);
 
   if(g_sbsa_log_file_handle) {
     ShellCloseFile(&g_sbsa_log_file_handle);

--- a/val/src/avs_dma.c
+++ b/val/src/avs_dma.c
@@ -109,7 +109,8 @@ val_dma_create_info_table(uint64_t *dma_info_ptr)
 
   pal_dma_create_info_table(g_dma_info_table);
 
-  val_print(AVS_PRINT_TEST, " DMA_INFO: Number of DMA CTRL in PCIe :    %x\n", val_dma_get_info(DMA_NUM_CTRL, 0));
+  val_print(AVS_PRINT_TEST, " DMA_INFO: Number of DMA CTRL in PCIe :    %x\n",
+                                                        val_dma_get_info(DMA_NUM_CTRL, 0));
 }
 
 

--- a/val/src/avs_dma.c
+++ b/val/src/avs_dma.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -109,7 +109,7 @@ val_dma_create_info_table(uint64_t *dma_info_ptr)
 
   pal_dma_create_info_table(g_dma_info_table);
 
-  val_print(AVS_PRINT_TEST, " DMA_INFO: Number of DMA CTRL in PCIe :    %x \n", val_dma_get_info(DMA_NUM_CTRL, 0));
+  val_print(AVS_PRINT_TEST, " DMA_INFO: Number of DMA CTRL in PCIe :    %x\n", val_dma_get_info(DMA_NUM_CTRL, 0));
 }
 
 
@@ -128,12 +128,12 @@ val_dma_get_info(DMA_INFO_e type, uint32_t index)
 
   if (g_dma_info_table == NULL)
   {
-      val_print(AVS_PRINT_ERR, "GET_DMA_INFO: DMA info table is not created \n", 0);
+      val_print(AVS_PRINT_ERR, "GET_DMA_INFO: DMA info table is not created\n", 0);
       return 0;
   }
   if (index > g_dma_info_table->num_dma_ctrls)
   {
-      val_print(AVS_PRINT_ERR, "GET_DMA_INFO: Index (%d) is greater than num of DMA \n", index);
+      val_print(AVS_PRINT_ERR, "GET_DMA_INFO: Index (%d) is greater than num of DMA\n", index);
       return 0;
   }
 
@@ -161,7 +161,7 @@ val_dma_get_info(DMA_INFO_e type, uint32_t index)
           return ((uint64_t)g_dma_info_table->info[index].flags & (PCI_EP_MASK));
 
       default:
-          val_print(AVS_PRINT_ERR, "This DMA info option not supported %d \n", type);
+          val_print(AVS_PRINT_ERR, "This DMA info option not supported %d\n", type);
           break;
   }
 

--- a/val/src/avs_exerciser.c
+++ b/val/src/avs_exerciser.c
@@ -67,7 +67,7 @@ void val_exerciser_create_info_table(void)
           val_print(AVS_PRINT_DEBUG, "      exerciser Bdf %x\n", Bdf);
       }
   }
-  val_print(AVS_PRINT_TEST, "      PCIE_INFO: Number of exerciser cards : %4d \n",
+  val_print(AVS_PRINT_TEST, "      PCIE_INFO: Number of exerciser cards : %4d\n",
                                                              g_exerciser_info_table.num_exerciser);
   return;
 }
@@ -287,7 +287,7 @@ val_exerciser_execute_tests(uint32_t level)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_EXERCISER_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_INFO, "\n USER Override - Skipping the Exerciser tests \n", 0);
+          val_print(AVS_PRINT_INFO, "\n USER Override - Skipping the Exerciser tests\n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -295,7 +295,7 @@ val_exerciser_execute_tests(uint32_t level)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(AVS_EXERCISER_TEST_NUM_BASE);
   if (status) {
-    val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all Exerciser tests \n", 0);
+    val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all Exerciser tests\n", 0);
     return AVS_STATUS_SKIP;
   }
 
@@ -306,7 +306,7 @@ val_exerciser_execute_tests(uint32_t level)
 
    if (pcie_bdf_table_list_flag == 1) {
     val_print(AVS_PRINT_WARN, "\n     *** Created device list with valid bdf doesn't match \
-                with the platform pcie device hierarchy, Skipping exerciser tests *** \n", 0);
+                with the platform pcie device hierarchy, Skipping exerciser tests ***\n", 0);
     return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_gic.c
+++ b/val/src/avs_gic.c
@@ -41,7 +41,7 @@ val_gic_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_GIC_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all GIC tests \n", 0);
+          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all GIC tests\n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -50,7 +50,7 @@ val_gic_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   module_skip = val_check_skip_module(AVS_GIC_TEST_NUM_BASE);
   if (module_skip) {
-      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all GIC tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all GIC tests\n", 0);
       return AVS_STATUS_SKIP;
   }
 
@@ -83,7 +83,7 @@ val_gic_create_info_table(uint64_t *gic_info_table)
 {
 
   if (gic_info_table == NULL) {
-      val_print(AVS_PRINT_ERR, "Input for Create Info table cannot be NULL \n", 0);
+      val_print(AVS_PRINT_ERR, "Input for Create Info table cannot be NULL\n", 0);
       return AVS_STATUS_ERR;
   }
 
@@ -91,8 +91,8 @@ val_gic_create_info_table(uint64_t *gic_info_table)
 
   pal_gic_create_info_table(g_gic_info_table);
 
-  val_print(AVS_PRINT_TEST, " GIC_INFO: Number of GICD             : %4d \n", g_gic_info_table->header.num_gicd);
-  val_print(AVS_PRINT_TEST, " GIC_INFO: Number of ITS              : %4d \n", g_gic_info_table->header.num_its);
+  val_print(AVS_PRINT_TEST, " GIC_INFO: Number of GICD             : %4d\n", g_gic_info_table->header.num_gicd);
+  val_print(AVS_PRINT_TEST, " GIC_INFO: Number of ITS              : %4d\n", g_gic_info_table->header.num_its);
 
   if (g_gic_info_table->header.num_gicd == 0) {
       val_print(AVS_PRINT_ERR,"\n ** CRITICAL ERROR: GIC Distributor count is 0 **\n", 0);
@@ -132,7 +132,7 @@ val_get_gicd_base(void)
   GIC_INFO_ENTRY  *gic_entry;
 
   if (g_gic_info_table == NULL) {
-      val_print(AVS_PRINT_ERR, "GIC INFO table not available \n", 0);
+      val_print(AVS_PRINT_ERR, "GIC INFO table not available\n", 0);
       return 0;
   }
 
@@ -161,7 +161,7 @@ val_get_gicr_base(uint32_t *rdbase_len)
   GIC_INFO_ENTRY  *gic_entry;
 
   if (g_gic_info_table == NULL) {
-      val_print(AVS_PRINT_ERR, "GIC INFO table not available \n", 0);
+      val_print(AVS_PRINT_ERR, "GIC INFO table not available\n", 0);
       return 0;
   }
 
@@ -197,7 +197,7 @@ val_get_gich_base(void)
   GIC_INFO_ENTRY  *gic_entry;
 
   if (g_gic_info_table == NULL) {
-      val_print(AVS_PRINT_ERR, "GIC INFO table not available \n", 0);
+      val_print(AVS_PRINT_ERR, "GIC INFO table not available\n", 0);
       return 0;
   }
 
@@ -225,7 +225,7 @@ val_get_cpuif_base(void)
   GIC_INFO_ENTRY  *gic_entry;
 
   if (g_gic_info_table == NULL) {
-      val_print(AVS_PRINT_ERR, "GIC INFO table not available \n", 0);
+      val_print(AVS_PRINT_ERR, "GIC INFO table not available\n", 0);
       return 0;
   }
 

--- a/val/src/avs_gic.c
+++ b/val/src/avs_gic.c
@@ -91,8 +91,10 @@ val_gic_create_info_table(uint64_t *gic_info_table)
 
   pal_gic_create_info_table(g_gic_info_table);
 
-  val_print(AVS_PRINT_TEST, " GIC_INFO: Number of GICD             : %4d\n", g_gic_info_table->header.num_gicd);
-  val_print(AVS_PRINT_TEST, " GIC_INFO: Number of ITS              : %4d\n", g_gic_info_table->header.num_its);
+  val_print(AVS_PRINT_TEST, " GIC_INFO: Number of GICD             : %4d\n",
+                                                            g_gic_info_table->header.num_gicd);
+  val_print(AVS_PRINT_TEST, " GIC_INFO: Number of ITS              : %4d\n",
+                                                            g_gic_info_table->header.num_its);
 
   if (g_gic_info_table->header.num_gicd == 0) {
       val_print(AVS_PRINT_ERR,"\n ** CRITICAL ERROR: GIC Distributor count is 0 **\n", 0);

--- a/val/src/avs_iovirt.c
+++ b/val/src/avs_iovirt.c
@@ -46,7 +46,7 @@ val_iovirt_get_smmu_info(SMMU_INFO_e type, uint32_t index)
 
   if (g_iovirt_info_table == NULL)
   {
-      val_print(AVS_PRINT_ERR, "GET_SMMU_INFO: iovirt info table is not created \n", 0);
+      val_print(AVS_PRINT_ERR, "GET_SMMU_INFO: iovirt info table is not created\n", 0);
       return 0;
   }
 
@@ -72,7 +72,7 @@ val_iovirt_get_smmu_info(SMMU_INFO_e type, uint32_t index)
                   case SMMU_IOVIRT_BLOCK:
                       return (uint64_t)block;
                   default:
-                      val_print(AVS_PRINT_ERR, "This SMMU info option not supported %d \n", type);
+                      val_print(AVS_PRINT_ERR, "This SMMU info option not supported %d\n", type);
                       return 0;
               }
           }
@@ -82,7 +82,7 @@ val_iovirt_get_smmu_info(SMMU_INFO_e type, uint32_t index)
 
   if (index > j-1)
   {
-      val_print(AVS_PRINT_ERR, "GET_SMMU_INFO: Index (%d) is greater than num of SMMU \n", index);
+      val_print(AVS_PRINT_ERR, "GET_SMMU_INFO: Index (%d) is greater than num of SMMU\n", index);
       return 0;
   }
   return j;
@@ -104,7 +104,7 @@ val_iovirt_get_pcie_rc_info(PCIE_RC_INFO_e type, uint32_t index)
 
   if (g_iovirt_info_table == NULL)
   {
-      val_print(AVS_PRINT_ERR, "GET_PCIe_RC_INFO: iovirt info table is not created \n", 0);
+      val_print(AVS_PRINT_ERR, "GET_PCIe_RC_INFO: iovirt info table is not created\n", 0);
       return 0;
   }
 
@@ -134,7 +134,7 @@ val_iovirt_get_pcie_rc_info(PCIE_RC_INFO_e type, uint32_t index)
                   case RC_SMMU_BASE:
                       return block->data.rc.smmu_base;
                   default:
-                      val_print(AVS_PRINT_ERR, "This PCIe RC info option not supported %d \n", type);
+                      val_print(AVS_PRINT_ERR, "This PCIe RC info option not supported %d\n", type);
                       return 0;
               }
           }
@@ -143,7 +143,7 @@ val_iovirt_get_pcie_rc_info(PCIE_RC_INFO_e type, uint32_t index)
   }
   if (index > j-1)
   {
-      val_print(AVS_PRINT_ERR, "GET_PCIe_RC_INFO: Index (%d) is greater than num of PCIe-RC \n", index);
+      val_print(AVS_PRINT_ERR, "GET_PCIe_RC_INFO: Index(%d) greater than num of PCIe-RC\n", index);
       return 0;
   }
   return j;
@@ -158,7 +158,7 @@ val_iovirt_get_rc_index(uint32_t rc_seg_num)
 
   if (g_iovirt_info_table == NULL)
   {
-      val_print(AVS_PRINT_ERR, "GET_PCIe_RC_INFO: iovirt info table is not created \n", 0);
+      val_print(AVS_PRINT_ERR, "GET_PCIe_RC_INFO: iovirt info table is not created\n", 0);
       return 0;
   }
 
@@ -178,7 +178,7 @@ val_iovirt_get_rc_index(uint32_t rc_seg_num)
   }
   if (i >=  g_iovirt_info_table->num_blocks)
   {
-      val_print(AVS_PRINT_ERR, "GET_PCIe_RC_INFO: segemnt (%d) is not valid \n", rc_seg_num);
+      val_print(AVS_PRINT_ERR, "GET_PCIe_RC_INFO: segemnt (%d) is not valid\n", rc_seg_num);
       return AVS_INVALID_INDEX;
   }
   return j;
@@ -202,7 +202,7 @@ val_iovirt_get_named_comp_info(NAMED_COMP_INFO_e type, uint32_t index)
 
   if (g_iovirt_info_table == NULL)
   {
-      val_print(AVS_PRINT_ERR, "GET_NAMED_COMP_INFO: iovirt info table is not created \n", 0);
+      val_print(AVS_PRINT_ERR, "GET_NAMED_COMP_INFO: iovirt info table is not created\n", 0);
       return 0; /* imply no named components parsed */
   }
 
@@ -212,7 +212,7 @@ val_iovirt_get_named_comp_info(NAMED_COMP_INFO_e type, uint32_t index)
   /* check if index in range */
   if (index > g_iovirt_info_table->num_named_components - 1) {
       val_print(AVS_PRINT_ERR,
-                "GET_NAMED_COMP_INFO: Index (%d) is greater than num of Named components \n",
+                "GET_NAMED_COMP_INFO: Index (%d) is greater than num of Named components\n",
                  index);
       return INVALID_NAMED_COMP_INFO;
   }
@@ -239,7 +239,7 @@ val_iovirt_get_named_comp_info(NAMED_COMP_INFO_e type, uint32_t index)
                       return block->data.named_comp.smmu_base;
                   default:
                       val_print(AVS_PRINT_ERR,
-                                "This Named component info option not supported %d \n", type);
+                                "This Named component info option not supported %d\n", type);
                       return INVALID_NAMED_COMP_INFO;
               }
           }
@@ -267,7 +267,7 @@ val_iovirt_get_pmcg_info(PMCG_INFO_e type, uint32_t index)
 
   if (g_iovirt_info_table == NULL)
   {
-      val_print(AVS_PRINT_ERR, "GET_PMCG_INFO: iovirt info table is not created \n", 0);
+      val_print(AVS_PRINT_ERR, "GET_PMCG_INFO: iovirt info table is not created\n", 0);
       return 0;
   }
 
@@ -295,7 +295,7 @@ val_iovirt_get_pmcg_info(PMCG_INFO_e type, uint32_t index)
                   case PMCG_NODE_SMMU_BASE:
                       return block->data.pmcg.smmu_base;
                   default:
-                      val_print(AVS_PRINT_ERR, "This PMCG info option not supported %d \n", type);
+                      val_print(AVS_PRINT_ERR, "This PMCG info option not supported %d\n", type);
                       return 0;
               }
           }
@@ -305,7 +305,7 @@ val_iovirt_get_pmcg_info(PMCG_INFO_e type, uint32_t index)
 
   if (index > j-1)
   {
-      val_print(AVS_PRINT_ERR, "GET_PMCG_INFO: Index (%d) is greater than num of PMCG \n", index);
+      val_print(AVS_PRINT_ERR, "GET_PMCG_INFO: Index (%d) is greater than num of PMCG\n", index);
       return 0;
   }
   return j;
@@ -341,7 +341,7 @@ val_iovirt_get_device_info(uint32_t rid, uint32_t segment, uint32_t *device_id,
   NODE_DATA_MAP *map;
   if (g_iovirt_info_table == NULL)
   {
-      val_print(AVS_PRINT_ERR, "GET_DEVICE_ID: iovirt info table is not created \n", 0);
+      val_print(AVS_PRINT_ERR, "GET_DEVICE_ID: iovirt info table is not created\n", 0);
       return AVS_STATUS_ERR;
   }
   if (!device_id) {
@@ -441,7 +441,7 @@ val_iovirt_create_info_table(uint64_t *iovirt_info_table)
 
   if (iovirt_info_table == NULL)
   {
-      val_print(AVS_PRINT_ERR, "\n   Input for Create Info table cannot be NULL \n", 0);
+      val_print(AVS_PRINT_ERR, "\n   Input for Create Info table cannot be NULL\n", 0);
       return;
   }
 
@@ -451,7 +451,7 @@ val_iovirt_create_info_table(uint64_t *iovirt_info_table)
 
   g_num_smmus = val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);
   val_print(AVS_PRINT_TEST,
-            " SMMU_INFO: Number of SMMU CTRL       :    %x \n", g_num_smmus);
+            " SMMU_INFO: Number of SMMU CTRL       :    %x\n", g_num_smmus);
 }
 
 uint32_t

--- a/val/src/avs_memory.c
+++ b/val/src/avs_memory.c
@@ -110,7 +110,7 @@ val_memory_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0 ; i < g_num_skip ; i++) {
       if (g_skip_test_num[i] == AVS_MEM_MAP_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all memory tests \n", 0);
+          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all memory tests\n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -118,7 +118,7 @@ val_memory_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in the current module with user override*/
   status = val_check_skip_module(AVS_MEM_MAP_TEST_NUM_BASE);
   if (status) {
-      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all memory tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all memory tests\n", 0);
       return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_mpam.c
+++ b/val/src/avs_mpam.c
@@ -42,7 +42,7 @@ val_mpam_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_MPAM_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all MPAM tests \n", 0);
+          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all MPAM tests\n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -50,7 +50,7 @@ val_mpam_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in the current module with user override*/
   skip_module = val_check_skip_module(AVS_MPAM_TEST_NUM_BASE);
   if (skip_module) {
-      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all MPAM tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all MPAM tests\n", 0);
       return AVS_STATUS_SKIP;
   }
 
@@ -749,7 +749,7 @@ void
 val_mpam_create_info_table(uint64_t *mpam_info_table)
 {
   if (mpam_info_table == NULL) {
-    val_print(AVS_PRINT_ERR, "\n Pre-allocated memory pointer is NULL \n", 0);
+    val_print(AVS_PRINT_ERR, "\n Pre-allocated memory pointer is NULL\n", 0);
     return;
   }
 
@@ -758,7 +758,7 @@ val_mpam_create_info_table(uint64_t *mpam_info_table)
   pal_mpam_create_info_table(g_mpam_info_table);
 
   val_print(AVS_PRINT_TEST,
-                " MPAM INFO: Number of MSC nodes       :    %d \n", g_mpam_info_table->msc_count);
+                " MPAM INFO: Number of MSC nodes       :    %d\n", g_mpam_info_table->msc_count);
 #endif
 }
 
@@ -785,7 +785,7 @@ void
 val_hmat_create_info_table(uint64_t *hmat_info_table)
 {
   if (hmat_info_table == NULL) {
-    val_print(AVS_PRINT_ERR, "\n Pre-allocated memory pointer is NULL \n", 0);
+    val_print(AVS_PRINT_ERR, "\n Pre-allocated memory pointer is NULL\n", 0);
     return;
   }
 #ifndef TARGET_LINUX
@@ -795,7 +795,7 @@ val_hmat_create_info_table(uint64_t *hmat_info_table)
 
   if (g_hmat_info_table->num_of_mem_prox_domain != 0)
       val_print(AVS_PRINT_TEST,
-                " HMAT INFO: Number of Prox domains    :    %d \n",
+                " HMAT INFO: Number of Prox domains    :    %d\n",
                                     g_hmat_info_table->num_of_mem_prox_domain);
 #endif
 }
@@ -823,7 +823,7 @@ void
 val_srat_create_info_table(uint64_t *srat_info_table)
 {
   if (srat_info_table == NULL) {
-    val_print(AVS_PRINT_ERR, "\n Pre-allocated memory pointer is NULL \n", 0);
+    val_print(AVS_PRINT_ERR, "\n Pre-allocated memory pointer is NULL\n", 0);
     return;
   }
 #ifndef TARGET_LINUX
@@ -833,7 +833,7 @@ val_srat_create_info_table(uint64_t *srat_info_table)
 
   if (g_srat_info_table->num_of_mem_ranges != 0)
       val_print(AVS_PRINT_TEST,
-                " SRAT INFO: Number of Memory Ranges   :    %d \n",
+                " SRAT INFO: Number of Memory Ranges   :    %d\n",
                                     g_srat_info_table->num_of_mem_ranges);
 #endif
 }

--- a/val/src/avs_nist.c
+++ b/val/src/avs_nist.c
@@ -35,7 +35,7 @@ val_nist_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_NIST_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all NIST tests \n", 0);
+          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all NIST tests\n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -43,7 +43,7 @@ val_nist_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(AVS_NIST_TEST_NUM_BASE);
   if (status) {
-      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all NIST tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all NIST tests\n", 0);
       return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -694,7 +694,7 @@ val_pcie_create_device_bdf_table()
   val_pcie_populate_device_rootport();
 
   val_print(AVS_PRINT_TEST,
-            " PCIE_INFO: Number of BDFs found      :    %d\n", g_pcie_bdf_table->num_entries);
+            " PCIE_INFO: Number of BDFs found      : %4d\n", g_pcie_bdf_table->num_entries);
 
   return 0;
 }

--- a/val/src/avs_pcie.c
+++ b/val/src/avs_pcie.c
@@ -128,7 +128,7 @@ val_pcie_write_cfg(uint32_t bdf, uint32_t offset, uint32_t data)
 
 
   if ((bus >= PCIE_MAX_BUS) || (dev >= PCIE_MAX_DEV) || (func >= PCIE_MAX_FUNC)) {
-     val_print(AVS_PRINT_ERR, "Invalid Bus/Dev/Func  %x \n", bdf);
+     val_print(AVS_PRINT_ERR, "Invalid Bus/Dev/Func  %x\n", bdf);
      return;
   }
 
@@ -228,7 +228,7 @@ uint64_t val_pcie_get_bdf_config_addr(uint32_t bdf)
   uint32_t i = 0;
 
   if ((bus >= PCIE_MAX_BUS) || (dev >= PCIE_MAX_DEV) || (func >= PCIE_MAX_FUNC)) {
-     val_print(AVS_PRINT_ERR, "Invalid Bus/Dev/Func  %x \n", bdf);
+     val_print(AVS_PRINT_ERR, "Invalid Bus/Dev/Func  %x\n", bdf);
      return 0;
   }
 
@@ -290,7 +290,7 @@ val_pcie_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_PCIE_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all PCIe tests \n", 0);
+          val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all PCIe tests\n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -298,13 +298,13 @@ val_pcie_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(AVS_PCIE_TEST_NUM_BASE);
   if (status) {
-      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all PCIe tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all PCIe tests\n", 0);
       return AVS_STATUS_SKIP;
   }
 
   if (pcie_bdf_table_list_flag == 1) {
     val_print(AVS_PRINT_WARN, "\n     *** Created device list with valid bdf doesn't match \
-                    with the platform pcie device hierarchy, Skipping PCIE tests *** \n", 0);
+                    with the platform pcie device hierarchy, Skipping PCIE tests ***\n", 0);
     return AVS_STATUS_SKIP;
   }
 
@@ -327,7 +327,7 @@ val_pcie_execute_tests(uint32_t level, uint32_t num_pe)
     status = p001_entry(num_pe);
 
     if (status == AVS_STATUS_FAIL) {
-      val_print(AVS_PRINT_WARN, "\n     *** Skipping remaining PCIE tests *** \n", 0);
+      val_print(AVS_PRINT_WARN, "\n     *** Skipping remaining PCIE tests ***\n", 0);
       return status;
     }
 
@@ -337,7 +337,7 @@ val_pcie_execute_tests(uint32_t level, uint32_t num_pe)
 
     if (g_pcie_bdf_table->num_entries == 0) {
       val_print(AVS_PRINT_WARN, "\n     *** No Valid Devices Found, \
-                Skipping remaining PCIE tests *** \n", 0);
+                Skipping remaining PCIE tests ***\n", 0);
       return AVS_STATUS_SKIP;
     }
 
@@ -464,16 +464,16 @@ val_pcie_print_device_info(void)
       }
   }
 
-  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of RCiEP           : %4d \n", num_rciep);
-  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of RCEC            : %4d \n", num_rcec);
-  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of EP              : %4d \n", num_ep);
-  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of RP              : %4d \n", num_rp);
-  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of iEP_EP          : %4d \n", num_iep);
-  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of iEP_RP          : %4d \n", num_irp);
-  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of UP of switch    : %4d \n", num_up);
-  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of DP of switch    : %4d \n", num_dp);
-  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of PCI/PCIe Bridge : %4d \n", num_pci_pcie);
-  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of PCIe/PCI Bridge : %4d \n", num_pcie_pci);
+  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of RCiEP           : %4d\n", num_rciep);
+  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of RCEC            : %4d\n", num_rcec);
+  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of EP              : %4d\n", num_ep);
+  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of RP              : %4d\n", num_rp);
+  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of iEP_EP          : %4d\n", num_iep);
+  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of iEP_RP          : %4d\n", num_irp);
+  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of UP of switch    : %4d\n", num_up);
+  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of DP of switch    : %4d\n", num_dp);
+  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of PCI/PCIe Bridge : %4d\n", num_pci_pcie);
+  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of PCIe/PCI Bridge : %4d\n", num_pcie_pci);
 
   while (ecam_index < val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0))
   {
@@ -544,7 +544,7 @@ void
 val_pcie_create_info_table(uint64_t *pcie_info_table)
 {
   if (pcie_info_table == NULL) {
-      val_print(AVS_PRINT_ERR, "Input for Create Info table cannot be NULL \n", 0);
+      val_print(AVS_PRINT_ERR, "Input for Create Info table cannot be NULL\n", 0);
       return;
   }
 
@@ -553,7 +553,7 @@ val_pcie_create_info_table(uint64_t *pcie_info_table)
 
   pal_pcie_create_info_table(g_pcie_info_table);
 
-  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of ECAM regions    :    %ld \n",
+  val_print(AVS_PRINT_TEST, " PCIE_INFO: Number of ECAM regions    :    %ld\n",
                                       val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0));
 
   val_pcie_enumerate();
@@ -782,13 +782,13 @@ val_pcie_get_info(PCIE_INFO_e type, uint32_t index)
 {
 
   if (g_pcie_info_table == NULL) {
-      val_print(AVS_PRINT_ERR, "GET_PCIe_INFO: PCIE info table is not created \n", 0);
+      val_print(AVS_PRINT_ERR, "GET_PCIe_INFO: PCIE info table is not created\n", 0);
       return 0;
   }
 
   if (index >= g_pcie_info_table->num_entries) {
       if (g_pcie_info_table->num_entries != 0)
-          val_print(AVS_PRINT_ERR, "Invalid index %d > num of entries \n", index);
+          val_print(AVS_PRINT_ERR, "Invalid index %d > num of entries\n", index);
       return 0;
   }
 
@@ -806,7 +806,7 @@ val_pcie_get_info(PCIE_INFO_e type, uint32_t index)
       case PCIE_INFO_SEGMENT:
           return g_pcie_info_table->block[index].segment_num;
       default:
-          val_print(AVS_PRINT_ERR, "This PCIE info option not supported %d \n", type);
+          val_print(AVS_PRINT_ERR, "This PCIE info option not supported %d\n", type);
           break;
   }
 
@@ -2105,7 +2105,7 @@ val_pcie_get_rootport(uint32_t bdf, uint32_t *rp_bdf)
 
   dp_type = val_pcie_device_port_type(bdf);
 
-  val_print(AVS_PRINT_DEBUG, " DP type 0x%03x ", dp_type);
+  val_print(AVS_PRINT_DEBUG, " DP type 0x%03x", dp_type);
 
   /* If the device is RP or iEP_RP, set its rootport value to same */
   if ((dp_type == RP) || (dp_type == iEP_RP))

--- a/val/src/avs_pe.c
+++ b/val/src/avs_pe.c
@@ -47,7 +47,7 @@ val_pe_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_PE_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all PE tests \n", 0);
+          val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all PE tests\n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -55,7 +55,7 @@ val_pe_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(AVS_PE_TEST_NUM_BASE);
   if (status) {
-      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all PE tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all PE tests\n", 0);
       return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_pe_infra.c
+++ b/val/src/avs_pe_infra.c
@@ -71,7 +71,7 @@ val_pe_create_info_table(uint64_t *pe_info_table)
   }
 
   if (pe_info_table == NULL) {
-      val_print(AVS_PRINT_ERR, "Input memory for PE Info table cannot be NULL \n", 0);
+      val_print(AVS_PRINT_ERR, "Input memory for PE Info table cannot be NULL\n", 0);
       return AVS_STATUS_ERR;
   }
 
@@ -80,7 +80,7 @@ val_pe_create_info_table(uint64_t *pe_info_table)
   pal_pe_create_info_table(g_pe_info_table);
   val_data_cache_ops_by_va((addr_t)&g_pe_info_table, CLEAN_AND_INVALIDATE);
 
-  val_print(AVS_PRINT_TEST, " PE_INFO: Number of PE detected       : %4d \n", val_pe_get_num());
+  val_print(AVS_PRINT_TEST, " PE_INFO: Number of PE detected       : %4d\n", val_pe_get_num());
 
   if (val_pe_get_num() == 0) {
       val_print(AVS_PRINT_ERR, "\n *** CRITICAL ERROR: Num PE is 0x0 ***\n", 0);
@@ -292,7 +292,7 @@ val_execute_on_pe(uint32_t index, void (*payload)(void), uint64_t test_input)
 
   int timeout = TIMEOUT_LARGE;
   if (index > g_pe_info_table->header.num_of_pe) {
-      val_print(AVS_PRINT_ERR, "Input Index exceeds Num of PE %x \n", index);
+      val_print(AVS_PRINT_ERR, "Input Index exceeds Num of PE %x\n", index);
       val_report_status(index, RESULT_FAIL(g_sbsa_level, 0, 0xFF), NULL);
       return;
   }
@@ -337,7 +337,7 @@ val_pe_install_esr(uint32_t exception_type, void (*esr)(uint64_t, void *))
 {
 
   if (exception_type > 3) {
-      val_print(AVS_PRINT_ERR, "Invalid Exception type %x \n", exception_type);
+      val_print(AVS_PRINT_ERR, "Invalid Exception type %x\n", exception_type);
       return AVS_STATUS_ERR;
   }
 
@@ -461,7 +461,7 @@ void
 val_cache_create_info_table(uint64_t *cache_info_table)
 {
   if (cache_info_table == NULL) {
-      val_print(AVS_PRINT_ERR, "\n   Pre-allocated memory pointer is NULL \n", 0);
+      val_print(AVS_PRINT_ERR, "\n   Pre-allocated memory pointer is NULL\n", 0);
       return;
   }
 
@@ -526,7 +526,7 @@ val_cache_get_info(CACHE_INFO_e type, uint32_t cache_index)
       return entry->is_private;
   default:
       val_print(AVS_PRINT_ERR,
-                "\n      cache option not supported %d \n", type);
+                "\n      cache option not supported %d\n", type);
       return INVALID_CACHE_INFO;
   }
 

--- a/val/src/avs_peripherals.c
+++ b/val/src/avs_peripherals.c
@@ -43,7 +43,7 @@ val_peripheral_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_PER_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all Peripheral tests \n", 0);
+          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all Peripheral tests\n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -51,7 +51,7 @@ val_peripheral_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   skip_module = val_check_skip_module(AVS_PER_TEST_NUM_BASE);
   if (skip_module) {
-      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all Peripheral tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all Peripheral tests\n", 0);
       return AVS_STATUS_SKIP;
   }
 
@@ -259,9 +259,9 @@ val_peripheral_dump_info(void)
       }
   }
 
-  val_print(AVS_PRINT_DEBUG, " Peripheral: Num of Network ctrl      :    %d \n", ntwk);
-  val_print(AVS_PRINT_DEBUG, " Peripheral: Num of Storage ctrl      :    %d \n", strg);
-  val_print(AVS_PRINT_DEBUG, " Peripheral: Num of Display ctrl      :    %d \n", dply);
+  val_print(AVS_PRINT_DEBUG, " Peripheral: Num of Network ctrl      :    %d\n", ntwk);
+  val_print(AVS_PRINT_DEBUG, " Peripheral: Num of Storage ctrl      :    %d\n", strg);
+  val_print(AVS_PRINT_DEBUG, " Peripheral: Num of Display ctrl      :    %d\n", dply);
 
 }
 
@@ -290,11 +290,11 @@ val_peripheral_create_info_table(uint64_t *peripheral_info_table)
 
   pal_peripheral_create_info_table(g_peripheral_info_table);
 
-  val_print(AVS_PRINT_TEST, " Peripheral: Num of USB controllers   :    %d \n",
+  val_print(AVS_PRINT_TEST, " Peripheral: Num of USB controllers   :    %d\n",
     val_peripheral_get_info(NUM_USB, 0));
-  val_print(AVS_PRINT_TEST, " Peripheral: Num of SATA controllers  :    %d \n",
+  val_print(AVS_PRINT_TEST, " Peripheral: Num of SATA controllers  :    %d\n",
     val_peripheral_get_info(NUM_SATA, 0));
-  val_print(AVS_PRINT_TEST, " Peripheral: Num of UART controllers  :    %d \n",
+  val_print(AVS_PRINT_TEST, " Peripheral: Num of UART controllers  :    %d\n",
     val_peripheral_get_info(NUM_UART, 0));
   val_peripheral_dump_info();
 }

--- a/val/src/avs_pmu.c
+++ b/val/src/avs_pmu.c
@@ -41,7 +41,7 @@ val_pmu_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_PMU_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all PMU tests \n", 0);
+          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all PMU tests\n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -49,7 +49,7 @@ val_pmu_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   skip_module = val_check_skip_module(AVS_PMU_TEST_NUM_BASE);
   if (skip_module) {
-      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all PMU tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all PMU tests\n", 0);
       return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_ras.c
+++ b/val/src/avs_ras.c
@@ -42,7 +42,7 @@ val_ras_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_RAS_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_INFO, "\n      USER Override - Skipping all RAS tests \n", 0);
+          val_print(AVS_PRINT_INFO, "\n      USER Override - Skipping all RAS tests\n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -50,7 +50,7 @@ val_ras_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   skip_module = val_check_skip_module(AVS_RAS_TEST_NUM_BASE);
   if (skip_module) {
-      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all RAS tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all RAS tests\n", 0);
       return AVS_STATUS_SKIP;
   }
 
@@ -105,7 +105,7 @@ val_ras_create_info_table(uint64_t *ras_info_table)
 {
 
   if (ras_info_table == NULL) {
-      val_print(AVS_PRINT_ERR, "Input for Create Info table cannot be NULL \n", 0);
+      val_print(AVS_PRINT_ERR, "Input for Create Info table cannot be NULL\n", 0);
       return AVS_STATUS_ERR;
   }
 
@@ -113,7 +113,7 @@ val_ras_create_info_table(uint64_t *ras_info_table)
 
   pal_ras_create_info_table(g_ras_info_table);
 
-  val_print(AVS_PRINT_TEST, " RAS_INFO: Number of RAS nodes        : %4d \n",
+  val_print(AVS_PRINT_TEST, " RAS_INFO: Number of RAS nodes        : %4d\n",
                            g_ras_info_table->num_nodes);
 
   return AVS_STATUS_PASS;
@@ -141,7 +141,7 @@ val_ras2_create_info_table(uint64_t *ras2_info_table)
 {
 
   if (ras2_info_table == NULL) {
-      val_print(AVS_PRINT_ERR, "\nInput for RAS2 feat create info table cannot be NULL \n", 0);
+      val_print(AVS_PRINT_ERR, "\nInput for RAS2 feat create info table cannot be NULL\n", 0);
       return;
   }
 
@@ -150,9 +150,9 @@ val_ras2_create_info_table(uint64_t *ras2_info_table)
 
   pal_ras2_create_info_table(g_ras2_info_table);
 
-  val_print(AVS_PRINT_TEST, " RAS2_INFO: Number of RAS2 entries    : %4d \n",
+  val_print(AVS_PRINT_TEST, " RAS2_INFO: Number of RAS2 entries    : %4d\n",
                            g_ras2_info_table->num_all_block);
-  val_print(AVS_PRINT_TEST, " RAS2_INFO: Num of RAS2 memory entries: %4d \n",
+  val_print(AVS_PRINT_TEST, " RAS2_INFO: Num of RAS2 memory entries: %4d\n",
                            g_ras2_info_table->num_of_mem_block);
 #endif
 return;
@@ -368,7 +368,7 @@ val_ras2_get_mem_info(RAS2_MEM_INFO_e type, uint32_t index)
   RAS2_BLOCK *block;
 
   if (g_ras2_info_table == NULL) {
-      val_print(AVS_PRINT_ERR, "\nRAS2_GET_MEM_INFO : ras2 info table is not created \n", 0);
+      val_print(AVS_PRINT_ERR, "\nRAS2_GET_MEM_INFO : ras2 info table is not created\n", 0);
       return 0; /* imply no ras2_info entries */
   }
 
@@ -396,7 +396,7 @@ val_ras2_get_mem_info(RAS2_MEM_INFO_e type, uint32_t index)
                   return block->block_info.mem_feat_info.patrol_scrub_support;
               default:
                   val_print(AVS_PRINT_ERR,
-                            "\nThis RAS2 memory info option not supported: %d \n", type);
+                            "\nThis RAS2 memory info option not supported: %d\n", type);
                   return INVALID_RAS2_INFO;
               }
           }
@@ -443,7 +443,7 @@ val_ras_reg_read(uint32_t node_index, uint32_t reg, uint32_t err_rec_idx)
       val_print(AVS_PRINT_ERR,
                 "\n       RAS_REG_READ : Error record index(%d) is unimplemented ", err_rec_idx);
       val_print(AVS_PRINT_ERR,
-                "for node with index: %d \n", node_index);
+                "for node with index: %d\n", node_index);
       return INVALID_RAS_REG_VAL;
   }
 
@@ -711,7 +711,7 @@ ras_pfg_access_node(uint32_t node_index)
                 node_index);
   }
 
-  val_print(AVS_PRINT_INFO, "      Access RAS Node, CTLR : 0x%llx \n", reg_value);
+  val_print(AVS_PRINT_INFO, "      Access RAS Node, CTLR : 0x%llx\n", reg_value);
 }
 
 /**

--- a/val/src/avs_smmu.c
+++ b/val/src/avs_smmu.c
@@ -59,7 +59,7 @@ val_smmu_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_SMMU_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all SMMU tests \n", 0);
+          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all SMMU tests\n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -67,7 +67,7 @@ val_smmu_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(AVS_SMMU_TEST_NUM_BASE);
   if (status) {
-      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all SMMU tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all SMMU tests\n", 0);
       return AVS_STATUS_SKIP;
   }
 
@@ -122,7 +122,7 @@ val_smmu_start_monitor_dev(uint32_t ctrl_index)
 
   ap = (void *)val_dma_get_info(DMA_PORT_INFO, ctrl_index);
   if (ap == NULL) {
-      val_print(AVS_PRINT_ERR, "Invalid Controller index %d \n", ctrl_index);
+      val_print(AVS_PRINT_ERR, "Invalid Controller index %d\n", ctrl_index);
       return AVS_STATUS_ERR;
   }
 
@@ -138,7 +138,7 @@ val_smmu_stop_monitor_dev(uint32_t ctrl_index)
 
   ap = (void *)val_dma_get_info(DMA_PORT_INFO, ctrl_index);
   if (ap == NULL) {
-      val_print(AVS_PRINT_ERR, "Invalid Controller index %d \n", ctrl_index);
+      val_print(AVS_PRINT_ERR, "Invalid Controller index %d\n", ctrl_index);
       return AVS_STATUS_ERR;
   }
 
@@ -164,10 +164,10 @@ val_smmu_check_device_iova(uint32_t ctrl_index, addr_t dma_addr)
 
   ap = (void *)val_dma_get_info(DMA_PORT_INFO, ctrl_index);
   if (ap == NULL) {
-      val_print(AVS_PRINT_ERR, "Invalid Controller index %d \n", ctrl_index);
+      val_print(AVS_PRINT_ERR, "Invalid Controller index %d\n", ctrl_index);
       return AVS_STATUS_ERR;
   }
-  val_print(AVS_PRINT_DEBUG, "Input dma addr = %llx \n", dma_addr);
+  val_print(AVS_PRINT_DEBUG, "Input dma addr = %llx\n", dma_addr);
 
   status = pal_smmu_check_device_iova(ap, dma_addr);
 

--- a/val/src/avs_status.c
+++ b/val/src/avs_status.c
@@ -46,7 +46,7 @@ val_report_status(uint32_t index, uint32_t status, char8_t *ruleid)
       val_print(AVS_PRINT_DEBUG, "\n       ", 0);
       val_print(AVS_PRINT_DEBUG, ruleid, 0);
       val_print(AVS_PRINT_DEBUG, "\n                                  ", 0);
-      val_print(AVS_PRINT_TEST, ": Result:  PASS \n", status);
+      val_print(AVS_PRINT_TEST, ": Result:  PASS\n", status);
   }
   else
     if (IS_TEST_FAIL(status)) {
@@ -56,7 +56,7 @@ val_report_status(uint32_t index, uint32_t status, char8_t *ruleid)
             val_print(AVS_PRINT_ERR, "\n       Checkpoint -- %2d             ",
                       status & STATUS_MASK);
         }
-        val_print(AVS_PRINT_ERR, "     : Result:  FAIL \n", 0);
+        val_print(AVS_PRINT_ERR, "     : Result:  FAIL\n", 0);
     }
     else
       if (IS_TEST_SKIP(status)) {
@@ -66,16 +66,16 @@ val_report_status(uint32_t index, uint32_t status, char8_t *ruleid)
               val_print(AVS_PRINT_WARN, "\n       Checkpoint -- %2d             ",
                         status & STATUS_MASK);
           }
-          val_print(AVS_PRINT_WARN, "     : Result:  SKIPPED \n", 0);
+          val_print(AVS_PRINT_WARN, "     : Result:  SKIPPED\n", 0);
       }
       else
         if (IS_TEST_START(status))
           val_print(AVS_PRINT_INFO, "\n       START  ", status);
         else
           if (IS_TEST_END(status))
-            val_print(AVS_PRINT_INFO, "       END  \n\n", status);
+            val_print(AVS_PRINT_INFO, "       END\n\n", status);
           else
-            val_print(AVS_PRINT_ERR, ": Result:  %8x  \n", status);
+            val_print(AVS_PRINT_ERR, ": Result:  %8x\n", status);
 
 }
 

--- a/val/src/avs_test_infra.c
+++ b/val/src/avs_test_infra.c
@@ -61,7 +61,7 @@ val_print_test_start(char8_t *string)
 {
   val_print(AVS_PRINT_TEST, "\n      *** Starting ", 0);
   val_print(AVS_PRINT_TEST, string, 0);
-  val_print(AVS_PRINT_TEST, " tests ***  \n", 0);
+  val_print(AVS_PRINT_TEST, " tests ***\n", 0);
 }
 
 void
@@ -558,7 +558,7 @@ val_check_for_error(uint32_t test_num, uint32_t num_pe, char8_t *ruleid)
 
   for (i = 0; i < num_pe; i++) {
       status = val_get_status(i);
-      //val_print(AVS_PRINT_ERR, "Status %4x \n", status);
+      //val_print(AVS_PRINT_ERR, "Status %4x\n", status);
       if (IS_TEST_FAIL_SKIP(status)) {
           val_report_status(i, status, ruleid);
           error_flag += 1;

--- a/val/src/avs_timer.c
+++ b/val/src/avs_timer.c
@@ -42,7 +42,7 @@ val_timer_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_TIMER_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all Timer tests \n", 0);
+          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all Timer tests\n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -50,7 +50,7 @@ val_timer_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   skip_module = val_check_skip_module(AVS_TIMER_TEST_NUM_BASE);
   if (skip_module) {
-      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all Timer tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all Timer tests\n", 0);
       return AVS_STATUS_SKIP;
   }
 
@@ -290,7 +290,7 @@ val_timer_create_info_table(uint64_t *timer_info_table)
   uint64_t timer_entry;
 
   if (timer_info_table == NULL) {
-      val_print(AVS_PRINT_ERR, "Input for Create Info table cannot be NULL \n", 0);
+      val_print(AVS_PRINT_ERR, "Input for Create Info table cannot be NULL\n", 0);
       return;
   }
 
@@ -304,7 +304,7 @@ val_timer_create_info_table(uint64_t *timer_info_table)
   val_timer_set_phy_el1(0);
   val_timer_set_vir_el1(0);
 
-  val_print(AVS_PRINT_TEST, " TIMER_INFO: Number of system timers  : %4d \n",
+  val_print(AVS_PRINT_TEST, " TIMER_INFO: Number of system timers  : %4d\n",
                                                   g_timer_info_table->header.num_platform_timer);
 
   timer_num = val_timer_get_info(TIMER_INFO_NUM_PLATFORM_TIMERS, 0);

--- a/val/src/avs_timer_support.c
+++ b/val/src/avs_timer_support.c
@@ -76,7 +76,7 @@ ArmArchTimerReadReg (
       break;
 
     default:
-      val_print (AVS_PRINT_TEST, "Unknown ARM Generic Timer register %x. \n", Reg);
+      val_print (AVS_PRINT_TEST, "Unknown ARM Generic Timer register %x.\n", Reg);
     }
 
     return 0xFFFFFFFF;
@@ -92,7 +92,7 @@ ArmArchTimerWriteReg (
     switch (Reg) {
 
     case CntPct:
-      val_print(AVS_PRINT_TEST, "Can't write to Read Only Register: CNTPCT \n", 0);
+      val_print(AVS_PRINT_TEST, "Can't write to Read Only Register: CNTPCT\n", 0);
       break;
 
     case CntkCtl:
@@ -116,7 +116,7 @@ ArmArchTimerWriteReg (
       break;
 
     case CntvCt:
-       val_print(AVS_PRINT_TEST, "Can't write to Read Only Register: CNTVCT \n", 0);
+       val_print(AVS_PRINT_TEST, "Can't write to Read Only Register: CNTVCT\n", 0);
       break;
 
     case CntpCval:
@@ -150,6 +150,6 @@ ArmArchTimerWriteReg (
       break;
 
     default:
-      val_print(AVS_PRINT_TEST, "Unknown ARM Generic Timer register %x. \n", Reg);
+      val_print(AVS_PRINT_TEST, "Unknown ARM Generic Timer register %x.\n", Reg);
     }
 }

--- a/val/src/avs_wakeup.c
+++ b/val/src/avs_wakeup.c
@@ -43,7 +43,7 @@ val_wakeup_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_WAKEUP_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all Wakeup tests \n", 0);
+          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all Wakeup tests\n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -51,7 +51,7 @@ val_wakeup_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   skip_module = val_check_skip_module(AVS_WAKEUP_TEST_NUM_BASE);
   if (skip_module) {
-      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all Wakeup tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all Wakeup tests\n", 0);
       return AVS_STATUS_SKIP;
   }
 

--- a/val/src/avs_wd.c
+++ b/val/src/avs_wd.c
@@ -115,7 +115,8 @@ val_wd_create_info_table(uint64_t *wd_info_table)
 
   pal_wd_create_info_table(g_wd_info_table);
 
-  val_print(AVS_PRINT_TEST, " WATCHDOG_INFO: Number of Watchdogs   : %4d\n", val_wd_get_info(0, WD_INFO_COUNT));
+  val_print(AVS_PRINT_TEST, " WATCHDOG_INFO: Number of Watchdogs   : %4d\n",
+                                                            val_wd_get_info(0, WD_INFO_COUNT));
 }
 
 /**

--- a/val/src/avs_wd.c
+++ b/val/src/avs_wd.c
@@ -39,7 +39,7 @@ val_wd_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == AVS_WD_TEST_NUM_BASE) {
-          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all Watchdog tests \n", 0);
+          val_print(AVS_PRINT_INFO, "      USER Override - Skipping all Watchdog tests\n", 0);
           return AVS_STATUS_SKIP;
       }
   }
@@ -47,7 +47,7 @@ val_wd_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(AVS_WD_TEST_NUM_BASE);
   if (status) {
-      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all Watchdog tests \n", 0);
+      val_print(AVS_PRINT_INFO, "\n USER Override - Skipping all Watchdog tests\n", 0);
       return AVS_STATUS_SKIP;
   }
 
@@ -107,7 +107,7 @@ val_wd_create_info_table(uint64_t *wd_info_table)
 {
 
   if (wd_info_table == NULL) {
-      val_print(AVS_PRINT_ERR, "Input for Create Info table cannot be NULL \n", 0);
+      val_print(AVS_PRINT_ERR, "Input for Create Info table cannot be NULL\n", 0);
       return;
   }
 
@@ -115,7 +115,7 @@ val_wd_create_info_table(uint64_t *wd_info_table)
 
   pal_wd_create_info_table(g_wd_info_table);
 
-  val_print(AVS_PRINT_TEST, " WATCHDOG_INFO: Number of Watchdogs   : %4d \n", val_wd_get_info(0, WD_INFO_COUNT));
+  val_print(AVS_PRINT_TEST, " WATCHDOG_INFO: Number of Watchdogs   : %4d\n", val_wd_get_info(0, WD_INFO_COUNT));
 }
 
 /**

--- a/val/sys_arch_src/gic/its/sbsa_gic_its.c
+++ b/val/sys_arch_src/gic/its/sbsa_gic_its.c
@@ -515,7 +515,7 @@ uint32_t val_its_init(void)
   uint32_t    Status;
   uint32_t    index;
 
-  val_print(AVS_PRINT_INFO, "\n      Initializing GIC ITS \n", 0);
+  val_print(AVS_PRINT_INFO, "\n      Initializing GIC ITS\n", 0);
 
   g_cwriter_ptr = (uint32_t *)pal_aligned_alloc(MEM_ALIGN_4K,
                                            sizeof(uint32_t) * (g_gic_its_info->GicNumIts));
@@ -556,7 +556,7 @@ uint32_t val_its_init(void)
 
   g_its_setup_done = 1;
 
-  val_print(AVS_PRINT_INFO, "      ITS : Info Block \n", 0);
+  val_print(AVS_PRINT_INFO, "      ITS : Info Block\n", 0);
   for (index = 0; index < g_gic_its_info->GicNumIts; index++)
   {
       val_print(AVS_PRINT_INFO, "      GIC ITS Index : %x\n", index);


### PR DESCRIPTION
 - Removed unwanted whitespace characters before new line in console prints.
 - Aligned whitespaces and \n with rest of the prints for hygiene logs.
 - Adjusted few lines of code to have max 100 chars in a line.