### PR TITLE
Smmu Sbsa Test will fail for no smmu compatibility

### DIFF
--- a/test_pool/smmu/operating_system/test_i001.c
+++ b/test_pool/smmu/operating_system/test_i001.c
@@ -33,7 +33,7 @@ payload(void)
     uint32_t num_smmu;
     uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
-    num_smmu = val_smmu_get_info(SMMU_NUM_CTRL, 0);
+    num_smmu = val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);
 
     if (num_smmu == 0) {
         val_print(ACS_PRINT_ERR, "\n       No SMMU Controllers are discovered ", 0);


### PR DESCRIPTION
Fix for #513 - Smmu Sbsa Test will fail for no smmu compatibility

-The no smmu check before running the smmu tests is removed.
- If the smmu compatibility fails then other tests will not run