### PR TITLE
Add support for PCCT based MSC

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,8 +276,10 @@ For more details on running the generated binaries on Bare-metal environment, re
 SBSA ACS test suite may run at higher privilege level. An attacker may utilize these tests as a means to elevate privilege which can potentially reveal the platform security assets. To prevent the leakage of secure information, it is strongly recommended that the ACS test suite is run only on development platforms. If it is run on production systems, the system should be scrubbed after running the test suite.
 
 ## Limitations
-Validating the compliance of certain PCIe rules defined in the SBSA specification requires the PCIe end-point to generate specific stimulus during the runtime of the test. Examples of such stimulus are  P2P, PASID, ATC, etc. The tests that requires these stimuli are grouped together in the exerciser module. The exerciser layer is an abstraction layer that enables the integration of hardware capable of generating such stimuli to the test framework.
+- Validating the compliance of certain PCIe rules defined in the SBSA specification requires the PCIe end-point to generate specific stimulus during the runtime of the test. Examples of such stimulus are  P2P, PASID, ATC, etc. The tests that requires these stimuli are grouped together in the exerciser module. The exerciser layer is an abstraction layer that enables the integration of hardware capable of generating such stimuli to the test framework.
 The details of the hardware or Verification IP which enable these exerciser tests are platform specific and are beyond the scope of this document.
+
+- The MPAM MSC PCC (ACPI Platform Communication Channel) support has been implemented but not yet verified on any platform. Please raise an issue if any failures or errors are encountered during the ACS run.
 
 ### SBSA Tests dependencies
  - MPAM tests will require EL3 firmware to enable access to MPAM registers from lower EL's.

--- a/baremetal_app/SbsaAcsMain.c
+++ b/baremetal_app/SbsaAcsMain.c
@@ -224,6 +224,17 @@ createSratInfoTable(
 
 }
 
+void
+createPccInfoTable(
+)
+{
+  uint64_t      *PccInfoTable;
+
+  PccInfoTable = val_aligned_alloc(SIZE_4K,
+                                    PLATFORM_PCC_SUBSPACE_COUNT * sizeof(PCC_INFO));
+  val_pcc_create_info_table(PccInfoTable);
+}
+
 /**
   @brief  This API allocates memory for info table and
           calls create info table function passed as parameter.
@@ -281,6 +292,7 @@ freeSbsaAvsMem()
   val_hmat_free_info_table();
   val_srat_free_info_table();
   val_ras2_free_info_table();
+  val_pcc_free_info_table();
   val_free_shared_mem();
 }
 
@@ -385,6 +397,9 @@ ShellAppMainsbsa(
   createWatchdogInfoTable();
 
   createCacheInfoTable();
+
+  /* required before calling createMpamInfoTable() */
+  createPccInfoTable();
 
   createMpamInfoTable();
 

--- a/uefi_app/SbsaAvs.h
+++ b/uefi_app/SbsaAvs.h
@@ -67,6 +67,8 @@
                                         /*[24+(24*5) B Each + 4 B Header]*/
   #define HMAT_INFO_TBL_SZ       12288  /*Supports maximum of 400 Proximity domains*/
                                         /*[24 B Each + 8 B Header]*/
+  #define PCC_INFO_TBL_SZ        262144 /*Supports maximum of 234 PCC info entries*/
+                                        /*[112 B Each + 4B Header]*/
 
   #ifdef _AARCH64_BUILD_
   unsigned long __stack_chk_guard = 0xBAAAAAAD;

--- a/uefi_app/SbsaAvsMain.c
+++ b/uefi_app/SbsaAvsMain.c
@@ -366,6 +366,27 @@ createSratInfoTable(
   return Status;
 }
 
+EFI_STATUS
+createPccInfoTable(
+)
+{
+  UINT64      *PccInfoTable;
+  EFI_STATUS  Status;
+
+  Status = gBS->AllocatePool(EfiBootServicesData,
+                              PCC_INFO_TBL_SZ,
+                              (VOID **) &PccInfoTable);
+
+  if (EFI_ERROR(Status))
+  {
+    Print(L"Allocate Pool failed %x\n", Status);
+    return Status;
+  }
+  val_pcc_create_info_table(PccInfoTable);
+
+  return Status;
+}
+
 /**
   @brief  This API allocates memory for info table and
           calls create info table function passed as parameter.
@@ -424,6 +445,7 @@ freeSbsaAvsMem()
   val_hmat_free_info_table();
   val_srat_free_info_table();
   val_ras2_free_info_table();
+  val_pcc_free_info_table();
   val_free_shared_mem();
 }
 
@@ -794,23 +816,28 @@ ShellAppMainsbsa (
 
   Status = createCacheInfoTable();
   if (Status)
-    Print(L" Failed to created Cache info table\n");
+    Print(L" Failed to create Cache info table\n");
+
+  /* required before calling createMpamInfoTable() */
+  Status = createPccInfoTable();
+  if (Status)
+    Print(L" Failed to create PCC info table\n");
 
   Status = createMpamInfoTable();
   if (Status)
-    Print(L" Failed to created Mpam info table\n");
+    Print(L" Failed to create Mpam info table\n");
 
   Status = createHmatInfoTable();
   if (Status)
-    Print(L" Failed to created HMAT info table\n");
+    Print(L" Failed to create HMAT info table\n");
 
   Status = createSratInfoTable();
   if (Status)
-    Print(L" Failed to created SRAT info table\n");
+    Print(L" Failed to create SRAT info table\n");
 
   Status = createInfoTable(val_ras2_create_info_table, RAS2_FEAT_INFO_TBL_SZ, "RAS2");
   if (Status)
-    Print(L" Failed to created RAS2 feature info table\n");
+    Print(L" Failed to create RAS2 feature info table\n");
 
   createPcieVirtInfoTable();
   createPeripheralInfoTable();


### PR DESCRIPTION
 - allocated memory for PCC info table and calling
   val_pcc_create_info_table.
 - allocated memory for pcc info table.
 
 Fixes: #454 
 Deps: https://github.com/ARM-software/bsa-acs/pull/344