### PR TITLE
Fix for https://github.com/ARM-software/bsa-acs/issues/352

### DIFF
--- a/test_pool/exerciser/operating_system/test_e008.c
+++ b/test_pool/exerciser/operating_system/test_e008.c
@@ -174,14 +174,14 @@ payload(void)
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
   req_instance = val_exerciser_get_info(EXERCISER_NUM_CARDS);
 
-  status = val_pcie_p2p_support();
   /* Check If PCIe Hierarchy supports P2P. */
-  if (status) {
-    val_print(ACS_PRINT_DEBUG, "\n       PCIe hierarchy does not support P2P: %x", status);
+  if (val_pcie_p2p_support() == NOT_IMPLEMENTED) {
+    val_print(ACS_PRINT_DEBUG, "\n       The test is applicable only if the system supports", 0);
+    val_print(ACS_PRINT_DEBUG, "\n       P2P traffic. If the system supports P2P, pass the", 0);
+    val_print(ACS_PRINT_DEBUG, "\n       command line option '-p2p' while running the binary", 0);
     val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 01));
     return;
   }
-
 
   while (req_instance-- != 0)
   {

--- a/test_pool/pcie/operating_system/test_p056.c
+++ b/test_pool/pcie/operating_system/test_p056.c
@@ -55,13 +55,6 @@ payload(void)
     return;
   }
 
-  if (val_pcie_p2p_support())
-  {
-      val_print(ACS_PRINT_DEBUG, "\n       PCIe P2P unsupported ", 0);
-      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 02));
-      return;
-  }
-
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
   test_fails = 0;
 
@@ -161,7 +154,7 @@ payload(void)
   if (test_skip == 1) {
       val_print(ACS_PRINT_DEBUG,
            "\n       No iEP_EP type device found with P2P support. Skipping test", 0);
-      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 03));
+      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 02));
   }
   else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(TEST_NUM, test_fails));

--- a/test_pool/pcie/operating_system/test_p057.c
+++ b/test_pool/pcie/operating_system/test_p057.c
@@ -44,6 +44,16 @@ payload(void)
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
+
+  /* Check If PCIe Hierarchy supports P2P */
+  if (val_pcie_p2p_support() == NOT_IMPLEMENTED) {
+    val_print(ACS_PRINT_DEBUG, "\n       The test is applicable only if the system supports", 0);
+    val_print(ACS_PRINT_DEBUG, "\n       P2P traffic. If the system supports P2P, pass the", 0);
+    val_print(ACS_PRINT_DEBUG, "\n       command line option '-p2p' while running the binary", 0);
+    val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 01));
+    return;
+  }
+
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
 
   test_fails = 0;
@@ -118,7 +128,7 @@ payload(void)
   if (test_skip == 1) {
       val_print(ACS_PRINT_DEBUG,
       "\n       No RCiEP/ iEP_EP type device with Multifunction and P2P support.Skipping test", 0);
-      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 01));
+      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 02));
   }
   else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(TEST_NUM, test_fails));


### PR DESCRIPTION
- val_pcie_p2p_support API either return non_implemented or 0. having it twice is redundant, hence removed it in tests
- In addition to the devices, the PCIe hierarchy also need to support P2P. hence added P2P check for PCIe hierarchy as well