### PR TITLE
Remove iEPs from test 850

### DIFF
--- a/test_pool/pcie/operating_system/test_p050.c
+++ b/test_pool/pcie/operating_system/test_p050.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2020-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -60,9 +60,8 @@ payload(void)
       bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
       dp_type = val_pcie_device_port_type(bdf);
 
-      /* Check entry is RCiEP/ RCEC/ iEP. Else move to next BDF. */
-      if ((dp_type != iEP_EP) && (dp_type != iEP_RP)
-          && (dp_type != RCEC) && (dp_type != RCiEP))
+      /* Check entry is RCiEP/ RCEC. Else move to next BDF. */
+      if ((dp_type != RCEC) && (dp_type != RCiEP))
           continue;
 
       val_print(AVS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);


### PR DESCRIPTION
- This rule is not requried to run for iEP_RP iEP_EP, as the rule IE_INT_1 and IE_INT_2 implies that iEP devices must generate only MSI or MSI-X interrupts and must not have any wire-based interrupts