### PR TITLE
Latency requirement relaxation

### DIFF
--- a/test_pool/pcie/operating_system/test_p024_data.h
+++ b/test_pool/pcie/operating_system/test_p024_data.h
@@ -61,7 +61,7 @@ pcie_cfgreg_bitfield_entry bf_info_table24[] = {
        0x10,                                    // Capability id
        0,                                       // Not applicable
        0x04,                                    // Offset from capability id base
-       (RCEC | RCiEP | iEP_EP | iEP_RP),        // Applicable to all onchip peripherals and RCEC
+       iEP_RP,                                  // Applicable only for RP's
        6,                                       // Start bit position
        8,                                       // End bit position
        0,                                       // Hardwired to 0b
@@ -76,7 +76,7 @@ pcie_cfgreg_bitfield_entry bf_info_table24[] = {
        0x10,                                    // Capability id
        0,                                       // Not applicable
        0x04,                                    // Offset from capability id base
-       (RCEC | RCiEP | iEP_EP | iEP_RP),        // Applicable to all onchip peripherals and RCEC
+       iEP_RP,                                  // Applicable only for RP's
        9,                                       // Start bit position
        11,                                      // End bit position
        0,                                       // Hardwired to 0b


### PR DESCRIPTION
- RCiEP and i-EP acceptable latency requirement relaxation
- Only for RP's the latency to be hardwired to 0 as defined in the PCIe Spec
- Errata 747