### PR TITLE
PE test 16, check for CPOR support for LLC presented as mem-side

### DIFF
--- a/baremetal_app/SbsaAvsMain.c
+++ b/baremetal_app/SbsaAvsMain.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2022-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2022-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,6 +38,7 @@ uint32_t  g_wakeup_timeout;
 uint32_t  *g_skip_test_num;
 uint32_t  *g_execute_tests;
 uint32_t  *g_execute_modules;
+uint32_t  g_sys_last_lvl_cache;
 
 extern uint32_t g_skip_array[];
 extern uint32_t g_num_skip;
@@ -351,6 +352,7 @@ ShellAppMainsbsa(
   g_execute_nist = FALSE;
   g_print_mmio = FALSE;
   g_wakeup_timeout = PLATFORM_OVERRIDE_TIMEOUT;
+  g_sys_last_lvl_cache = PLATFORM_OVERRRIDE_SLC;
 
   //
   // Initialize global counters

--- a/platform/pal_baremetal/RDN2/include/platform_override_fvp.h
+++ b/platform/pal_baremetal/RDN2/include/platform_override_fvp.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2020-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,13 @@
 /* Settings */
 #define PLATFORM_OVERRIDE_SBSA_LEVEL   0x7     //The permissible levels are 3,4,5,6 and 7
 #define PLATFORM_OVERRIDE_PRINT_LEVEL  0x3     //The permissible levels are 1,2,3,4 and 5
+
+/* System Last-Level cache info
+   0 - Unknown
+   1 - PPTT PE-side LLC
+   2 - HMAT mem-side LLC
+*/
+#define PLATFORM_OVERRRIDE_SLC 0x0
 
 /* PCIe BAR config parameters*/
 #define PLATFORM_OVERRIDE_PCIE_BAR64_VAL   0x4000100000

--- a/platform/pal_uefi/src/pal_mpam.c
+++ b/platform/pal_uefi/src/pal_mpam.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -65,6 +65,8 @@ pal_mpam_dump_table(MPAM_INFO_TABLE *MpamTable)
                             curr_entry->rsrc_node[j].locator_type);
           sbsa_print(AVS_PRINT_INFO, L"\ndescriptor1     :%llx ",
                              curr_entry->rsrc_node[j].descriptor1);
+          sbsa_print(AVS_PRINT_INFO, L"\ndescriptor2     :%x ",
+                             curr_entry->rsrc_node[j].descriptor2);
       }
       curr_entry = MPAM_NEXT_MSC(curr_entry);
   }
@@ -163,6 +165,7 @@ pal_mpam_create_info_table(MPAM_INFO_TABLE *MpamTable)
          curr_entry->rsrc_node[i].ris_index = rsrc_node->ris_index;
          curr_entry->rsrc_node[i].locator_type = rsrc_node->locator_type;
          curr_entry->rsrc_node[i].descriptor1 =  rsrc_node->descriptor1;
+         curr_entry->rsrc_node[i].descriptor2 =  rsrc_node->descriptor2;
          rsrc_node = ADD_PTR(EFI_ACPI_MPAM_RESOURCE_NODE_STRUCTURE, rsrc_node,
                      sizeof(EFI_ACPI_MPAM_RESOURCE_NODE_STRUCTURE) +
                      (sizeof(EFI_ACPI_MPAM_FUNC_DEPEN_DESC_STRUCTURE) *

--- a/test_pool/pe/operating_system/test_c016.c
+++ b/test_pool/pe/operating_system/test_c016.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,79 +24,138 @@
 #define TEST_RULE  "S_MPAM_PE"
 #define TEST_DESC  "Check MPAM LLC Requirements       "
 
+#define MEM_CACHE_LEVEL_1      1
+#define SLC_TYPE_UNKNOWN       0
+#define SLC_TYPE_PPTT_CACHE    1
+#define SLC_TYPE_MEMSIDE_CACHE 2
+
 static void payload(void)
 {
     uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
     uint32_t msc_node_cnt;
     uint32_t rsrc_node_cnt;
     uint32_t msc_index, rsrc_index;
-    uint32_t llc_index;
-    uint64_t cache_identifier;
-    uint32_t test_run = 0;
+    uint32_t pptt_llc_index;
+    uint64_t pptt_cache_id;
+    uint32_t pptt_llc_msc_found = 0;
+    uint32_t mem_llc_msc_found = 0;
     uint32_t ris_supported = 0;
-    uint32_t cpor_supported = 0;
+    uint32_t pe_prox_domain;
+    uint32_t pptt_llc_cpor_supported = 0;
+    uint32_t memside_llc_cpor_supported = 0;
+    uint64_t desc1;
+    uint64_t desc2;
 
     if (g_sbsa_level < 5) {
         val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
         return;
     }
 
-    /* Check if PE implements FEAT_MPAM */
+    /* If PE not implements FEAT_MPAM, Skip the test */
     if (!((VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64PFR0_EL1), 40, 43) > 0) ||
         (VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64PFR1_EL1), 16, 19) > 0))) {
-            val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
+            val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 02));
             return;
     }
 
-    /* Find the LLC cache identifier */
-    llc_index = val_cache_get_llc_index();
-    if (llc_index == CACHE_TABLE_EMPTY) {
-        val_print(AVS_PRINT_ERR, "\n       PPTT table empty", 0);
-        val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
-        return;
-    }
-    cache_identifier = val_cache_get_info(CACHE_ID, llc_index);
-
-    if (cache_identifier == INVALID_CACHE_INFO) {
-        val_print(AVS_PRINT_ERR, "\n       LLC invalid in PPTT", 0);
-        val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 02));
-        return;
-    }
-
-    /* Check in the MPAM table which MSC is attached to the LLC */
+    /* If MPAM table not present, or no MSC
+       found in table fail the test */
     msc_node_cnt = val_mpam_get_msc_count();
     val_print(AVS_PRINT_DEBUG, "\n       MSC count = %d", msc_node_cnt);
 
     if (msc_node_cnt == 0) {
         val_print(AVS_PRINT_ERR, "\n       MSC count is 0", 0);
-        val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 03));
+        val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));
         return;
     }
 
-    /* visit each MSC node and check for cache resources */
+    /* Find the PPTT LLC cache identifier */
+    pptt_llc_index = val_cache_get_llc_index();
+    if (pptt_llc_index == CACHE_TABLE_EMPTY) {
+        val_print(AVS_PRINT_DEBUG, "\n       PPTT table empty", 0);
+    } else {
+        pptt_cache_id = val_cache_get_info(CACHE_ID, pptt_llc_index);
+        if (pptt_cache_id == INVALID_CACHE_INFO) {
+            val_print(AVS_PRINT_DEBUG, "\n       LLC invalid in PPTT", 0);
+        } else {
+
+            /* visit each MSC node and check for PPTT cache resources */
+            for (msc_index = 0; msc_index < msc_node_cnt; msc_index++) {
+                rsrc_node_cnt = val_mpam_get_info(MPAM_MSC_RSRC_COUNT, msc_index, 0);
+
+                val_print(AVS_PRINT_DEBUG, "\n       MSC index  = %d", msc_index);
+                val_print(AVS_PRINT_DEBUG, "\n       Resource count = %d", rsrc_node_cnt);
+
+                ris_supported = val_mpam_msc_supports_ris(msc_index);
+                val_print(AVS_PRINT_INFO, "\n       RIS support = %d", ris_supported);
+
+                for (rsrc_index = 0; rsrc_index < rsrc_node_cnt; rsrc_index++) {
+                    /* check whether the resource location is PPTT cache */
+                    if (val_mpam_get_info(MPAM_MSC_RSRC_TYPE, msc_index, rsrc_index) ==
+                                                                        MPAM_RSRC_TYPE_PE_CACHE) {
+                        val_print(AVS_PRINT_DEBUG, "\n       rsrc index  = %d", rsrc_index);
+                        desc1 = val_mpam_get_info(MPAM_MSC_RSRC_DESC1, msc_index, rsrc_index);
+
+                        /* match pptt llc cache id */
+                        val_print(AVS_PRINT_DEBUG, "\n       rsrc descriptor 1  = %llx", desc1);
+                        if (desc1 == pptt_cache_id) {
+                            pptt_llc_msc_found = 1;
+                            /* Select resource instance if RIS feature implemented */
+                            if (ris_supported)
+                                val_mpam_memory_configure_ris_sel(msc_index, rsrc_index);
+
+                            /* Check CPOR are present */
+                            if (val_mpam_supports_cpor(msc_index)) {
+                                val_print(AVS_PRINT_DEBUG,
+                                    "\n       CPOR Supported by LLC for rsrc_index %d", rsrc_index);
+                                pptt_llc_cpor_supported = 1;
+                                break;
+                            }
+                            val_print(AVS_PRINT_DEBUG,
+                              "\n       CPOR Not Supported by LLC for rsrc_index %d", rsrc_index);
+                        }
+                    }
+                }
+                if (pptt_llc_cpor_supported)
+                    break;
+            }
+        }
+    }
+
+    if (!pptt_llc_msc_found) {
+        val_print(AVS_PRINT_DEBUG, "\n       No MSC found on PPTT LLC", 0);
+    } else if (!pptt_llc_cpor_supported) {
+        val_print(AVS_PRINT_DEBUG, "\n       CPOR unsupported by PPTT LLC", 0);
+    }
+
+    /* test mem-side cache for cpor support */
+    val_print(AVS_PRINT_DEBUG, "\n\n       Testing mem-side caches for CPOR support", 0);
+    pe_prox_domain = val_srat_get_info(SRAT_GICC_PROX_DOMAIN, val_pe_get_uid(index));
+    /* visit each MSC node and check for mem cache resources */
     for (msc_index = 0; msc_index < msc_node_cnt; msc_index++) {
         rsrc_node_cnt = val_mpam_get_info(MPAM_MSC_RSRC_COUNT, msc_index, 0);
 
-        val_print(AVS_PRINT_DEBUG, "\n       msc index  = %d", msc_index);
+        val_print(AVS_PRINT_DEBUG, "\n       MSC index  = %d", msc_index);
         val_print(AVS_PRINT_DEBUG, "\n       Resource count = %d", rsrc_node_cnt);
 
-        cpor_supported = 0;
-
         ris_supported = val_mpam_msc_supports_ris(msc_index);
-        val_print(AVS_PRINT_INFO, "\n       RIS Support = %d", ris_supported);
+        val_print(AVS_PRINT_INFO, "\n       RIS support = %d", ris_supported);
 
         for (rsrc_index = 0; rsrc_index < rsrc_node_cnt; rsrc_index++) {
-
-            /* check whether the resource location is cache */
+            /* check whether the resource type is a mem-cache */
             if (val_mpam_get_info(MPAM_MSC_RSRC_TYPE, msc_index, rsrc_index) ==
-                                                                       MPAM_RSRC_TYPE_PE_CACHE) {
-                if (val_mpam_get_info(MPAM_MSC_RSRC_DESC1, msc_index, rsrc_index) ==
-                                                                               cache_identifier) {
-                    /* We have MSC which controls/monitors the LLC cache */
-                    val_print(AVS_PRINT_DEBUG, "\n       rsrc index  = %d", rsrc_index);
+                MPAM_RSRC_TYPE_MEM_SIDE_CACHE) {
+                val_print(AVS_PRINT_DEBUG, "\n       rsrc index  = %d", rsrc_index);
+                desc1 = val_mpam_get_info(MPAM_MSC_RSRC_DESC1, msc_index, rsrc_index);
+                desc2 = val_mpam_get_info(MPAM_MSC_RSRC_DESC2, msc_index, rsrc_index);
+                val_print(AVS_PRINT_DEBUG, "\n       rsrc descriptor 1  = %llx", desc1);
+                val_print(AVS_PRINT_DEBUG, "\n       rsrc descriptor 2  = %llx", desc2);
 
-                    test_run = 1;
-
+                /* check if mem-side cache matches with PE proximity domain
+                   and cache level == 1 for mem-side LLC (based on assumption that
+           mem-cache nearer to memory is LLC) */
+                if ((desc2 == pe_prox_domain) && (desc1 == MEM_CACHE_LEVEL_1)) {
+                    mem_llc_msc_found = 1;
                     /* Select resource instance if RIS feature implemented */
                     if (ris_supported)
                         val_mpam_memory_configure_ris_sel(msc_index, rsrc_index);
@@ -104,30 +163,57 @@ static void payload(void)
                     /* Check CPOR are present */
                     if (val_mpam_supports_cpor(msc_index)) {
                         val_print(AVS_PRINT_DEBUG,
-                                  "\n       CPOR Supported by LLC for rsrc_index %d", rsrc_index);
-                        cpor_supported = 1;
+                                  "\n       CPOR Supported by mem-side cache with rsrc_index %d",
+                  rsrc_index);
+                        memside_llc_cpor_supported = 1;
                         break;
                     }
                     val_print(AVS_PRINT_DEBUG,
-                              "\n       CPOR Not Supported by LLC for rsrc_index %d", rsrc_index);
+                              "\n       CPOR Not Supported by mem-side cache with rsrc_index %d",
+                   rsrc_index);
                 }
             }
         }
-        if (cpor_supported)
+        if (memside_llc_cpor_supported)
             break;
     }
 
-    if (!test_run) {
-        val_print(AVS_PRINT_ERR, "\n       No LLC MSC found", 0);
-        val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 05));
-        return;
-    } else if (!cpor_supported) {
-        val_print(AVS_PRINT_ERR, "\n       CPOR unsupported by LLC", 0);
-        val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 04));
-        return;
+    if (!mem_llc_msc_found) {
+        val_print(AVS_PRINT_DEBUG, "\n       No MSC found on mem-side LLC", 0);
+    } else if (!memside_llc_cpor_supported) {
+        val_print(AVS_PRINT_DEBUG, "\n       CPOR unsupported by mem-side LLC", 0);
     }
 
-    val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
+    /* if both PPTT LLC and mem-side cache MSCs found, read user input to
+       know which should be considered as Last level System Cache */
+    if (pptt_llc_msc_found && mem_llc_msc_found) {
+        if (g_sys_last_lvl_cache == SLC_TYPE_UNKNOWN) {
+            val_print(AVS_PRINT_ERR, "\n       PPTT and memside LLC MSC found, Please provide"
+                      "System Last-Level cache info via -slc cmdline option \n", 0);
+            val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 02));
+            return;
+        } else if (g_sys_last_lvl_cache == SLC_TYPE_PPTT_CACHE && pptt_llc_cpor_supported) {
+            val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
+            return;
+        } else if (g_sys_last_lvl_cache == SLC_TYPE_MEMSIDE_CACHE && memside_llc_cpor_supported) {
+            val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 02));
+            return;
+        } else {
+            val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 03));
+            val_print(AVS_PRINT_ERR, "\n       CPOR unsupported by System last-level cache", 0);
+            return;
+        }
+    }
+
+    /* if either of PPTT LLC or mem-side LLC supports cache portioning (CPOR) pass the test */
+    if (pptt_llc_cpor_supported || memside_llc_cpor_supported) {
+        val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 03));
+    }
+    else {
+        val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 04));
+    }
+
+    return;
 }
 
 uint32_t c016_entry(uint32_t num_pe)

--- a/uefi_app/SbsaAvsMain.c
+++ b/uefi_app/SbsaAvsMain.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,6 +51,7 @@ UINT64  g_stack_pointer;
 UINT64  g_exception_ret_addr;
 UINT64  g_ret_addr;
 UINT32  g_wakeup_timeout;
+UINT32 g_sys_last_lvl_cache;
 SHELL_FILE_HANDLE g_sbsa_log_file_handle;
 
 STATIC VOID FlushImage (VOID)
@@ -445,6 +446,9 @@ HelpMsg (
          "-cache  Pass this flag to indicate that if the test system supports PCIe address translation cache\n"
          "-timeout  Set timeout multiple for wakeup tests\n"
          "        1 - min value  5 - max value\n"
+         "-slc    Provide system last level cache type\n"
+         "        1 - PPTT PE-side cache,  2 - HMAT mem-side cache\n"
+         "        defaults to 0, if not set depicting SLC type unknown\n"
   );
 }
 
@@ -462,6 +466,7 @@ STATIC CONST SHELL_PARAM_ITEM ParamList[] = {
   {L"-p2p", TypeFlag},       // -p2p  # Peer-to-Peer is supported
   {L"-cache", TypeFlag},     // -cache# PCIe address translation cache is supported
   {L"-timeout" , TypeValue}, // -timeout # Set timeout multiple for wakeup tests
+  {L"-slc"  , TypeValue},    // -slc  # system last level cache type
   {NULL     , TypeMax}
   };
 
@@ -569,7 +574,7 @@ ShellAppMainsbsa (
     Print(L"Wakeup timeout multiple %d.\n", g_wakeup_timeout);
     if (g_wakeup_timeout > 5)
         g_wakeup_timeout = 5;
-    }
+  }
 
     // Options with Values
   CmdLineArg  = ShellCommandLineGetValue (ParamPackage, L"-f");
@@ -584,6 +589,17 @@ ShellAppMainsbsa (
     }
   }
 
+  /* get System Last-level cache info */
+  CmdLineArg  = ShellCommandLineGetValue (ParamPackage, L"-slc");
+  if (CmdLineArg == NULL) {
+    g_sys_last_lvl_cache = 0; /* default value. SLC unknown */
+  } else {
+    g_sys_last_lvl_cache = StrDecimalToUintn(CmdLineArg);
+    if (g_sys_last_lvl_cache > 2 || g_sys_last_lvl_cache < 1) {
+        Print(L"Invalid value provided for -slc, Value = %d\n", g_sys_last_lvl_cache);
+        g_sys_last_lvl_cache = 0; /* default value. SLC unknown */
+    }
+  }
 
   // Options with Flags
   if ((ShellCommandLineGetFlag (ParamPackage, L"-help")) || (ShellCommandLineGetFlag (ParamPackage, L"-h"))){

--- a/val/include/sbsa_avs_cfg.h
+++ b/val/include/sbsa_avs_cfg.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,4 +34,5 @@ extern uint32_t *g_execute_tests;
 extern uint32_t g_num_tests;
 extern uint32_t *g_execute_modules;
 extern uint32_t g_num_modules;
+extern uint32_t g_sys_last_lvl_cache;
 #endif

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -461,6 +461,7 @@ typedef enum {
   MPAM_MSC_BASE_ADDR,
   MPAM_MSC_ADDR_LEN,
   MPAM_MSC_RSRC_DESC1,
+  MPAM_MSC_RSRC_DESC2,
   MPAM_MSC_NRDY
 } MPAM_INFO_e;
 

--- a/val/src/avs_mpam.c
+++ b/val/src/avs_mpam.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -180,6 +180,8 @@ val_mpam_get_info(MPAM_INFO_e type, uint32_t msc_index, uint32_t rsrc_index)
               return msc_entry->rsrc_node[rsrc_index].locator_type;
           case MPAM_MSC_RSRC_DESC1:
               return msc_entry->rsrc_node[rsrc_index].descriptor1;
+          case MPAM_MSC_RSRC_DESC2:
+              return msc_entry->rsrc_node[rsrc_index].descriptor2;
           case MPAM_MSC_BASE_ADDR:
               return msc_entry->msc_base_addr;
           case MPAM_MSC_ADDR_LEN:


### PR DESCRIPTION
 - Added support to parse and check for cpor support by memory side last level cache.
 - Level 1 mem-side cache present near to memory is considered as mem-side LLC.

Fixes: #388