### PR TITLE
Add support for PCCT based MPAM MSC

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,8 +276,10 @@ For more details on running the generated binaries on Bare-metal environment, re
 SBSA ACS test suite may run at higher privilege level. An attacker may utilize these tests as a means to elevate privilege which can potentially reveal the platform security assets. To prevent the leakage of secure information, it is strongly recommended that the ACS test suite is run only on development platforms. If it is run on production systems, the system should be scrubbed after running the test suite.
 
 ## Limitations
-Validating the compliance of certain PCIe rules defined in the SBSA specification requires the PCIe end-point to generate specific stimulus during the runtime of the test. Examples of such stimulus are  P2P, PASID, ATC, etc. The tests that requires these stimuli are grouped together in the exerciser module. The exerciser layer is an abstraction layer that enables the integration of hardware capable of generating such stimuli to the test framework.
+- Validating the compliance of certain PCIe rules defined in the SBSA specification requires the PCIe end-point to generate specific stimulus during the runtime of the test. Examples of such stimulus are  P2P, PASID, ATC, etc. The tests that requires these stimuli are grouped together in the exerciser module. The exerciser layer is an abstraction layer that enables the integration of hardware capable of generating such stimuli to the test framework.
 The details of the hardware or Verification IP which enable these exerciser tests are platform specific and are beyond the scope of this document.
+
+- The MPAM MSC PCC (ACPI Platform Communication Channel) support has been implemented but not yet verified on any platform. Please raise an issue if any failures or errors are encountered during the ACS run.
 
 ### SBSA Tests dependencies
  - MPAM tests will require EL3 firmware to enable access to MPAM registers from lower EL's.

--- a/uefi_app/SbsaAvs.h
+++ b/uefi_app/SbsaAvs.h
@@ -67,6 +67,8 @@
                                         /*[24+(24*5) B Each + 4 B Header]*/
   #define HMAT_INFO_TBL_SZ       12288  /*Supports maximum of 400 Proximity domains*/
                                         /*[24 B Each + 8 B Header]*/
+  #define PCC_INFO_TBL_SZ        262144 /*Supports maximum of  PCC info entries*/
+                                        /*[112 B Each + 4B Header]*/
 
   #ifdef _AARCH64_BUILD_
   unsigned long __stack_chk_guard = 0xBAAAAAAD;

--- a/uefi_app/SbsaAvsMain.c
+++ b/uefi_app/SbsaAvsMain.c
@@ -366,6 +366,27 @@ createSratInfoTable(
   return Status;
 }
 
+EFI_STATUS
+createPccInfoTable(
+)
+{
+  UINT64      *PccInfoTable;
+  EFI_STATUS  Status;
+
+  Status = gBS->AllocatePool(EfiBootServicesData,
+                              PCC_INFO_TBL_SZ,
+                              (VOID **) &PccInfoTable);
+
+  if (EFI_ERROR(Status))
+  {
+    Print(L"Allocate Pool failed %x\n", Status);
+    return Status;
+  }
+  val_pcc_create_info_table(PccInfoTable);
+
+  return Status;
+}
+
 /**
   @brief  This API allocates memory for info table and
           calls create info table function passed as parameter.
@@ -425,6 +446,7 @@ freeSbsaAvsMem()
   val_srat_free_info_table();
   val_ras2_free_info_table();
   val_free_shared_mem();
+  val_pcc_free_info_table();
 }
 
 VOID
@@ -784,6 +806,9 @@ ShellAppMainsbsa (
   Status = createPeInfoTable();
   if (Status)
     return Status;
+
+  /* required before calling createMpamInfoTable() */
+  createPccInfoTable();
 
   Status = createGicInfoTable();
   if (Status)


### PR DESCRIPTION
 - allocated memory for PCC info table and calling val_pcc_create_info_table.
 - call val_pcc_create_info table in UEFI app.
 - Added limitation note regarding PCC MPAM support.
 
Fixes: #454
Deps : https://github.com/ARM-software/bsa-acs/pull/333