### PR TITLE
Added new argument "-only"

### DIFF
--- a/baremetal_app/SbsaAcsMain.c
+++ b/baremetal_app/SbsaAcsMain.c
@@ -342,7 +342,11 @@ ShellAppMainsbsa(
   val_print(ACS_PRINT_TEST, "%d.", SBSA_ACS_MINOR_VER);
   val_print(ACS_PRINT_TEST, "%d\n", SBSA_ACS_SUBMINOR_VER);
 
-  val_print(ACS_PRINT_TEST, "\n Starting tests for level %2d", g_sbsa_level);
+  if (g_sbsa_only_level)
+      val_print(ACS_PRINT_TEST, "\n Starting tests for only level %2d", g_sbsa_level);
+  else
+      val_print(ACS_PRINT_TEST, "\n Starting tests for level %2d", g_sbsa_level);
+
   val_print(ACS_PRINT_TEST, " (Print level is %2d)\n\n", g_print_level);
 
   val_print(ACS_PRINT_TEST, " Creating Platform Information Tables\n", 0);

--- a/linux_app/sbsa-acs-app/sbsa_app_main.c
+++ b/linux_app/sbsa-acs-app/sbsa_app_main.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,7 @@
 #include <getopt.h>
 
 int  g_sbsa_level = 4;
+int  g_sbsa_only_level = 0;
 int  g_print_level = 3;
 unsigned int g_num_skip = 3;
 unsigned int *g_skip_test_num;


### PR DESCRIPTION
 - Added new argument "-only" to only run tests belonging to a specific level of compliance
 - Changes in app files for prints when this option is passed