### PR TITLE
Sbsa Errata Mantis - 668, 659, 581 and 582

### DIFF
--- a/test_pool/pe/operating_system/test_c030.c
+++ b/test_pool/pe/operating_system/test_c030.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,22 +21,26 @@
 
 #define TEST_NUM   (AVS_PE_TEST_NUM_BASE  +  30)
 #define TEST_RULE  "S_L7PE_03"
-#define TEST_DESC  "Check for AMUv1p1 Support         "
+#define TEST_DESC  "Check for AMUv1 Support           "
 
 static void payload(void)
 {
     uint64_t data = 0;
     uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
+    uint32_t primary_pe_idx = val_pe_get_primary_index();
 
     if (g_sbsa_level < 7) {
         val_set_status(index, RESULT_SKIP(g_sbsa_level, TEST_NUM, 01));
         return;
     }
 
-    /*  ID_AA64PFR0_EL1.AMU[47:44] = 0b0010 indicate AMU Support */
+    /*  ID_AA64PFR0_EL1.AMU[47:44] >= 0b0001 indicate AMU Support */
     data = VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64PFR0_EL1), 44, 47);
+    if (index == primary_pe_idx) {
+        val_print(AVS_PRINT_DEBUG, "\n       ID_AA64PFR0_EL1.AMU[47:44]  = %llx", data);
+    }
 
-    if (data == 2)
+    if (data >= 1)
         val_set_status(index, RESULT_PASS(g_sbsa_level, TEST_NUM, 01));
     else
         val_set_status(index, RESULT_FAIL(g_sbsa_level, TEST_NUM, 01));

--- a/val/include/sbsa_avs_pe.h
+++ b/val/include/sbsa_avs_pe.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -161,7 +161,8 @@ typedef enum {
   MAIR_ELx,
   TCR_ELx,
   TTBR_ELx,
-  ID_AA64ZFR0_EL1
+  ID_AA64ZFR0_EL1,
+  ID_AA64ISAR2_EL1
 }SBSA_AVS_PE_REGS;
 
 uint64_t ArmReadMpidr(void);
@@ -183,6 +184,8 @@ uint64_t AA64ReadCtr(void);
 uint64_t AA64ReadIsar0(void);
 
 uint64_t AA64ReadIsar1(void);
+
+uint64_t AA64ReadIsar2(void);
 
 uint64_t AA64ReadSctlr3(void);
 

--- a/val/src/AArch64/PeRegSysSupport.S
+++ b/val/src/AArch64/PeRegSysSupport.S
@@ -1,5 +1,5 @@
 #/** @file
-# Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,6 +47,7 @@ GCC_ASM_EXPORT (AA64ReadCtr)
 GCC_ASM_EXPORT (ArmReadMmfr0)
 GCC_ASM_EXPORT (AA64ReadIsar0)
 GCC_ASM_EXPORT (AA64ReadIsar1)
+GCC_ASM_EXPORT (AA64ReadIsar2)
 GCC_ASM_EXPORT (AA64ReadSctlr3)
 GCC_ASM_EXPORT (AA64ReadSctlr2)
 GCC_ASM_EXPORT (AA64ReadSctlr1)
@@ -153,6 +154,10 @@ ASM_PFX(AA64ReadIsar0):
 
 ASM_PFX(AA64ReadIsar1):
   mrs   x0, id_aa64isar1_el1
+  ret
+
+ASM_PFX(AA64ReadIsar2):
+  mrs   x0, id_aa64isar2_el1
   ret
 
 ASM_PFX(AA64ReadSctlr3):

--- a/val/src/avs_pe.c
+++ b/val/src/avs_pe.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -148,6 +148,8 @@ val_pe_reg_read(uint32_t reg_id)
           return AA64ReadIsar0();
       case ID_AA64ISAR1_EL1:
           return AA64ReadIsar1();
+      case ID_AA64ISAR2_EL1:
+          return AA64ReadIsar2();
       case SCTLR_EL3:
           return AA64ReadSctlr3();
       case SCTLR_EL2:


### PR DESCRIPTION
- The rule S_l7PE_03 is changed to check for AMU support  (668)
- The rule S_L5PE_07 is changed to check for FEAT_NV   (659)
- The S_L5PE_02 is changed to check for both generic and address auth (581, 582)
- The rule S_L7PE_06 has added to check for one of QARMA3 and QARMA5 (581, 582)