### PR TITLE
Change for consistent spaces across sbsa and bsa

### DIFF
--- a/test_pool/ete/operating_system/test_ete001.c
+++ b/test_pool/ete/operating_system/test_ete001.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_ETE_TEST_NUM_BASE + 1)
 #define TEST_RULE  "ETE_02"
-#define TEST_DESC  "Check for FEAT_ETE                "
+#define TEST_DESC  "Check for FEAT_ETE                    "
 
 static void payload(void)
 {

--- a/test_pool/ete/operating_system/test_ete002.c
+++ b/test_pool/ete/operating_system/test_ete002.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_ETE_TEST_NUM_BASE + 2)
 #define TEST_RULE  "ETE_03"
-#define TEST_DESC  "Check trace unit ETE supports     "
+#define TEST_DESC  "Check trace unit ETE supports         "
 
 static void payload(void)
 {

--- a/test_pool/ete/operating_system/test_ete003.c
+++ b/test_pool/ete/operating_system/test_ete003.c
@@ -27,7 +27,7 @@
 
 #define TEST_NUM   (ACS_ETE_TEST_NUM_BASE + 3)
 #define TEST_RULE  "ETE_04, ETE_06"
-#define TEST_DESC  "Check ETE Trace Timestamp Source  "
+#define TEST_DESC  "Check ETE Trace Timestamp Source      "
 
 volatile uint64_t buffer_addr;
 volatile uint64_t *start_timestamp;

--- a/test_pool/ete/operating_system/test_ete004.c
+++ b/test_pool/ete/operating_system/test_ete004.c
@@ -24,7 +24,7 @@
 
 #define TEST_NUM   (ACS_ETE_TEST_NUM_BASE + 4)
 #define TEST_RULE  "ETE_05"
-#define TEST_DESC  "Check Trace Same Timestamp Source "
+#define TEST_DESC  "Check Trace Same Timestamp Source     "
 
 volatile uint64_t trace_buffer_addr;
 

--- a/test_pool/ete/operating_system/test_ete005.c
+++ b/test_pool/ete/operating_system/test_ete005.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_ETE_TEST_NUM_BASE + 5)
 #define TEST_RULE  "ETE_07"
-#define TEST_DESC  "Check for FEAT_TRBE               "
+#define TEST_DESC  "Check for FEAT_TRBE                   "
 
 static void payload(void)
 {

--- a/test_pool/ete/operating_system/test_ete006.c
+++ b/test_pool/ete/operating_system/test_ete006.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_ETE_TEST_NUM_BASE + 6)
 #define TEST_RULE  "ETE_08"
-#define TEST_DESC  "Check trace buffers flag updates  "
+#define TEST_DESC  "Check trace buffers flag updates      "
 
 static uint32_t primary_pe_flag_updates;
 

--- a/test_pool/ete/operating_system/test_ete007.c
+++ b/test_pool/ete/operating_system/test_ete007.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_ETE_TEST_NUM_BASE + 7)
 #define TEST_RULE  "ETE_09"
-#define TEST_DESC  "Check TRBE trace buffers alignment"
+#define TEST_DESC  "Check TRBE trace buffers alignment    "
 
 static uint32_t min_trace_alignment;
 

--- a/test_pool/ete/operating_system/test_ete008.c
+++ b/test_pool/ete/operating_system/test_ete008.c
@@ -23,7 +23,7 @@
 
 #define TEST_NUM   (ACS_ETE_TEST_NUM_BASE + 8)
 #define TEST_RULE  "ETE_10"
-#define TEST_DESC  "Check GICC TRBE Interrupt field   "
+#define TEST_DESC  "Check GICC TRBE Interrupt field       "
 
 static void payload(void)
 {

--- a/test_pool/exerciser/operating_system/test_e001.c
+++ b/test_pool/exerciser/operating_system/test_e001.c
@@ -23,7 +23,7 @@
 #include "val/sbsa/include/sbsa_acs_exerciser.h"
 
 #define TEST_NUM   (ACS_EXERCISER_TEST_NUM_BASE + 1)
-#define TEST_DESC  "Enhanced ECAM Memory access check "
+#define TEST_DESC  "Enhanced ECAM Memory access check     "
 #define TEST_RULE  ""
 
 static

--- a/test_pool/exerciser/operating_system/test_e002.c
+++ b/test_pool/exerciser/operating_system/test_e002.c
@@ -30,7 +30,7 @@
 #include "val/sbsa/include/sbsa_acs_exerciser.h"
 
 #define TEST_NUM   (ACS_EXERCISER_TEST_NUM_BASE + 2)
-#define TEST_DESC  "PCIe Address translation check    "
+#define TEST_DESC  "PCIe Address translation check        "
 #define TEST_RULE  "RE_SMU_2"
 
 #define TEST_DATA_NUM_PAGES  4

--- a/test_pool/exerciser/operating_system/test_e003.c
+++ b/test_pool/exerciser/operating_system/test_e003.c
@@ -30,7 +30,7 @@
 #include "val/sbsa/include/sbsa_acs_exerciser.h"
 
 #define TEST_NUM   (ACS_EXERCISER_TEST_NUM_BASE + 3)
-#define TEST_DESC  "ATS Functionality Check           "
+#define TEST_DESC  "ATS Functionality Check               "
 #define TEST_RULE  "RE_SMU_2"
 
 #define TEST_DATA_NUM_PAGES  1

--- a/test_pool/exerciser/operating_system/test_e004.c
+++ b/test_pool/exerciser/operating_system/test_e004.c
@@ -26,7 +26,7 @@
 #include "val/sbsa/include/sbsa_acs_exerciser.h"
 
 #define TEST_NUM   (ACS_EXERCISER_TEST_NUM_BASE + 4)
-#define TEST_DESC  "Arrival order & Gathering Check   "
+#define TEST_DESC  "Arrival order & Gathering Check       "
 #define TEST_RULE  "RE_ORD_1, RE_ORD_2, IE_ORD_1, IE_ORD_2"
 
 /* 0 means read transction, 1 means write transaction */

--- a/test_pool/exerciser/operating_system/test_e005.c
+++ b/test_pool/exerciser/operating_system/test_e005.c
@@ -27,7 +27,7 @@
 #include "val/sbsa/include/sbsa_acs_exerciser.h"
 
 #define TEST_NUM   (ACS_EXERCISER_TEST_NUM_BASE + 5)
-#define TEST_DESC  "PE 2/4/8B writes to PCIe as 2/4/8B"
+#define TEST_DESC  "PE 2/4/8B writes to PCIe as 2/4/8B    "
 #define TEST_RULE  "S_PCIe_03"
 
 static uint32_t transaction_size = 4;

--- a/test_pool/exerciser/operating_system/test_e006.c
+++ b/test_pool/exerciser/operating_system/test_e006.c
@@ -29,7 +29,7 @@
 #include "val/sbsa/include/sbsa_acs_exerciser.h"
 
 #define TEST_NUM   (ACS_EXERCISER_TEST_NUM_BASE + 6)
-#define TEST_DESC  "RP's must support AER feature          "
+#define TEST_DESC  "RP's must support AER feature         "
 #define TEST_RULE  "PCI_ER_01, PCI_ER_02, PCI_ER_03, PCI_ER_04"
 
 #define ERR_CORR     0x2

--- a/test_pool/exerciser/operating_system/test_e007.c
+++ b/test_pool/exerciser/operating_system/test_e007.c
@@ -28,7 +28,7 @@
 #include "val/sbsa/include/sbsa_acs_exerciser.h"
 
 #define TEST_NUM   (ACS_EXERCISER_TEST_NUM_BASE + 7)
-#define TEST_DESC  "RP's must support DPC                  "
+#define TEST_DESC  "RP's must support DPC                 "
 #define TEST_RULE  "PCI_ER_05, PCI_ER_06"
 
 #define ERR_FATAL 1

--- a/test_pool/exerciser/operating_system/test_e008.c
+++ b/test_pool/exerciser/operating_system/test_e008.c
@@ -27,7 +27,7 @@
 #include "val/sbsa/include/sbsa_acs_pcie.h"
 
 #define TEST_NUM   (ACS_EXERCISER_TEST_NUM_BASE + 8)
-#define TEST_DESC  "Check 2/4/8 Bytes targeted writes"
+#define TEST_DESC  "Check 2/4/8 Bytes targeted writes     "
 #define TEST_RULE  "S_PCIe_04"
 
 

--- a/test_pool/exerciser/operating_system/test_e009.c
+++ b/test_pool/exerciser/operating_system/test_e009.c
@@ -27,7 +27,7 @@
 #include "val/sbsa/include/sbsa_acs_exerciser.h"
 
 #define TEST_NUM   (ACS_EXERCISER_TEST_NUM_BASE + 9)
-#define TEST_DESC  "Check Relaxed Ordering of writes  "
+#define TEST_DESC  "Check Relaxed Ordering of writes      "
 #define TEST_RULE  "S_PCIe_07, S_PCIe_08"
 
 #define DMA_BUFF_LEN 0x8

--- a/test_pool/exerciser/operating_system/test_e010.c
+++ b/test_pool/exerciser/operating_system/test_e010.c
@@ -29,7 +29,7 @@
 #include "val/sbsa/include/sbsa_acs_exerciser.h"
 
 #define TEST_NUM   (ACS_EXERCISER_TEST_NUM_BASE + 10)
-#define TEST_DESC  "DPC trig when RP-PIO unimplemented"
+#define TEST_DESC  "DPC trig when RP-PIO unimplemented    "
 #define TEST_RULE  "PCI_ER_10"
 
 #define ERR_UNCORR   0x3

--- a/test_pool/exerciser/operating_system/test_e011.c
+++ b/test_pool/exerciser/operating_system/test_e011.c
@@ -26,7 +26,7 @@
 
 #define TEST_NUM   (ACS_EXERCISER_TEST_NUM_BASE + 11)
 #define TEST_RULE  "PCI_ER_08"
-#define TEST_DESC  "RAS ERR record for poisoned data  "
+#define TEST_DESC  "RAS ERR record for poisoned data      "
 
 static
 void

--- a/test_pool/exerciser/operating_system/test_e012.c
+++ b/test_pool/exerciser/operating_system/test_e012.c
@@ -26,7 +26,7 @@
 #include "val/sbsa/include/sbsa_acs_exerciser.h"
 
 #define TEST_NUM   (ACS_EXERCISER_TEST_NUM_BASE + 12)
-#define TEST_DESC  "RAS ERR record for external abort "
+#define TEST_DESC  "RAS ERR record for external abort     "
 #define TEST_RULE  "PCI_ER_07"
 
 static void *branch_to_test;

--- a/test_pool/gic/operating_system/test_g001.c
+++ b/test_pool/gic/operating_system/test_g001.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_GIC_TEST_NUM_BASE + 1)
 #define TEST_RULE  "S_L3GI_01"
-#define TEST_DESC  "Check GIC version                 "
+#define TEST_DESC  "Check GIC version                     "
 
 static
 void

--- a/test_pool/gic/operating_system/test_g002.c
+++ b/test_pool/gic/operating_system/test_g002.c
@@ -23,7 +23,7 @@
 
 #define TEST_NUM   (ACS_GIC_TEST_NUM_BASE + 2)
 #define TEST_RULE  "S_L5PP_01"
-#define TEST_DESC  "Check Reserved PPI Assignments    "
+#define TEST_DESC  "Check Reserved PPI Assignments        "
 
 /* PPI IDs 1056-1071 and 1088-1103 are reserved for future SBSA usage */
 #define IS_PPI_RESERVED(id) ((id > 1055 && id < 1072) || (id > 1087 && id < 1104))

--- a/test_pool/memory_map/operating_system/test_m001.c
+++ b/test_pool/memory_map/operating_system/test_m001.c
@@ -23,7 +23,7 @@
 
 #define TEST_NUM (ACS_MEMORY_MAP_TEST_NUM_BASE + 1)
 #define TEST_RULE "S_L3MM_01, S_L3MM_02"
-#define TEST_DESC "Check peripherals addr 64Kb apart "
+#define TEST_DESC "Check peripherals addr 64Kb apart     "
 
 static void payload(void)
 {

--- a/test_pool/mpam/operating_system/test_mpam001.c
+++ b/test_pool/mpam/operating_system/test_mpam001.c
@@ -23,9 +23,9 @@
 #include "val/sbsa/include/sbsa_acs_mpam.h"
 
 
-#define TEST_NUM (ACS_MPAM_TEST_NUM_BASE + 1)
-#define TEST_RULE "S_L7MP_01, S_L7MP_02"
-#define TEST_DESC "Check for MPAM extension          "
+#define TEST_NUM   (ACS_MPAM_TEST_NUM_BASE + 1)
+#define TEST_RULE  "S_L7MP_01, S_L7MP_02"
+#define TEST_DESC  "Check for MPAM extension              "
 
 static void payload(void)
 {

--- a/test_pool/mpam/operating_system/test_mpam002.c
+++ b/test_pool/mpam/operating_system/test_mpam002.c
@@ -23,9 +23,9 @@
 #include "val/sbsa/include/sbsa_acs_mpam.h"
 
 
-#define TEST_NUM (ACS_MPAM_TEST_NUM_BASE + 2)
-#define TEST_RULE "S_L7MP_03, S_L7MP_04"
-#define TEST_DESC "Check for MPAM LLC CSU            "
+#define TEST_NUM   (ACS_MPAM_TEST_NUM_BASE + 2)
+#define TEST_RULE  "S_L7MP_03, S_L7MP_04"
+#define TEST_DESC  "Check for MPAM LLC CSU                "
 
 static void payload(void)
 {

--- a/test_pool/mpam/operating_system/test_mpam003.c
+++ b/test_pool/mpam/operating_system/test_mpam003.c
@@ -24,9 +24,9 @@
 #include "val/sbsa/include/sbsa_acs_mpam.h"
 
 
-#define TEST_NUM  (ACS_MPAM_TEST_NUM_BASE + 3)
-#define TEST_RULE "S_L7MP_05, S_L7MP_06"
-#define TEST_DESC "Check for MPAM MBWUs Monitor func "
+#define TEST_NUM   (ACS_MPAM_TEST_NUM_BASE + 3)
+#define TEST_RULE  "S_L7MP_05, S_L7MP_06"
+#define TEST_DESC  "Check for MPAM MBWUs Monitor func     "
 
 #define BUFFER_SIZE 65536 /* 64 Kilobytes*/
 

--- a/test_pool/mpam/operating_system/test_mpam004.c
+++ b/test_pool/mpam/operating_system/test_mpam004.c
@@ -24,9 +24,9 @@
 #include "val/sbsa/include/sbsa_acs_mpam.h"
 
 
-#define TEST_NUM  (ACS_MPAM_TEST_NUM_BASE + 4)
-#define TEST_RULE "S_L7MP_07"
-#define TEST_DESC "Check for MBWU counter size       "
+#define TEST_NUM   (ACS_MPAM_TEST_NUM_BASE + 4)
+#define TEST_RULE  "S_L7MP_07"
+#define TEST_DESC  "Check for MBWU counter size           "
 
 #define MBWU_COUNTER_44BIT 0
 #define MAX_44BIT_COUNTER_BW 1677722 /* this is in MB (1.6 TB) */

--- a/test_pool/mpam/operating_system/test_mpam005.c
+++ b/test_pool/mpam/operating_system/test_mpam005.c
@@ -22,9 +22,9 @@
 #include "val/sbsa/include/sbsa_acs_mpam.h"
 #include "val/common/include/acs_peripherals.h"
 
-#define TEST_NUM (ACS_MPAM_TEST_NUM_BASE + 5)
-#define TEST_RULE "S_L7MP_08"
-#define TEST_DESC "Check for MPAM MSC address overlap"
+#define TEST_NUM   (ACS_MPAM_TEST_NUM_BASE + 5)
+#define TEST_RULE  "S_L7MP_08"
+#define TEST_DESC  "Check for MPAM MSC address overlap    "
 
 static void payload(void)
 {

--- a/test_pool/mpam/operating_system/test_mpam006.c
+++ b/test_pool/mpam/operating_system/test_mpam006.c
@@ -23,9 +23,9 @@
 #include "val/sbsa/include/sbsa_acs_mpam.h"
 #include "val/sbsa/include/sbsa_acs_memory.h"
 
-#define TEST_NUM (ACS_MPAM_TEST_NUM_BASE + 6)
-#define TEST_RULE "S_L7MP_03"
-#define TEST_DESC "Check PMG storage by CPOR nodes   "
+#define TEST_NUM   (ACS_MPAM_TEST_NUM_BASE + 6)
+#define TEST_RULE  "S_L7MP_03"
+#define TEST_DESC  "Check PMG storage by CPOR nodes       "
 
 #define PARTITION_PERCENTAGE 75
 #define CACHE_PERCENTAGE 50

--- a/test_pool/nist_sts/test_n001.c
+++ b/test_pool/nist_sts/test_n001.c
@@ -26,7 +26,7 @@
 
 #define TEST_NUM   (ACS_NIST_TEST_NUM_BASE + 1)
 #define TEST_RULE "S_L7ENT_1"
-#define TEST_DESC  "NIST Statistical Test Suite       "
+#define TEST_DESC  "NIST Statistical Test Suite           "
 
 #define BUFFER_SIZE     1000
 #define RND_FILE_SIZE   36428

--- a/test_pool/pcie/operating_system/test_p001.c
+++ b/test_pool/pcie/operating_system/test_p001.c
@@ -19,7 +19,7 @@
 #include "val/sbsa/include/sbsa_acs_pcie.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 1)
-#define TEST_DESC  "Check ECAM Presence               "
+#define TEST_DESC  "Check ECAM Presence                   "
 #define TEST_RULE  "PCI_IN_01"
 
 static

--- a/test_pool/pcie/operating_system/test_p003.c
+++ b/test_pool/pcie/operating_system/test_p003.c
@@ -23,7 +23,7 @@
 #include "val/sbsa/include/sbsa_acs_pe.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 3)
-#define TEST_DESC  "Check ECAM Memory accessibility   "
+#define TEST_DESC  "Check ECAM Memory accessibility       "
 #define TEST_RULE  "PCI_IN_02"
 
 static void *branch_to_test;

--- a/test_pool/pcie/operating_system/test_p005.c
+++ b/test_pool/pcie/operating_system/test_p005.c
@@ -22,7 +22,7 @@
 
 /* SBSA-checklist 63 & 64 */
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 5)
-#define TEST_DESC  "PCIe Unaligned access, Norm mem   "
+#define TEST_DESC  "PCIe Unaligned access, Norm mem       "
 #define TEST_RULE  "PCI_MM_01, PCI_MM_02, PCI_MM_03, RE_BAR_2, IE_BAR_2"
 
 #define DATA 0xC0DECAFE

--- a/test_pool/pcie/operating_system/test_p009.c
+++ b/test_pool/pcie/operating_system/test_p009.c
@@ -21,7 +21,7 @@
 #include "val/sbsa/include/sbsa_acs_pcie.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 9)
-#define TEST_DESC  "Check all MSI(X) vectors are LPIs "
+#define TEST_DESC  "Check all MSI(X) vectors are LPIs     "
 #define TEST_RULE  "S_L3GI_02"
 
 #define LPI_BASE 8192

--- a/test_pool/pcie/operating_system/test_p016.c
+++ b/test_pool/pcie/operating_system/test_p016.c
@@ -20,7 +20,7 @@
 #include "val/sbsa/include/sbsa_acs_pcie.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 16)
-#define TEST_DESC  "NP type-1 pcie only support 32-bit"
+#define TEST_DESC  "NP type-1 pcie only support 32-bit    "
 #define TEST_RULE  "PCI_MM_04"
 
 #define BAR0    0x10

--- a/test_pool/pcie/operating_system/test_p020.c
+++ b/test_pool/pcie/operating_system/test_p020.c
@@ -21,7 +21,7 @@
 #include "test_p020_data.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 20)
-#define TEST_DESC  "Check Type 0/1 common config rules"
+#define TEST_DESC  "Check Type 0/1 common config rules    "
 #define TEST_RULE  "RE_REG_1, IE_REG_1, IE_REG_3"
 
 static

--- a/test_pool/pcie/operating_system/test_p021.c
+++ b/test_pool/pcie/operating_system/test_p021.c
@@ -21,7 +21,7 @@
 #include "test_p021_data.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 21)
-#define TEST_DESC  "Check Type 0 config header rules  "
+#define TEST_DESC  "Check Type 0 config header rules      "
 #define TEST_RULE  "RE_REG_1, IE_REG_1"
 
 static

--- a/test_pool/pcie/operating_system/test_p022.c
+++ b/test_pool/pcie/operating_system/test_p022.c
@@ -21,7 +21,7 @@
 #include "test_p022_data.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 22)
-#define TEST_DESC  "Check Type 1 config header rules  "
+#define TEST_DESC  "Check Type 1 config header rules      "
 #define TEST_RULE  "IE_REG_3"
 
 static

--- a/test_pool/pcie/operating_system/test_p023.c
+++ b/test_pool/pcie/operating_system/test_p023.c
@@ -21,7 +21,7 @@
 #include "test_p023_data.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 23)
-#define TEST_DESC  "Check PCIe capability rules       "
+#define TEST_DESC  "Check PCIe capability rules           "
 #define TEST_RULE  "IE_REG_4"
 
 static

--- a/test_pool/pcie/operating_system/test_p024.c
+++ b/test_pool/pcie/operating_system/test_p024.c
@@ -21,7 +21,7 @@
 #include "test_p024_data.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 24)
-#define TEST_DESC  "Check Device capabilities reg rule"
+#define TEST_DESC  "Check Device capabilities reg rule    "
 #define TEST_RULE  "RE_REG_3, RE_REC_1, IE_REG_2, IE_REG_4"
 
 static

--- a/test_pool/pcie/operating_system/test_p025.c
+++ b/test_pool/pcie/operating_system/test_p025.c
@@ -21,7 +21,7 @@
 #include "test_p025_data.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 25)
-#define TEST_DESC  "Check Device Control register rule"
+#define TEST_DESC  "Check Device Control register rule    "
 #define TEST_RULE  "RE_REG_3, RE_REC_1, IE_REG_2, IE_REG_4"
 
 static

--- a/test_pool/pcie/operating_system/test_p026.c
+++ b/test_pool/pcie/operating_system/test_p026.c
@@ -21,7 +21,7 @@
 #include "test_p026_data.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 26)
-#define TEST_DESC  "Check Device cap 2 register rules "
+#define TEST_DESC  "Check Device cap 2 register rules     "
 #define TEST_RULE  "RE_REG_3, RE_REC_1, IE_REG_2, IE_REG_4"
 
 static

--- a/test_pool/pcie/operating_system/test_p027.c
+++ b/test_pool/pcie/operating_system/test_p027.c
@@ -21,7 +21,7 @@
 #include "test_p027_data.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 27)
-#define TEST_DESC  "Check Device control 2 reg rules  "
+#define TEST_DESC  "Check Device control 2 reg rules      "
 #define TEST_RULE  "RE_REG_3, RE_REC_1, IE_REG_2, IE_REG_4"
 
 static

--- a/test_pool/pcie/operating_system/test_p028.c
+++ b/test_pool/pcie/operating_system/test_p028.c
@@ -21,7 +21,7 @@
 #include "test_p028_data.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 28)
-#define TEST_DESC  "Check Power management cap rules  "
+#define TEST_DESC  "Check Power management cap rules      "
 #define TEST_RULE  "RE_REG_2, IE_REG_5"
 
 static

--- a/test_pool/pcie/operating_system/test_p029.c
+++ b/test_pool/pcie/operating_system/test_p029.c
@@ -21,7 +21,7 @@
 #include "test_p029_data.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 29)
-#define TEST_DESC  "Check Power management/status rule"
+#define TEST_DESC  "Check Power management/status rule    "
 #define TEST_RULE  "RE_REG_2, IE_REG_5"
 
 static

--- a/test_pool/pcie/operating_system/test_p030.c
+++ b/test_pool/pcie/operating_system/test_p030.c
@@ -23,7 +23,7 @@
 #include "val/sbsa/include/sbsa_acs_pe.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 30)
-#define TEST_DESC  "Check Cmd Reg memory space enable "
+#define TEST_DESC  "Check Cmd Reg memory space enable     "
 #define TEST_RULE  "RE_REG_1, IE_REG_1, IE_REG_3"
 
 static void *branch_to_test;

--- a/test_pool/pcie/operating_system/test_p031.c
+++ b/test_pool/pcie/operating_system/test_p031.c
@@ -22,7 +22,7 @@
 #include "val/sbsa/include/sbsa_acs_pe.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 31)
-#define TEST_DESC  "Check Type0/1 BIST Register rule  "
+#define TEST_DESC  "Check Type0/1 BIST Register rule      "
 #define TEST_RULE  "RE_REG_1, IE_REG_1, IE_REG_3"
 
 static

--- a/test_pool/pcie/operating_system/test_p032.c
+++ b/test_pool/pcie/operating_system/test_p032.c
@@ -22,7 +22,7 @@
 #include "val/sbsa/include/sbsa_acs_pe.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 32)
-#define TEST_DESC  "Check HDR CapPtr Register rule    "
+#define TEST_DESC  "Check HDR CapPtr Register rule        "
 #define TEST_RULE  "RE_REG_1, IE_REG_1, IE_REG_3"
 
 static

--- a/test_pool/pcie/operating_system/test_p033.c
+++ b/test_pool/pcie/operating_system/test_p033.c
@@ -22,7 +22,7 @@
 #include "val/sbsa/include/sbsa_acs_pe.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 33)
-#define TEST_DESC  "Check Max payload size supported  "
+#define TEST_DESC  "Check Max payload size supported      "
 #define TEST_RULE  "RE_REC_1, IE_REG_2, IE_REG_4"
 
 static

--- a/test_pool/pcie/operating_system/test_p034.c
+++ b/test_pool/pcie/operating_system/test_p034.c
@@ -22,7 +22,7 @@
 #include "val/sbsa/include/sbsa_acs_pe.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 34)
-#define TEST_DESC  "Check BAR memory space & Type rule"
+#define TEST_DESC  "Check BAR memory space & Type rule    "
 #define TEST_RULE  "RE_BAR_3, IE_BAR_3"
 
 static

--- a/test_pool/pcie/operating_system/test_p035.c
+++ b/test_pool/pcie/operating_system/test_p035.c
@@ -23,7 +23,7 @@
 #include "val/sbsa/include/sbsa_acs_memory.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 35)
-#define TEST_DESC  "Check Function level reset rule   "
+#define TEST_DESC  "Check Function level reset rule       "
 #define TEST_RULE  "RE_RST_1, IE_RST_1, PCI_SM_02"
 
 static

--- a/test_pool/pcie/operating_system/test_p036.c
+++ b/test_pool/pcie/operating_system/test_p036.c
@@ -23,7 +23,7 @@
 #include "val/sbsa/include/sbsa_acs_memory.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 36)
-#define TEST_DESC  "Check ARI forwarding support rule "
+#define TEST_DESC  "Check ARI forwarding support rule     "
 #define TEST_RULE  "PCI_IN_17"
 
 static

--- a/test_pool/pcie/operating_system/test_p037.c
+++ b/test_pool/pcie/operating_system/test_p037.c
@@ -23,7 +23,7 @@
 #include "val/sbsa/include/sbsa_acs_memory.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 37)
-#define TEST_DESC  "Check OBFF supported rule         "
+#define TEST_DESC  "Check OBFF supported rule             "
 #define TEST_RULE  "IE_REG_2"
 
 static

--- a/test_pool/pcie/operating_system/test_p038.c
+++ b/test_pool/pcie/operating_system/test_p038.c
@@ -23,7 +23,7 @@
 #include "val/sbsa/include/sbsa_acs_memory.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 38)
-#define TEST_DESC  "Check CTRS and CTDS rule          "
+#define TEST_DESC  "Check CTRS and CTDS rule              "
 #define TEST_RULE  "IE_REG_4"
 
 static

--- a/test_pool/pcie/operating_system/test_p039.c
+++ b/test_pool/pcie/operating_system/test_p039.c
@@ -23,7 +23,7 @@
 #include "val/sbsa/include/sbsa_acs_memory.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 39)
-#define TEST_DESC  "Check i-EP AtomicOp rule          "
+#define TEST_DESC  "Check i-EP AtomicOp rule              "
 #define TEST_RULE  "IE_REG_2"
 
 static

--- a/test_pool/pcie/operating_system/test_p041.c
+++ b/test_pool/pcie/operating_system/test_p041.c
@@ -23,7 +23,7 @@
 #include "val/sbsa/include/sbsa_acs_memory.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 41)
-#define TEST_DESC  "Check MSI and MSI-X support rule  "
+#define TEST_DESC  "Check MSI and MSI-X support rule      "
 #define TEST_RULE  "RE_INT_1, IE_INT_1"
 
 static

--- a/test_pool/pcie/operating_system/test_p042.c
+++ b/test_pool/pcie/operating_system/test_p042.c
@@ -23,7 +23,7 @@
 #include "val/sbsa/include/sbsa_acs_memory.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 42)
-#define TEST_DESC  "Check Power Management rules      "
+#define TEST_DESC  "Check Power Management rules          "
 #define TEST_RULE  "RE_PWR_1, IE_PWR_1"
 
 static

--- a/test_pool/pcie/operating_system/test_p043.c
+++ b/test_pool/pcie/operating_system/test_p043.c
@@ -23,7 +23,7 @@
 #include "val/sbsa/include/sbsa_acs_memory.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 43)
-#define TEST_DESC  "Check ARI forwarding enable rule  "
+#define TEST_DESC  "Check ARI forwarding enable rule      "
 #define TEST_RULE  "PCI_IN_17"
 
 static

--- a/test_pool/pcie/operating_system/test_p044.c
+++ b/test_pool/pcie/operating_system/test_p044.c
@@ -22,7 +22,7 @@
 #include "val/sbsa/include/sbsa_acs_pe.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 44)
-#define TEST_DESC  "Check device under RP in same ECAM"
+#define TEST_DESC  "Check device under RP in same ECAM    "
 #define TEST_RULE  "PCI_IN_04"
 
 

--- a/test_pool/pcie/operating_system/test_p045.c
+++ b/test_pool/pcie/operating_system/test_p045.c
@@ -23,7 +23,7 @@
 #include "val/sbsa/include/sbsa_acs_memory.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 45)
-#define TEST_DESC  "Check all RP in HB is in same ECAM"
+#define TEST_DESC  "Check all RP in HB is in same ECAM    "
 #define TEST_RULE  "PCI_IN_03"
 
 

--- a/test_pool/pcie/operating_system/test_p046.c
+++ b/test_pool/pcie/operating_system/test_p046.c
@@ -22,7 +22,7 @@
 #include "val/sbsa/include/sbsa_acs_pe.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 46)
-#define TEST_DESC  "Check RP Byte Enable Rules        "
+#define TEST_DESC  "Check RP Byte Enable Rules            "
 #define TEST_RULE  "PCI_IN_18"
 
 static

--- a/test_pool/pcie/operating_system/test_p047.c
+++ b/test_pool/pcie/operating_system/test_p047.c
@@ -22,7 +22,7 @@
 #include "val/sbsa/include/sbsa_acs_pe.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 47)
-#define TEST_DESC  "Check Config Txn for RP in HB     "
+#define TEST_DESC  "Check Config Txn for RP in HB         "
 #define TEST_RULE  "PCI_IN_12"
 
 static

--- a/test_pool/pcie/operating_system/test_p048.c
+++ b/test_pool/pcie/operating_system/test_p048.c
@@ -23,7 +23,7 @@
 #include "val/sbsa/include/sbsa_acs_pe.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 48)
-#define TEST_DESC  "Check RootPort NP Memory Access   "
+#define TEST_DESC  "Check RootPort NP Memory Access       "
 #define TEST_RULE  "PCI_IN_13"
 
 #define KNOWN_DATA  0xABABABAB

--- a/test_pool/pcie/operating_system/test_p049.c
+++ b/test_pool/pcie/operating_system/test_p049.c
@@ -23,7 +23,7 @@
 #include "val/sbsa/include/sbsa_acs_pe.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 49)
-#define TEST_DESC  "Check RootPort P Memory Access    "
+#define TEST_DESC  "Check RootPort P Memory Access        "
 #define TEST_RULE  "PCI_IN_13"
 
 #define KNOWN_DATA  0xABABABAB

--- a/test_pool/pcie/operating_system/test_p050.c
+++ b/test_pool/pcie/operating_system/test_p050.c
@@ -23,7 +23,7 @@
 #include "val/sbsa/include/sbsa_acs_memory.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 50)
-#define TEST_DESC  "Check L-Intr SPI Level-Sensitive  "
+#define TEST_DESC  "Check L-Intr SPI Level-Sensitive      "
 #define TEST_RULE  "PCI_LI_01, PCI_LI_03"
 
 static

--- a/test_pool/pcie/operating_system/test_p051.c
+++ b/test_pool/pcie/operating_system/test_p051.c
@@ -23,7 +23,7 @@
 #include "val/sbsa/include/sbsa_acs_memory.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 51)
-#define TEST_DESC  "Check Sec Bus Reset For iEP_RP    "
+#define TEST_DESC  "Check Sec Bus Reset For iEP_RP        "
 #define TEST_RULE  "IE_RST_2"
 
 static

--- a/test_pool/pcie/operating_system/test_p052.c
+++ b/test_pool/pcie/operating_system/test_p052.c
@@ -23,7 +23,7 @@
 #include "val/sbsa/include/sbsa_acs_memory.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 52)
-#define TEST_DESC  "Check ATS Support Rule            "
+#define TEST_DESC  "Check ATS Support Rule                "
 #define TEST_RULE  "IE_SMU_1, RE_SMU_2"
 
 static

--- a/test_pool/pcie/operating_system/test_p056.c
+++ b/test_pool/pcie/operating_system/test_p056.c
@@ -23,7 +23,7 @@
 #include "val/sbsa/include/sbsa_acs_memory.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 56)
-#define TEST_DESC  "Check iEP-RootPort P2P Support    "
+#define TEST_DESC  "Check iEP-RootPort P2P Support        "
 #define TEST_RULE  "IE_ACS_2"
 
 static

--- a/test_pool/pcie/operating_system/test_p057.c
+++ b/test_pool/pcie/operating_system/test_p057.c
@@ -24,7 +24,7 @@
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 57)
 #define TEST_RULE  "IE_ACS_1, RE_ACS_1, RE_ACS_2"
-#define TEST_DESC  "Check RCiEP, iEP_EP P2P Supp      "
+#define TEST_DESC  "Check RCiEP, iEP_EP P2P Supp          "
 
 static
 void

--- a/test_pool/pcie/operating_system/test_p058.c
+++ b/test_pool/pcie/operating_system/test_p058.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 58)
 #define TEST_RULE  "RE_BAR_1, IE_BAR_1"
-#define TEST_DESC  "Read and write to BAR reg         "
+#define TEST_DESC  "Read and write to BAR reg             "
 
 #define TEST_DATA_1  0xDEADDAED
 #define TEST_DATA_2  0xABABABAB

--- a/test_pool/pcie/operating_system/test_p060.c
+++ b/test_pool/pcie/operating_system/test_p060.c
@@ -23,7 +23,7 @@
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 60)
 #define TEST_RULE  "RE_PCI_1"
-#define TEST_DESC  "Check RCiEP Hdr type & link Cap   "
+#define TEST_DESC  "Check RCiEP Hdr type & link Cap       "
 
 static
 void

--- a/test_pool/pcie/operating_system/test_p061.c
+++ b/test_pool/pcie/operating_system/test_p061.c
@@ -23,7 +23,7 @@
 #include "val/sbsa/include/sbsa_acs_pe.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 61)
-#define TEST_DESC  "Check RootPort P&NP Memory Access "
+#define TEST_DESC  "Check RootPort P&NP Memory Access     "
 #define TEST_RULE  "S_PCIe_02"
 
 static void *branch_to_test;

--- a/test_pool/pcie/operating_system/test_p062.c
+++ b/test_pool/pcie/operating_system/test_p062.c
@@ -22,7 +22,7 @@
 #include "val/sbsa/include/sbsa_acs_pe.h"
 
 #define TEST_NUM   (ACS_PER_TEST_NUM_BASE + 01)
-#define TEST_DESC  "Check EA Capability               "
+#define TEST_DESC  "Check EA Capability                   "
 #define TEST_RULE  "S_L4PCI_2"
 
 static

--- a/test_pool/pcie/operating_system/test_p063.c
+++ b/test_pool/pcie/operating_system/test_p063.c
@@ -21,7 +21,7 @@
 #include "test_p063_data.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 63)
-#define TEST_DESC  "Slot Cap, Control and Status register rules      "
+#define TEST_DESC  "Slot Cap, Control and Status reg rules"
 #define TEST_RULE  "IE_REG_4"
 
 static

--- a/test_pool/pcie/operating_system/test_p064.c
+++ b/test_pool/pcie/operating_system/test_p064.c
@@ -23,7 +23,7 @@
 #include "val/sbsa/include/sbsa_acs_pe.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 64)
-#define TEST_DESC  "Check ATS & Page Req for all RP   "
+#define TEST_DESC  "Check ATS & Page Req for all RP       "
 #define TEST_RULE  "GPU_04"
 
 static void payload(void)

--- a/test_pool/pcie/operating_system/test_p065.c
+++ b/test_pool/pcie/operating_system/test_p065.c
@@ -22,7 +22,7 @@
 #include "val/common/include/acs_pe.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 65)
-#define TEST_DESC  "Check RP Extensions for DPC       "
+#define TEST_DESC  "Check RP Extensions for DPC           "
 #define TEST_RULE  "PCI_ER_09"
 
 static

--- a/test_pool/pe/operating_system/test_c001.c
+++ b/test_pool/pe/operating_system/test_c001.c
@@ -21,7 +21,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  01)
 #define TEST_RULE  "S_L3PE_01"
-#define TEST_DESC  "Check PE Granule Support          "
+#define TEST_DESC  "Check PE Granule Support              "
 
 static
 void

--- a/test_pool/pe/operating_system/test_c002.c
+++ b/test_pool/pe/operating_system/test_c002.c
@@ -21,7 +21,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  02)
 #define TEST_RULE  "S_L3PE_02"
-#define TEST_DESC  "Check for 16-bit ASID support     "
+#define TEST_DESC  "Check for 16-bit ASID support         "
 
 static
 void

--- a/test_pool/pe/operating_system/test_c003.c
+++ b/test_pool/pe/operating_system/test_c003.c
@@ -21,7 +21,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  3)
 #define TEST_RULE  "S_L3PE_03"
-#define TEST_DESC  "Check AARCH64 implementation      "
+#define TEST_DESC  "Check AARCH64 implementation          "
 
 static
 void

--- a/test_pool/pe/operating_system/test_c004.c
+++ b/test_pool/pe/operating_system/test_c004.c
@@ -23,7 +23,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE + 4)
 #define TEST_RULE  "S_L3PE_04"
-#define TEST_DESC  "Check FEAT_LPA Requirements       "
+#define TEST_DESC  "Check FEAT_LPA Requirements           "
 
 #define FEAT_LPA_IMPL 0x6
 /* Retuns true if addr is greater than 48 bits */

--- a/test_pool/pe/operating_system/test_c005.c
+++ b/test_pool/pe/operating_system/test_c005.c
@@ -21,7 +21,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  + 5)
 #define TEST_RULE  "S_L4PE_01"
-#define TEST_DESC  "Check for RAS extension           "
+#define TEST_DESC  "Check for RAS extension               "
 
 static
 void payload(void)

--- a/test_pool/pe/operating_system/test_c006.c
+++ b/test_pool/pe/operating_system/test_c006.c
@@ -23,7 +23,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE + 6)
 #define TEST_RULE  "S_L4PE_02"
-#define TEST_DESC  "Check DC CVAP support             "
+#define TEST_DESC  "Check DC CVAP support                 "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c007.c
+++ b/test_pool/pe/operating_system/test_c007.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  + 7)
 #define TEST_RULE  "S_L4PE_03"
-#define TEST_DESC  "Check for 16-Bit VMID             "
+#define TEST_DESC  "Check for 16-Bit VMID                 "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c008.c
+++ b/test_pool/pe/operating_system/test_c008.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  + 8)
 #define TEST_RULE  "S_L4PE_04"
-#define TEST_DESC  "Check for Virtual host extensions "
+#define TEST_DESC  "Check for Virtual host extensions     "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c009.c
+++ b/test_pool/pe/operating_system/test_c009.c
@@ -21,7 +21,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  9)
 #define TEST_RULE  "S_L5PE_01"
-#define TEST_DESC  "Support Page table map size change"
+#define TEST_DESC  "Support Page table map size change    "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c010.c
+++ b/test_pool/pe/operating_system/test_c010.c
@@ -21,7 +21,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  10)
 #define TEST_RULE  "S_L5PE_02"
-#define TEST_DESC  "Check for addr and generic auth   "
+#define TEST_DESC  "Check for addr and generic auth       "
 
 
 static void check_pointer_signing_algorithm(uint32_t index, uint64_t data1, uint64_t data2)

--- a/test_pool/pe/operating_system/test_c011.c
+++ b/test_pool/pe/operating_system/test_c011.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  11)
 #define TEST_RULE  "S_L5PE_04"
-#define TEST_DESC  "Check Activity monitors extension "
+#define TEST_DESC  "Check Activity monitors extension     "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c012.c
+++ b/test_pool/pe/operating_system/test_c012.c
@@ -20,7 +20,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  12)
 #define TEST_RULE  "S_L5PE_05"
-#define TEST_DESC  "Check for SHA3 and SHA512 support "
+#define TEST_DESC  "Check for SHA3 and SHA512 support     "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c013.c
+++ b/test_pool/pe/operating_system/test_c013.c
@@ -21,7 +21,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  13)
 #define TEST_RULE  "S_L5PE_06"
-#define TEST_DESC  "Stage 2 control of mem and cache  "
+#define TEST_DESC  "Stage 2 control of mem and cache      "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c014.c
+++ b/test_pool/pe/operating_system/test_c014.c
@@ -21,7 +21,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  14)
 #define TEST_RULE  "S_L5PE_07"
-#define TEST_DESC  "Check for FEAT_NV2 support        "
+#define TEST_DESC  "Check for FEAT_NV2 support            "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c015.c
+++ b/test_pool/pe/operating_system/test_c015.c
@@ -23,7 +23,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  15)
 #define TEST_RULE  "S_MPAM_PE"
-#define TEST_DESC  "Check MPAM PE Requirements        "
+#define TEST_DESC  "Check MPAM PE Requirements            "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c016.c
+++ b/test_pool/pe/operating_system/test_c016.c
@@ -23,7 +23,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  16)
 #define TEST_RULE  "S_MPAM_PE"
-#define TEST_DESC  "Check MPAM LLC Requirements       "
+#define TEST_DESC  "Check MPAM LLC Requirements           "
 
 #define MEM_CACHE_LEVEL_1      1
 #define SLC_TYPE_UNKNOWN       0

--- a/test_pool/pe/operating_system/test_c017.c
+++ b/test_pool/pe/operating_system/test_c017.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  17)
 #define TEST_RULE  "B_PE_17"
-#define TEST_DESC  "Check SPE if implemented          "
+#define TEST_DESC  "Check SPE if implemented              "
 
 static
 void payload(void)

--- a/test_pool/pe/operating_system/test_c018.c
+++ b/test_pool/pe/operating_system/test_c018.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  18)
 #define TEST_RULE  "S_L6PE_02"
-#define TEST_DESC  "Check Branch Target Support       "
+#define TEST_DESC  "Check Branch Target Support           "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c019.c
+++ b/test_pool/pe/operating_system/test_c019.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  19)
 #define TEST_RULE  "S_L6PE_03"
-#define TEST_DESC  "Check Protect Against Timing Fault"
+#define TEST_DESC  "Check Protect Against Timing Fault    "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c020.c
+++ b/test_pool/pe/operating_system/test_c020.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  20)
 #define TEST_RULE  "S_L6PE_04, S_L8PE_05"
-#define TEST_DESC  "Check PMU Version Support         "
+#define TEST_DESC  "Check PMU Version Support             "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c021.c
+++ b/test_pool/pe/operating_system/test_c021.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  21)
 #define TEST_RULE  "S_L6PE_05"
-#define TEST_DESC  "Check AccessFlag DirtyState Update"
+#define TEST_DESC  "Check AccessFlag DirtyState Update    "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c022.c
+++ b/test_pool/pe/operating_system/test_c022.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  22)
 #define TEST_RULE  "S_L6PE_06"
-#define TEST_DESC  "Check Enhanced Virtualization Trap"
+#define TEST_DESC  "Check Enhanced Virtualization Trap    "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c023.c
+++ b/test_pool/pe/operating_system/test_c023.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  23)
 #define TEST_RULE  "B_SEC_01"
-#define TEST_DESC  "Check Speculation Restriction     "
+#define TEST_DESC  "Check Speculation Restriction         "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c024.c
+++ b/test_pool/pe/operating_system/test_c024.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  24)
 #define TEST_RULE  "B_SEC_02"
-#define TEST_DESC  "Check Speculative Str Bypass Safe "
+#define TEST_DESC  "Check Speculative Str Bypass Safe     "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c025.c
+++ b/test_pool/pe/operating_system/test_c025.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  + 25)
 #define TEST_RULE  "B_SEC_03"
-#define TEST_DESC  "Check PEs Impl CSDB,SSBB,PSSBB    "
+#define TEST_DESC  "Check PEs Impl CSDB,SSBB,PSSBB        "
 
 static
 void

--- a/test_pool/pe/operating_system/test_c026.c
+++ b/test_pool/pe/operating_system/test_c026.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  26)
 #define TEST_RULE  "B_SEC_04"
-#define TEST_DESC  "Check PEs Implement SB Barrier    "
+#define TEST_DESC  "Check PEs Implement SB Barrier        "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c027.c
+++ b/test_pool/pe/operating_system/test_c027.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  27)
 #define TEST_RULE  "B_SEC_05"
-#define TEST_DESC  "Check PE Impl CFP,DVP,CPP RCTX    "
+#define TEST_DESC  "Check PE Impl CFP,DVP,CPP RCTX        "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c028.c
+++ b/test_pool/pe/operating_system/test_c028.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  28)
 #define TEST_RULE  "S_L7PE_01"
-#define TEST_DESC  "Check Fine Grain Trap Support     "
+#define TEST_DESC  "Check Fine Grain Trap Support         "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c029.c
+++ b/test_pool/pe/operating_system/test_c029.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  29)
 #define TEST_RULE  "S_L7PE_02"
-#define TEST_DESC  "Check for ECV support             "
+#define TEST_DESC  "Check for ECV support                 "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c030.c
+++ b/test_pool/pe/operating_system/test_c030.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  30)
 #define TEST_RULE  "S_L7PE_03"
-#define TEST_DESC  "Check for AMUv1 Support           "
+#define TEST_DESC  "Check for AMUv1 Support               "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c031.c
+++ b/test_pool/pe/operating_system/test_c031.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  31)
 #define TEST_RULE  "S_L7PE_04"
-#define TEST_DESC  "Checks ASIMD Int8 matrix multiplc "
+#define TEST_DESC  "Checks ASIMD Int8 matrix multiplc     "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c032.c
+++ b/test_pool/pe/operating_system/test_c032.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE + 32)
 #define TEST_RULE  "S_L7PE_05"
-#define TEST_DESC  "Check for BFLOAT16 extension      "
+#define TEST_DESC  "Check for BFLOAT16 extension          "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c034.c
+++ b/test_pool/pe/operating_system/test_c034.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE + 34)
 #define TEST_RULE  "S_L7PE_07"
-#define TEST_DESC  "Check for SVE Int8 matrix multiplc"
+#define TEST_DESC  "Check for SVE Int8 matrix multiplc    "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c035.c
+++ b/test_pool/pe/operating_system/test_c035.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE + 35)
 #define TEST_RULE  "S_L7PE_08"
-#define TEST_DESC  "Check for data gathering hint     "
+#define TEST_DESC  "Check for data gathering hint         "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c036.c
+++ b/test_pool/pe/operating_system/test_c036.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE + 36)
 #define TEST_RULE  "S_L7PE_09"
-#define TEST_DESC  "Check WFE Fine tune delay feature "
+#define TEST_DESC  "Check WFE Fine tune delay feature     "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c037.c
+++ b/test_pool/pe/operating_system/test_c037.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE + 37)
 #define TEST_RULE  "S_L8PE_04"
-#define TEST_DESC  "Check for enhanced PAN feature    "
+#define TEST_DESC  "Check for enhanced PAN feature        "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c041.c
+++ b/test_pool/pe/operating_system/test_c041.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE + 41)
 #define TEST_RULE  "S_L8PE_06"
-#define TEST_DESC  "Check for FEAT_BRBE support     "
+#define TEST_DESC  "Check for FEAT_BRBE support         "
 
 static void payload(void)
 {

--- a/test_pool/pe/operating_system/test_c042.c
+++ b/test_pool/pe/operating_system/test_c042.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE + 42)
 #define TEST_RULE  "S_L8PE_07"
-#define TEST_DESC  "Check for unsupported PBHA bits   "
+#define TEST_DESC  "Check for unsupported PBHA bits       "
 
 static void payload(void)
 {

--- a/test_pool/pmu/operating_system/test_pmu001.c
+++ b/test_pool/pmu/operating_system/test_pmu001.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_PMU_TEST_NUM_BASE  +  1)
 #define TEST_RULE  "PMU_PE_02"
-#define TEST_DESC  "Check PMU Overflow signal         "
+#define TEST_DESC  "Check PMU Overflow signal             "
 
 static uint32_t int_id;
 

--- a/test_pool/pmu/operating_system/test_pmu002.c
+++ b/test_pool/pmu/operating_system/test_pmu002.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM    (ACS_PMU_TEST_NUM_BASE  +  2)
 #define TEST_RULE  " PMU_PE_03"
-#define TEST_DESC  "Check number of PMU counters      "
+#define TEST_DESC  "Check number of PMU counters          "
 
 static
 void

--- a/test_pool/pmu/operating_system/test_pmu003.c
+++ b/test_pool/pmu/operating_system/test_pmu003.c
@@ -22,9 +22,9 @@
 #include "val/sbsa/include/sbsa_acs_pmu.h"
 #include "val/common/include/acs_common.h"
 
-#define TEST_NUM  (ACS_PMU_TEST_NUM_BASE + 3)
-#define TEST_RULE "PMU_EV_11"
-#define TEST_DESC "Check for multi-threaded PMU ext  "
+#define TEST_NUM   (ACS_PMU_TEST_NUM_BASE + 3)
+#define TEST_RULE  "PMU_EV_11"
+#define TEST_DESC  "Check for multi-threaded PMU ext      "
 
 static void payload(void)
 {

--- a/test_pool/pmu/operating_system/test_pmu004.c
+++ b/test_pool/pmu/operating_system/test_pmu004.c
@@ -26,7 +26,7 @@
 
 #define TEST_NUM  (ACS_PMU_TEST_NUM_BASE + 4)
 #define TEST_RULE "PMU_BM_1, PMU_SYS_1, PMU_SYS_2"
-#define TEST_DESC "Check memory bandwidth monitors   "
+#define TEST_DESC "Check memory bandwidth monitors        "
 
 #define BUFFER_SIZE 4194304 /* 4 Megabytes*/
 #define NUM_PMU_MON 3       /* Minimum required monitors */

--- a/test_pool/pmu/operating_system/test_pmu005.c
+++ b/test_pool/pmu/operating_system/test_pmu005.c
@@ -25,7 +25,7 @@
 
 #define TEST_NUM  (ACS_PMU_TEST_NUM_BASE + 5)
 #define TEST_RULE "PMU_MEM_1, PMU_SYS_1, PMU_SYS_2"
-#define TEST_DESC "Check memory latency monitors     "
+#define TEST_DESC "Check memory latency monitors          "
 
 #define BUFFER_SIZE 4194304 /* 4 Megabytes*/
 

--- a/test_pool/pmu/operating_system/test_pmu006.c
+++ b/test_pool/pmu/operating_system/test_pmu006.c
@@ -22,9 +22,9 @@
 #include "val/sbsa/include/sbsa_acs_pmu.h"
 #include "val/common/include/acs_common.h"
 
-#define TEST_NUM  (ACS_PMU_TEST_NUM_BASE + 6)
-#define TEST_RULE "PMU_SPE"
-#define TEST_DESC "Check for PMU SPE Requirements    "
+#define TEST_NUM   (ACS_PMU_TEST_NUM_BASE + 6)
+#define TEST_RULE  "PMU_SPE"
+#define TEST_DESC  "Check for PMU SPE Requirements        "
 
 static void payload(void)
 {

--- a/test_pool/pmu/operating_system/test_pmu007.c
+++ b/test_pool/pmu/operating_system/test_pmu007.c
@@ -24,7 +24,7 @@
 
 #define TEST_NUM  (ACS_PMU_TEST_NUM_BASE + 7)
 #define TEST_RULE "PMU_BM_2, PMU_SYS_1, PMU_SYS_2"
-#define TEST_DESC "Check PCIe bandwidth monitors     "
+#define TEST_DESC "Check PCIe bandwidth monitors          "
 
 #define NUM_TOTAL_PMU_MON 6 /* Minimum required bandwidth monitors */
 

--- a/test_pool/pmu/operating_system/test_pmu008.c
+++ b/test_pool/pmu/operating_system/test_pmu008.c
@@ -25,7 +25,7 @@
 
 #define TEST_NUM  (ACS_PMU_TEST_NUM_BASE + 8)
 #define TEST_RULE "PMU_SYS_5"
-#define TEST_DESC "Check System PMU for NUMA systems "
+#define TEST_DESC "Check System PMU for NUMA systems      "
 
 #define BUFFER_SIZE 4194304 /* 4 Megabytes*/
 

--- a/test_pool/pmu/operating_system/test_pmu009.c
+++ b/test_pool/pmu/operating_system/test_pmu009.c
@@ -25,7 +25,7 @@
 
 #define TEST_NUM  (ACS_PMU_TEST_NUM_BASE + 9)
 #define TEST_RULE "PMU_SYS_6"
-#define TEST_DESC "Check multiple types of traffic measurement"
+#define TEST_DESC "Check multiple type traffic measurement"
 
 #define NUM_TRAFFIC_TYPE 2 /* To atleast check 2 different types of traffic */
 

--- a/test_pool/ras/operating_system/test_ras001.c
+++ b/test_pool/ras/operating_system/test_ras001.c
@@ -24,7 +24,7 @@
 
 #define TEST_NUM   (ACS_RAS_TEST_NUM_BASE + 1)
 #define TEST_RULE  "RAS_01"
-#define TEST_DESC  "Check Error Counter               "
+#define TEST_DESC  "Check Error Counter                   "
 
 static
 void

--- a/test_pool/ras/operating_system/test_ras002.c
+++ b/test_pool/ras/operating_system/test_ras002.c
@@ -24,7 +24,7 @@
 
 #define TEST_NUM   (ACS_RAS_TEST_NUM_BASE + 2)
 #define TEST_RULE  "RAS_02"
-#define TEST_DESC  "Check CFI, DUI, UI Controls       "
+#define TEST_DESC  "Check CFI, DUI, UI Controls           "
 
 static
 void

--- a/test_pool/ras/operating_system/test_ras003.c
+++ b/test_pool/ras/operating_system/test_ras003.c
@@ -24,7 +24,7 @@
 
 #define TEST_NUM   (ACS_RAS_TEST_NUM_BASE + 3)
 #define TEST_RULE  "RAS_03"
-#define TEST_DESC  "Check FHI in Error Record Group   "
+#define TEST_DESC  "Check FHI in Error Record Group       "
 
 static
 void

--- a/test_pool/ras/operating_system/test_ras004.c
+++ b/test_pool/ras/operating_system/test_ras004.c
@@ -24,7 +24,7 @@
 
 #define TEST_NUM   (ACS_RAS_TEST_NUM_BASE + 4)
 #define TEST_RULE  "RAS_04"
-#define TEST_DESC  "Check ERI in Error Record Group   "
+#define TEST_DESC  "Check ERI in Error Record Group       "
 
 static
 void

--- a/test_pool/ras/operating_system/test_ras005.c
+++ b/test_pool/ras/operating_system/test_ras005.c
@@ -24,7 +24,7 @@
 
 #define TEST_NUM   (ACS_RAS_TEST_NUM_BASE + 5)
 #define TEST_RULE  "RAS_06"
-#define TEST_DESC  "Check ERI/FHI Connected to GIC    "
+#define TEST_DESC  "Check ERI/FHI Connected to GIC        "
 
 #define IS_NOT_SPI_PPI(int_id) ((int_id < 16) || (int_id > 1019))
 

--- a/test_pool/ras/operating_system/test_ras006.c
+++ b/test_pool/ras/operating_system/test_ras006.c
@@ -25,7 +25,7 @@
 
 #define TEST_NUM   (ACS_RAS_TEST_NUM_BASE + 6)
 #define TEST_RULE  "RAS_07"
-#define TEST_DESC  "RAS ERR<n>ADDR.AI bit status check"
+#define TEST_DESC  "RAS ERR<n>ADDR.AI bit status check    "
 
 #define ONE_BYTE_BUFFER 0x1
 

--- a/test_pool/ras/operating_system/test_ras007.c
+++ b/test_pool/ras/operating_system/test_ras007.c
@@ -24,7 +24,7 @@
 
 #define TEST_NUM   (ACS_RAS_TEST_NUM_BASE + 7)
 #define TEST_RULE  "RAS_08"
-#define TEST_DESC  "Check Error Group Status          "
+#define TEST_DESC  "Check Error Group Status              "
 
 static
 void

--- a/test_pool/ras/operating_system/test_ras008.c
+++ b/test_pool/ras/operating_system/test_ras008.c
@@ -26,7 +26,7 @@
 
 #define TEST_NUM   (ACS_RAS_TEST_NUM_BASE + 8)
 #define TEST_RULE  "RAS_11, RAS_12"
-#define TEST_DESC  "Software Fault Error Check        "
+#define TEST_DESC  "Software Fault Error Check            "
 
 /* The generic peripherals which ACS can rely on like PCIe spec it ruled out as the
    rule mentions to follow PCIe specification mentioned behaviour for handling those

--- a/test_pool/ras/operating_system/test_ras009.c
+++ b/test_pool/ras/operating_system/test_ras009.c
@@ -26,7 +26,7 @@
 
 #define TEST_NUM   (ACS_RAS_TEST_NUM_BASE + 9)
 #define TEST_RULE  "S_L7RAS_1"
-#define TEST_DESC  "Data abort on Containable err     "
+#define TEST_DESC  "Data abort on Containable err         "
 
 #define ONE_BYTE_BUFFER 0x1
 

--- a/test_pool/ras/operating_system/test_ras010.c
+++ b/test_pool/ras/operating_system/test_ras010.c
@@ -23,7 +23,7 @@
 
 #define TEST_NUM   (ACS_RAS_TEST_NUM_BASE + 10)
 #define TEST_RULE  "SYS_RAS_1"
-#define TEST_DESC  "Check for patrol scrubbing support"
+#define TEST_DESC  "Check for patrol scrubbing support    "
 
 static
 void

--- a/test_pool/ras/operating_system/test_ras011.c
+++ b/test_pool/ras/operating_system/test_ras011.c
@@ -25,7 +25,7 @@
 
 #define TEST_NUM   (ACS_RAS_TEST_NUM_BASE + 11)
 #define TEST_RULE  "SYS_RAS_2,SYS_RAS_3"
-#define TEST_DESC  "Check Poison Storage & Forwarding "
+#define TEST_DESC  "Check Poison Storage & Forwarding     "
 
 static uint32_t esr_pending = 1;
 static uint64_t int_id;

--- a/test_pool/ras/operating_system/test_ras012.c
+++ b/test_pool/ras/operating_system/test_ras012.c
@@ -25,7 +25,7 @@
 
 #define TEST_NUM   (ACS_RAS_TEST_NUM_BASE + 12)
 #define TEST_RULE  "SYS_RAS_2"
-#define TEST_DESC  "Check Pseudo Fault Injection      "
+#define TEST_DESC  "Check Pseudo Fault Injection          "
 
 static void *branch_to_test;
 

--- a/test_pool/ras/operating_system/test_ras013.c
+++ b/test_pool/ras/operating_system/test_ras013.c
@@ -25,7 +25,7 @@
 
 #define TEST_NUM   (ACS_RAS_TEST_NUM_BASE + 13)
 #define TEST_RULE  "SYS_RAS_4"
-#define TEST_DESC  "Check RAS memory mapped view supp "
+#define TEST_DESC  "Check RAS memory mapped view supp     "
 
 #define RESOURCE_FLAG(flag) ((flag >> 1) & 1)
 

--- a/test_pool/smmu/operating_system/test_i001.c
+++ b/test_pool/smmu/operating_system/test_i001.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_SMMU_TEST_NUM_BASE + 1)
 #define TEST_RULE  "S_L4SM_01, S_L4SM_02"
-#define TEST_DESC  "Check SMMU Compatibility          "
+#define TEST_DESC  "Check SMMU Compatibility              "
 
 static
 void

--- a/test_pool/smmu/operating_system/test_i002.c
+++ b/test_pool/smmu/operating_system/test_i002.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_SMMU_TEST_NUM_BASE + 2)
 #define TEST_RULE  "S_L5SM_01, S_L5SM_02, S_L8SM_01"
-#define TEST_DESC  "Check SMMUv3.2 or higher          "
+#define TEST_DESC  "Check SMMUv3.2 or higher              "
 
 static
 void

--- a/test_pool/smmu/operating_system/test_i003.c
+++ b/test_pool/smmu/operating_system/test_i003.c
@@ -25,7 +25,7 @@
 
 #define TEST_NUM   (ACS_SMMU_TEST_NUM_BASE + 3)
 #define TEST_RULE  "B_SMMU_09"
-#define TEST_DESC  "Check S-EL2 & SMMU Stage1 support "
+#define TEST_DESC  "Check S-EL2 & SMMU Stage1 support     "
 
 static
 void

--- a/test_pool/smmu/operating_system/test_i004.c
+++ b/test_pool/smmu/operating_system/test_i004.c
@@ -25,7 +25,7 @@
 
 #define TEST_NUM   (ACS_SMMU_TEST_NUM_BASE + 4)
 #define TEST_RULE  "B_SMMU_20"
-#define TEST_DESC  "Check S-EL2 & SMMU Stage2 Support "
+#define TEST_DESC  "Check S-EL2 & SMMU Stage2 Support     "
 
 static
 void

--- a/test_pool/smmu/operating_system/test_i005.c
+++ b/test_pool/smmu/operating_system/test_i005.c
@@ -24,7 +24,7 @@
 
 #define TEST_NUM   (ACS_SMMU_TEST_NUM_BASE + 5)
 #define TEST_RULE  "B_SMMU_11, B_SMMU_22, S_L5SM_03"
-#define TEST_DESC  "Check SMMU for MPAM support       "
+#define TEST_DESC  "Check SMMU for MPAM support           "
 
 static
 void

--- a/test_pool/smmu/operating_system/test_i006.c
+++ b/test_pool/smmu/operating_system/test_i006.c
@@ -23,7 +23,7 @@
 
 #define TEST_NUM   (ACS_SMMU_TEST_NUM_BASE + 6)
 #define TEST_RULE  "S_L6SM_02"
-#define TEST_DESC  "Check SMMU HTTU Support           "
+#define TEST_DESC  "Check SMMU HTTU Support               "
 
 static
 void

--- a/test_pool/smmu/operating_system/test_i007.c
+++ b/test_pool/smmu/operating_system/test_i007.c
@@ -23,7 +23,7 @@
 
 #define TEST_NUM   (ACS_SMMU_TEST_NUM_BASE + 7)
 #define TEST_RULE  "S_L6SM_03"
-#define TEST_DESC  "Check SMMU MSI Support            "
+#define TEST_DESC  "Check SMMU MSI Support                "
 
 static
 void

--- a/test_pool/smmu/operating_system/test_i008.c
+++ b/test_pool/smmu/operating_system/test_i008.c
@@ -25,7 +25,7 @@
 
 #define TEST_NUM   (ACS_SMMU_TEST_NUM_BASE + 8)
 #define TEST_RULE  "B_SMMU_23"
-#define TEST_DESC  "Check SMMU 16 Bit VMID Support    "
+#define TEST_DESC  "Check SMMU 16 Bit VMID Support        "
 
 static
 void

--- a/test_pool/smmu/operating_system/test_i009.c
+++ b/test_pool/smmu/operating_system/test_i009.c
@@ -24,7 +24,7 @@
 
 #define TEST_NUM   (ACS_SMMU_TEST_NUM_BASE + 9)
 #define TEST_RULE  "B_SMMU_03"
-#define TEST_DESC  "Check SMMU Large VA Support       "
+#define TEST_DESC  "Check SMMU Large VA Support           "
 
 static
 void

--- a/test_pool/smmu/operating_system/test_i010.c
+++ b/test_pool/smmu/operating_system/test_i010.c
@@ -24,7 +24,7 @@
 
 #define TEST_NUM   (ACS_SMMU_TEST_NUM_BASE + 10)
 #define TEST_RULE  "B_SMMU_04, B_SMMU_05"
-#define TEST_DESC  "Check TLB Range Invalidation      "
+#define TEST_DESC  "Check TLB Range Invalidation          "
 
 static
 void

--- a/test_pool/smmu/operating_system/test_i011.c
+++ b/test_pool/smmu/operating_system/test_i011.c
@@ -25,7 +25,7 @@
 
 #define TEST_NUM   (ACS_SMMU_TEST_NUM_BASE + 11)
 #define TEST_RULE  "B_SMMU_13"
-#define TEST_DESC  "Check SMMU 16 Bit ASID Support    "
+#define TEST_DESC  "Check SMMU 16 Bit ASID Support        "
 
 static
 void

--- a/test_pool/smmu/operating_system/test_i012.c
+++ b/test_pool/smmu/operating_system/test_i012.c
@@ -25,7 +25,7 @@
 
 #define TEST_NUM   (ACS_SMMU_TEST_NUM_BASE + 12)
 #define TEST_RULE  "B_SMMU_14"
-#define TEST_DESC  "Check SMMU Endianess Support      "
+#define TEST_DESC  "Check SMMU Endianess Support          "
 
 static
 void

--- a/test_pool/smmu/operating_system/test_i013.c
+++ b/test_pool/smmu/operating_system/test_i013.c
@@ -23,7 +23,7 @@
 
 #define TEST_NUM   (ACS_SMMU_TEST_NUM_BASE + 13)
 #define TEST_RULE  "S_L6SM_01"
-#define TEST_DESC  "Check SMMU Coherent Access Support"
+#define TEST_DESC  "Check SMMU Coherent Access Support    "
 
 static
 void

--- a/test_pool/smmu/operating_system/test_i014.c
+++ b/test_pool/smmu/operating_system/test_i014.c
@@ -24,7 +24,7 @@
 
 #define TEST_NUM   (ACS_SMMU_TEST_NUM_BASE + 14)
 #define TEST_RULE  "S_L7SM_03, S_L7SM_04"
-#define TEST_DESC  "Check SMMU PMU Extension          "
+#define TEST_DESC  "Check SMMU PMU Extension              "
 
 static
 void

--- a/test_pool/smmu/operating_system/test_i015.c
+++ b/test_pool/smmu/operating_system/test_i015.c
@@ -23,7 +23,7 @@
 
 #define TEST_NUM   (ACS_SMMU_TEST_NUM_BASE + 15)
 #define TEST_RULE  "S_L7SM_01"
-#define TEST_DESC  "Check if all DMA reqs behind SMMU "
+#define TEST_DESC  "Check if all DMA reqs behind SMMU     "
 
 static
 void

--- a/test_pool/smmu/operating_system/test_i016.c
+++ b/test_pool/smmu/operating_system/test_i016.c
@@ -26,7 +26,7 @@
 
 #define TEST_NUM   (ACS_SMMU_TEST_NUM_BASE + 16)
 #define TEST_RULE  "S_L7SM_02"
-#define TEST_DESC  "Check for SMMU/CATU in ETR Path   "
+#define TEST_DESC  "Check for SMMU/CATU in ETR Path       "
 
 #define MAX_NUM_ETR 6
 

--- a/test_pool/smmu/operating_system/test_i017.c
+++ b/test_pool/smmu/operating_system/test_i017.c
@@ -23,7 +23,7 @@
 
 #define TEST_NUM   (ACS_SMMU_TEST_NUM_BASE + 17)
 #define TEST_RULE  "GPU_04"
-#define TEST_DESC  "Check ATS and Page Req Support    "
+#define TEST_DESC  "Check ATS and Page Req Support        "
 
 static void payload(void)
 {

--- a/test_pool/watchdog/operating_system/test_w001.c
+++ b/test_pool/watchdog/operating_system/test_w001.c
@@ -22,7 +22,7 @@
 
 #define TEST_NUM   (ACS_WD_TEST_NUM_BASE + 1)
 #define TEST_RULE  "S_L6WD_01"
-#define TEST_DESC  "Check NS Watchdog Revision        "
+#define TEST_DESC  "Check NS Watchdog Revision            "
 
 static
 void


### PR DESCRIPTION
- When the rule id is printed in next line, there is a diff in the no. of spaces.
- Made the spaces consistent between sbsa and bsa for all tests


Change-Id: I496243bfe46174a35ffaed3cddf5ef213ea28def