### PR TITLE
Removing WORKSPACE dependency from .inf files

### DIFF
--- a/tools/scripts/acsbuild.sh
+++ b/tools/scripts/acsbuild.sh
@@ -22,6 +22,19 @@ then
     return 0
 fi
 
+# Get the path of the current shell script. Based on the script path navigate to sbsa-acs path
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+sbsa_path="$(dirname "$(dirname "$script_dir")")"
+echo "sbsa-acs path is: $(realpath "$sbsa_path")"
+
+# Use the default bsa-acs directory
+bsa_path="$sbsa_path/../bsa-acs"
+
+# Export BSA_PATH to bsa-acs path. This will be used in .inf files with -I compiler option.
+export BSA_PATH=$(realpath "$bsa_path")
+echo "bsa-acs path set to: $(realpath "$bsa_path")"
+
 NISTStatus=1;
 
 function build_with_NIST()

--- a/uefi_app/SbsaAvs.inf
+++ b/uefi_app/SbsaAvs.inf
@@ -227,4 +227,4 @@
 
 [BuildOptions]
   GCC:*_*_*_ASM_FLAGS  =  -march=armv8.1-a
-  GCC:*_*_*_CC_FLAGS   = -O0 -I${WORKSPACE}/ShellPkg/Application/bsa-acs/val/ -I${WORKSPACE}/ShellPkg/Application/bsa-acs/val/sbsa -I${WORKSPACE}/ShellPkg/Application/bsa-acs/val/common -I${WORKSPACE}/ShellPkg/Application/bsa-acs/
+  GCC:*_*_*_CC_FLAGS   = -O0 -I${BSA_PATH}/ -I${BSA_PATH}/val/ -I${BSA_PATH}/val/sbsa -I${BSA_PATH}/val/common

--- a/uefi_app/SbsaAvsNist.inf
+++ b/uefi_app/SbsaAvsNist.inf
@@ -231,4 +231,4 @@
 
 [BuildOptions]
   GCC:*_*_*_ASM_FLAGS  =  -march=armv8.1-a
-  GCC:*_*_*_CC_FLAGS   = -O0 -I${WORKSPACE}/ShellPkg/Application/bsa-acs/val/ -I${WORKSPACE}/ShellPkg/Application/bsa-acs/val/sbsa -I${WORKSPACE}/ShellPkg/Application/bsa-acs/val/common -I${WORKSPACE}/ShellPkg/Application/bsa-acs/
+  GCC:*_*_*_CC_FLAGS   = -O0 -I${BSA_PATH}/ -I${BSA_PATH}/val/ -I${BSA_PATH}/val/sbsa -I${BSA_PATH}/val/common


### PR DESCRIPTION
1.  Resolves #446 
2.  -I compiler option now uses BSA_PATH instead of WORKSPACE.
3.  BSA_PATH to be set by acsbuild.sh script.