### PR TITLE
Check export restriction for crypto extension. 

### DIFF
--- a/test_pool/pe/operating_system/test_c012.c
+++ b/test_pool/pe/operating_system/test_c012.c
@@ -32,6 +32,13 @@ static void payload(void)
         return;
     }
 
+    if (!g_crypto_support) {
+        val_print_primary_pe(ACS_PRINT_DEBUG, "\n       Export Restrictions on crypto extension",
+                                                                                      0, index);
+        val_set_status(index, RESULT_SKIP(TEST_NUM, 1));
+        return;
+  }
+
     /* Read ID_AA64ISAR0_EL1.SHA3[35:32] for cryptography support for SHA3 */
     data = VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64ISAR0_EL1), 32, 35);
     if (data == 0x1)

--- a/uefi_app/SbsaAvsMain.c
+++ b/uefi_app/SbsaAvsMain.c
@@ -49,6 +49,7 @@ UINT32  g_num_modules = 0;
 UINT32  g_acs_tests_total;
 UINT32  g_acs_tests_pass;
 UINT32  g_acs_tests_fail;
+UINT32  g_crypto_support = TRUE;
 UINT64  g_stack_pointer;
 UINT64  g_exception_ret_addr;
 UINT64  g_ret_addr;
@@ -450,6 +451,7 @@ HelpMsg (
          "-nist   Enable the NIST Statistical test suite\n"
          "-t      If Test ID(s) set, will only run the specified test, all others will be skipped.\n"
          "-m      If Module ID(s) set, will only run the specified module, all others will be skipped.\n"
+         "-no_crypto_ext  Pass this flag if cryptography extension not supported due to export restrictions\n"
          "-p2p    Pass this flag to indicate that PCIe Hierarchy Supports Peer-to-Peer\n"
          "-cache  Pass this flag to indicate that if the test system supports PCIe address translation cache\n"
          "-timeout  Set timeout multiple for wakeup tests\n"
@@ -475,6 +477,7 @@ STATIC CONST SHELL_PARAM_ITEM ParamList[] = {
   {L"-m"    , TypeValue},    // -m    # Module to be run
   {L"-p2p", TypeFlag},       // -p2p  # Peer-to-Peer is supported
   {L"-cache", TypeFlag},     // -cache# PCIe address translation cache is supported
+  {L"-no_crypto_ext", TypeFlag},  //-no_crypto_ext # Skip tests which have export restrictions
   {L"-timeout" , TypeValue}, // -timeout # Set timeout multiple for wakeup tests
   {L"-slc"  , TypeValue},    // -slc  # system last level cache type
   {L"-el1physkip", TypeFlag}, // -el1physkip # Skips EL1 register checks
@@ -659,6 +662,10 @@ ShellAppMainsbsa (
   if (ShellCommandLineGetFlag (ParamPackage, L"-el1physkip")) {
     g_el1physkip = TRUE;
   }
+
+  // Options with Flags
+  if ((ShellCommandLineGetFlag (ParamPackage, L"-no_crypto_ext")))
+     g_crypto_support = FALSE;
 
   if (g_sbsa_level == 7)
       g_execute_nist = TRUE;


### PR DESCRIPTION
Fix for #439: Check for SHA3 and SHA512 support 

-Skip test_c012 based on command line argument
-The value of -no_crypto_ext flag depends on export restriction on crypto


Change-Id: I9dab9f818864b69dce3e32df19d83651b6810d3c