### PR TITLE
Fixes irq_to_hwirq() API should have a return type of uint64

### DIFF
--- a/platform/pal_baremetal/common/include/pal_common_support.h
+++ b/platform/pal_baremetal/common/include/pal_common_support.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2020-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -502,7 +502,7 @@ typedef struct {
   uint32_t  vector_lower_addr; ///< Base Address of the controller
   uint32_t  vector_data;       ///< Base Address of the controller
   uint32_t  vector_control;    ///< IRQ to install an ISR
-  uint32_t  vector_irq_base;   ///< Base IRQ for the vectors in the block
+  uint64_t  vector_irq_base;   ///< Base IRQ for the vectors in the block
   uint32_t  vector_n_irqs;     ///< Number of irq vectors in the block
   uint32_t  vector_mapped_irq_base; ///< Mapped IRQ number base for this MSI
 }PERIPHERAL_VECTOR_BLOCK;

--- a/platform/pal_uefi/include/pal_uefi.h
+++ b/platform/pal_uefi/include/pal_uefi.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -403,7 +403,7 @@ typedef struct {
   UINT32         vector_lower_addr; ///< Base Address of the controller
   UINT32         vector_data;       ///< Base Address of the controller
   UINT32         vector_control;    ///< IRQ to install an ISR
-  UINT32         vector_irq_base;   ///< Base IRQ for the vectors in the block
+  UINT64         vector_irq_base;   ///< Base IRQ for the vectors in the block
   UINT32         vector_n_irqs;     ///< Number of irq vectors in the block
   UINT32         vector_mapped_irq_base; ///< Mapped IRQ number base for this MSI
 }PERIPHERAL_VECTOR_BLOCK;

--- a/test_pool/pcie/operating_system/test_p009.c
+++ b/test_pool/pcie/operating_system/test_p009.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -107,7 +107,7 @@ payload (void)
           while(mvec) {
               if(mvec->vector.vector_irq_base < LPI_BASE) {
                  val_print(AVS_PRINT_ERR,
-                    "       MSI vector irq %d is not an LPI\n", mvec->vector.vector_irq_base);
+                    "       MSI vector irq %llx is not an LPI\n", mvec->vector.vector_irq_base);
                  val_set_status (index, RESULT_FAIL (g_sbsa_level, TEST_NUM, mvec->vector.vector_irq_base));
                  status = 1;
               }

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -610,7 +610,7 @@ typedef struct {
   uint32_t         vector_lower_addr; ///< Base Address of the controller
   uint32_t         vector_data;       ///< Base Address of the controller
   uint32_t         vector_control;    ///< IRQ to install an ISR
-  uint32_t         vector_irq_base;   ///< Base IRQ for the vectors in the block
+  uint64_t         vector_irq_base;   ///< Base IRQ for the vectors in the block
   uint32_t         vector_n_irqs;     ///< Number of irq vectors in the block
   uint32_t         vector_mapped_irq_base; ///< Mapped IRQ number base for this MSI
 }PERIPHERAL_VECTOR_BLOCK;


### PR DESCRIPTION
Fixes irq_to_hwirq() API should have a return type of uint64