### PR TITLE
Removing DMA status dependency on exerciser

### DIFF
--- a/platform/pal_baremetal/RDN2/src/pal_bm_exerciser.c
+++ b/platform/pal_baremetal/RDN2/src/pal_bm_exerciser.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -170,7 +170,6 @@ uint32_t pal_exerciser_start_dma_direction (uint64_t Base, EXERCISER_DMA_ATTR Di
   */
 
   uint32_t Mask;
-  uint32_t Status;
 
   if (Direction == EDMA_TO_DEVICE) {
 
@@ -186,10 +185,7 @@ uint32_t pal_exerciser_start_dma_direction (uint64_t Base, EXERCISER_DMA_ATTR Di
   // Triggering the DMA
   pal_mmio_write(Base + DMACTL1, (pal_mmio_read(Base + DMACTL1) | MASK_BIT));
 
-  // Reading the Status of the DMA
-
-  Status = (pal_mmio_read(Base + DMASTATUS) & ((MASK_BIT << 1) | MASK_BIT));
-  return Status;
+  return 0;
 }
 
 /**

--- a/platform/pal_uefi/src/pal_exerciser.c
+++ b/platform/pal_uefi/src/pal_exerciser.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -103,7 +103,6 @@ pal_exerciser_start_dma_direction (
   )
 {
   UINT32 Mask;
-  UINT32 Status;
 
   if (Direction == EDMA_TO_DEVICE) {
       Mask = DMA_TO_DEVICE_MASK;//  DMA direction:to Device
@@ -118,9 +117,7 @@ pal_exerciser_start_dma_direction (
   // Triggering the DMA
   pal_mmio_write(Base + DMACTL1, (pal_mmio_read(Base + DMACTL1) | MASK_BIT));
 
-  // Reading the Status of the DMA
-  Status = (pal_mmio_read(Base + DMASTATUS) & ((MASK_BIT << 1) | MASK_BIT));
-  return Status;
+  return 0;
 }
 
 /**

--- a/test_pool/exerciser/operating_system/test_e002.c
+++ b/test_pool/exerciser/operating_system/test_e002.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -234,10 +234,7 @@ payload(void)
     }
 
     /* Trigger DMA from input buffer to exerciser memory */
-    if (val_exerciser_ops(START_DMA, EDMA_TO_DEVICE, instance)) {
-        val_print(AVS_PRINT_ERR, "\n       DMA write failure to exerciser %4x", instance);
-        goto test_fail;
-    }
+    val_exerciser_ops(START_DMA, EDMA_TO_DEVICE, instance);
 
     if (val_exerciser_set_param(DMA_ATTRIBUTES, dram_buf_out_iova, dma_len, instance)) {
         val_print(AVS_PRINT_ERR, "\n       DMA attributes setting failure %4x", instance);
@@ -245,10 +242,7 @@ payload(void)
     }
 
     /* Trigger DMA from exerciser memory to output buffer*/
-    if (val_exerciser_ops(START_DMA, EDMA_FROM_DEVICE, instance)) {
-        val_print(AVS_PRINT_ERR, "\n       DMA read failure from exerciser %4x", instance);
-        goto test_fail;
-    }
+    val_exerciser_ops(START_DMA, EDMA_FROM_DEVICE, instance);
 
     if (val_memory_compare(dram_buf_in_virt, dram_buf_out_virt, dma_len)) {
         val_print(AVS_PRINT_ERR, "\n       Data Comparasion failure for Exerciser %4x", instance);

--- a/test_pool/exerciser/operating_system/test_e003.c
+++ b/test_pool/exerciser/operating_system/test_e003.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -292,10 +292,7 @@ payload(void)
     }
 
     /* Trigger DMA from input buffer to exerciser memory */
-    if (val_exerciser_ops(START_DMA, EDMA_TO_DEVICE, instance)) {
-        val_print(AVS_PRINT_ERR, "\n       DMA write failure to exerciser %4x", instance);
-        goto test_fail;
-    }
+    val_exerciser_ops(START_DMA, EDMA_TO_DEVICE, instance);
 
     if (val_exerciser_set_param(DMA_ATTRIBUTES, dram_buf_out_iova, dma_len, instance)) {
         val_print(AVS_PRINT_ERR, "\n       DMA attributes setting failure %4x", instance);
@@ -303,10 +300,7 @@ payload(void)
     }
 
     /* Trigger DMA from exerciser memory to output buffer*/
-    if (val_exerciser_ops(START_DMA, EDMA_FROM_DEVICE, instance)) {
-        val_print(AVS_PRINT_ERR, "\n       DMA read failure from exerciser %4x", instance);
-        goto test_fail;
-    }
+    val_exerciser_ops(START_DMA, EDMA_FROM_DEVICE, instance);
 
     if (val_memory_compare(dram_buf_in_virt, dram_buf_out_virt, dma_len)) {
         val_print(AVS_PRINT_ERR, "\n       Data Comparasion failure for Exerciser %4x", instance);


### PR DESCRIPTION
- Exerciser does not have a way to identify the status of DMA transaction as they are posted requests.
- Removed DMA status dependency on exerciser APIs.
- Mem compare of input and output buffers verifies the status of DMA transactions. 
 