### PR TITLE
L7_PE_09 is recommendation test

### DIFF
--- a/test_pool/pe/operating_system/test_c036.c
+++ b/test_pool/pe/operating_system/test_c036.c
@@ -27,6 +27,7 @@ static void payload(void)
 {
     uint64_t data = 0;
     uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
+    uint32_t primary_pe_idx = val_pe_get_primary_index();
 
     if (g_sbsa_level < 7) {
         val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
@@ -36,11 +37,17 @@ static void payload(void)
     /* ID_AA64MMFR1_EL1.TWED [35:32] = 0b0001 indicates support for configurable delayed
        trapping for WFE instruction */
     data = VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64MMFR1_EL1), 32, 35);
+    if (index == primary_pe_idx)
+        val_print(AVS_PRINT_DEBUG, "\n       ID_AA64MMFR1_EL1.TWED = %llx", data);
 
     if (data == 1)
         val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
-    else
-        val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
+    else {
+        if (index == primary_pe_idx)
+            val_print(AVS_PRINT_WARN,
+                "\n       Recommened WFE fine-tuning delay feature not implemented", 0);
+        val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 02));
+    }
 }
 
 uint32_t c036_entry(uint32_t num_pe)

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -91,6 +91,7 @@ uint32_t val_pe_get_uid(uint64_t mpidr);
 uint32_t val_pe_install_esr(uint32_t exception_type, void (*esr)(uint64_t, void *));
 uint32_t val_pe_get_gmain_gsiv(uint32_t index);
 uint32_t val_pe_feat_check(PE_FEAT_NAME pe_feature);
+uint32_t val_pe_get_primary_index(void);
 
 void     val_execute_on_pe(uint32_t index, void (*payload)(void), uint64_t args);
 void     val_suspend_pe(uint32_t power_state, uint64_t entry, uint32_t context_id);

--- a/val/src/avs_pe_infra.c
+++ b/val/src/avs_pe_infra.c
@@ -44,6 +44,8 @@ CACHE_INFO_TABLE *g_cache_info_table;
 **/
 ARM_SMC_ARGS g_smc_args;
 
+/* global variable to store primary PE index */
+uint32_t g_primary_pe_index = 0;
 
 /**
   @brief   This API will call PAL layer to fill in the PE information
@@ -86,6 +88,10 @@ val_pe_create_info_table(uint64_t *pe_info_table)
       val_print(AVS_PRINT_ERR, "\n *** CRITICAL ERROR: Num PE is 0x0 ***\n", 0);
       return AVS_STATUS_ERR;
   }
+  /* store primary PE index for debug message printing purposes on
+     multi PE tests */
+  g_primary_pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
+  val_print(AVS_PRINT_DEBUG, " PE_INFO: Primary PE index       : %4d \n", g_primary_pe_index);
   return AVS_STATUS_PASS;
 }
 
@@ -447,6 +453,19 @@ val_pe_cache_clean_range(uint64_t start_addr, uint64_t length)
       aligned_addr += line_length;
   }
 #endif
+}
+
+/**
+  @brief   This API returns the index of primary PE on which system is booted.
+           1. Caller       -  Test Suite, VAL
+           2. Prerequisite -  val_create_peinfo_table
+  @param   None
+  @return  Primary PE index.
+**/
+uint32_t
+val_pe_get_primary_index(void)
+{
+  return g_primary_pe_index;
 }
 
 /**


### PR DESCRIPTION
 - It is recommended that PEs implement the WFE fine-tuning delay feature, Changing from fail to skip.
 - Added VAL API to get the primery PE index which helps to print only when test is running on primary PE
 - Added a print to display value of ID_AA64MMFR0_EL1.TWED only when test is running on primary PE.