### PR TITLE
PMU test changes: Skip the test if PMU node not following CS pmu register layout.

### DIFF
--- a/test_pool/pmu/operating_system/test_pmu004.c
+++ b/test_pool/pmu/operating_system/test_pmu004.c
@@ -82,7 +82,7 @@ static void payload(void)
     uint64_t num_mem_range;
     uint64_t mc_prox_domain;
     uint64_t prox_base_addr, addr_len;
-    uint32_t i;
+    uint32_t i, cs_com = 0;
 
     if (g_sbsa_level < 7) {
         val_set_status(index, RESULT_SKIP(TEST_NUM, 01));
@@ -95,6 +95,16 @@ static void payload(void)
     if (node_count == 0) {
         val_set_status(index, RESULT_FAIL(TEST_NUM, 01));
         val_print(ACS_PRINT_ERR, "\n       No PMU nodes found", 0);
+        return;
+    }
+
+    /* The test uses PMU CoreSight arch register map, skip if pmu node is not cs */
+    for (node_index = 0; node_index < node_count; node_index++) {
+        cs_com |= val_pmu_get_info(PMU_NODE_CS_COM, node_index);
+    }
+    if (cs_com != 0x1) {
+        val_set_status(index, RESULT_SKIP(TEST_NUM, 02));
+        val_print(ACS_PRINT_DEBUG, "\n       No CS PMU nodes found", 0);
         return;
     }
 

--- a/test_pool/pmu/operating_system/test_pmu004.c
+++ b/test_pool/pmu/operating_system/test_pmu004.c
@@ -93,8 +93,8 @@ static void payload(void)
     val_print(ACS_PRINT_DEBUG, "\n       PMU NODES = %d", node_count);
 
     if (node_count == 0) {
-        val_set_status(index, RESULT_FAIL(TEST_NUM, 01));
-        val_print(ACS_PRINT_ERR, "\n       No PMU nodes found", 0);
+        val_set_status(index, RESULT_SKIP(TEST_NUM, 02));
+        val_print(ACS_PRINT_ERR, "\n       No APMT PMU nodes found", 0);
         return;
     }
 
@@ -103,7 +103,7 @@ static void payload(void)
         cs_com |= val_pmu_get_info(PMU_NODE_CS_COM, node_index);
     }
     if (cs_com != 0x1) {
-        val_set_status(index, RESULT_SKIP(TEST_NUM, 02));
+        val_set_status(index, RESULT_SKIP(TEST_NUM, 03));
         val_print(ACS_PRINT_DEBUG, "\n       No CS PMU nodes found", 0);
         return;
     }

--- a/test_pool/pmu/operating_system/test_pmu005.c
+++ b/test_pool/pmu/operating_system/test_pmu005.c
@@ -43,6 +43,7 @@ static void payload(void)
     uint64_t mc_prox_domain;
     uint64_t prox_base_addr, addr_len;
     uint32_t status1, status2;
+    uint32_t cs_com = 0;
     void *src_buf = 0;
     void *dest_buf = 0;
 
@@ -57,6 +58,16 @@ static void payload(void)
     if (node_count == 0) {
         val_set_status(index, RESULT_FAIL(TEST_NUM, 01));
         val_print(ACS_PRINT_ERR, "\n       No PMU nodes found", 0);
+        return;
+    }
+
+    /* The test uses PMU CoreSight arch register map, skip if pmu node is not cs */
+    for (node_index = 0; node_index < node_count; node_index++) {
+        cs_com |= val_pmu_get_info(PMU_NODE_CS_COM, node_index);
+    }
+    if (cs_com != 0x1) {
+        val_set_status(index, RESULT_SKIP(TEST_NUM, 02));
+        val_print(ACS_PRINT_DEBUG, "\n       No CS PMU nodes found", 0);
         return;
     }
 

--- a/test_pool/pmu/operating_system/test_pmu005.c
+++ b/test_pool/pmu/operating_system/test_pmu005.c
@@ -56,8 +56,8 @@ static void payload(void)
     val_print(ACS_PRINT_DEBUG, "\n       PMU NODES = %d", node_count);
 
     if (node_count == 0) {
-        val_set_status(index, RESULT_FAIL(TEST_NUM, 01));
-        val_print(ACS_PRINT_ERR, "\n       No PMU nodes found", 0);
+        val_set_status(index, RESULT_SKIP(TEST_NUM, 02));
+        val_print(ACS_PRINT_ERR, "\n       No APMT PMU nodes found", 0);
         return;
     }
 
@@ -66,7 +66,7 @@ static void payload(void)
         cs_com |= val_pmu_get_info(PMU_NODE_CS_COM, node_index);
     }
     if (cs_com != 0x1) {
-        val_set_status(index, RESULT_SKIP(TEST_NUM, 02));
+        val_set_status(index, RESULT_SKIP(TEST_NUM, 03));
         val_print(ACS_PRINT_DEBUG, "\n       No CS PMU nodes found", 0);
         return;
     }

--- a/test_pool/pmu/operating_system/test_pmu007.c
+++ b/test_pool/pmu/operating_system/test_pmu007.c
@@ -102,8 +102,8 @@ static void payload(void)
     val_print(ACS_PRINT_DEBUG, "\n       PMU NODES = %d", node_count);
 
     if (node_count == 0) {
-        val_set_status(index, RESULT_FAIL(TEST_NUM, 03));
-        val_print(ACS_PRINT_ERR, "\n       No PMU nodes found", 0);
+        val_set_status(index, RESULT_SKIP(TEST_NUM, 03));
+        val_print(ACS_PRINT_ERR, "\n       No APMT PMU nodes found", 0);
         return;
     }
 
@@ -112,7 +112,7 @@ static void payload(void)
         cs_com |= val_pmu_get_info(PMU_NODE_CS_COM, node_index);
     }
     if (cs_com != 0x1) {
-        val_set_status(index, RESULT_SKIP(TEST_NUM, 03));
+        val_set_status(index, RESULT_SKIP(TEST_NUM, 04));
         val_print(ACS_PRINT_DEBUG, "\n       No CS PMU nodes found", 0);
         return;
     }
@@ -186,7 +186,7 @@ static void payload(void)
         val_set_status(index, RESULT_FAIL(TEST_NUM, 05));
         return;
     } else if (test_skip) {
-        val_set_status(index, RESULT_SKIP(TEST_NUM, 04));
+        val_set_status(index, RESULT_SKIP(TEST_NUM, 05));
         return;
     }
 

--- a/test_pool/pmu/operating_system/test_pmu007.c
+++ b/test_pool/pmu/operating_system/test_pmu007.c
@@ -83,7 +83,7 @@ static void payload(void)
     uint32_t run_flag = 0;
     uint32_t status;
     uint32_t num_ecam;
-    uint32_t i;
+    uint32_t i, cs_com = 0;
 
     if (g_sbsa_level < 7) {
         val_set_status(index, RESULT_SKIP(TEST_NUM, 01));
@@ -104,6 +104,16 @@ static void payload(void)
     if (node_count == 0) {
         val_set_status(index, RESULT_FAIL(TEST_NUM, 03));
         val_print(ACS_PRINT_ERR, "\n       No PMU nodes found", 0);
+        return;
+    }
+
+    /* The test uses PMU CoreSight arch register map, skip if pmu node is not cs */
+    for (node_index = 0; node_index < node_count; node_index++) {
+        cs_com |= val_pmu_get_info(PMU_NODE_CS_COM, node_index);
+    }
+    if (cs_com != 0x1) {
+        val_set_status(index, RESULT_SKIP(TEST_NUM, 03));
+        val_print(ACS_PRINT_DEBUG, "\n       No CS PMU nodes found", 0);
         return;
     }
 
@@ -176,7 +186,7 @@ static void payload(void)
         val_set_status(index, RESULT_FAIL(TEST_NUM, 05));
         return;
     } else if (test_skip) {
-        val_set_status(index, RESULT_SKIP(TEST_NUM, 05));
+        val_set_status(index, RESULT_SKIP(TEST_NUM, 04));
         return;
     }
 

--- a/test_pool/pmu/operating_system/test_pmu008.c
+++ b/test_pool/pmu/operating_system/test_pmu008.c
@@ -105,7 +105,7 @@ static void payload(void)
     uint32_t node_count;
     uint32_t mc_node_index;
     uint32_t status;
-    uint32_t i;
+    uint32_t i, node_index, cs_com = 0;
     uint64_t num_mem_range;
     uint32_t pe_uid, pe_prox_domain;
     uint32_t remote_pe_uid, remote_pe_prox_domain;
@@ -123,6 +123,16 @@ static void payload(void)
     if (node_count == 0) {
         val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
         val_print(ACS_PRINT_ERR, "\n       No PMU nodes found", 0);
+        return;
+    }
+
+    /* The test uses PMU CoreSight arch register map, skip if pmu node is not cs */
+    for (node_index = 0; node_index < node_count; node_index++) {
+        cs_com |= val_pmu_get_info(PMU_NODE_CS_COM, node_index);
+    }
+    if (cs_com != 0x1) {
+        val_set_status(index, RESULT_SKIP(TEST_NUM, 02));
+        val_print(ACS_PRINT_DEBUG, "\n       No CS PMU nodes found", 0);
         return;
     }
 

--- a/test_pool/pmu/operating_system/test_pmu008.c
+++ b/test_pool/pmu/operating_system/test_pmu008.c
@@ -121,8 +121,8 @@ static void payload(void)
     val_print(ACS_PRINT_DEBUG, "\n       PMU NODES = %d", node_count);
 
     if (node_count == 0) {
-        val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
-        val_print(ACS_PRINT_ERR, "\n       No PMU nodes found", 0);
+        val_set_status(index, RESULT_SKIP(TEST_NUM, 02));
+        val_print(ACS_PRINT_ERR, "\n       No APMT PMU nodes found", 0);
         return;
     }
 
@@ -131,7 +131,7 @@ static void payload(void)
         cs_com |= val_pmu_get_info(PMU_NODE_CS_COM, node_index);
     }
     if (cs_com != 0x1) {
-        val_set_status(index, RESULT_SKIP(TEST_NUM, 02));
+        val_set_status(index, RESULT_SKIP(TEST_NUM, 03));
         val_print(ACS_PRINT_DEBUG, "\n       No CS PMU nodes found", 0);
         return;
     }

--- a/test_pool/pmu/operating_system/test_pmu009.c
+++ b/test_pool/pmu/operating_system/test_pmu009.c
@@ -41,6 +41,7 @@ static void payload(void)
     uint32_t ret_status, status;
     uint64_t interface_acpiid;
     uint32_t num_traffic_support;
+    uint32_t cs_com = 0, node_index;
 
     if (g_sbsa_level < 7) {
         val_set_status(index, RESULT_SKIP(TEST_NUM, 1));
@@ -53,6 +54,16 @@ static void payload(void)
     if (pmu_node_count == 0) {
         val_set_status(index, RESULT_FAIL(TEST_NUM, 2));
         val_print(ACS_PRINT_ERR, "\n       No PMU nodes found", 0);
+        return;
+    }
+
+    /* The test uses PMU CoreSight arch register map, skip if pmu node is not cs */
+    for (node_index = 0; node_index < pmu_node_count; node_index++) {
+        cs_com |= val_pmu_get_info(PMU_NODE_CS_COM, node_index);
+    }
+    if (cs_com != 0x1) {
+        val_set_status(index, RESULT_SKIP(TEST_NUM, 02));
+        val_print(ACS_PRINT_DEBUG, "\n       No CS PMU nodes found", 0);
         return;
     }
 

--- a/test_pool/pmu/operating_system/test_pmu009.c
+++ b/test_pool/pmu/operating_system/test_pmu009.c
@@ -52,8 +52,8 @@ static void payload(void)
     val_print(ACS_PRINT_DEBUG, "\n       PMU NODES = %d", pmu_node_count);
 
     if (pmu_node_count == 0) {
-        val_set_status(index, RESULT_FAIL(TEST_NUM, 2));
-        val_print(ACS_PRINT_ERR, "\n       No PMU nodes found", 0);
+        val_set_status(index, RESULT_SKIP(TEST_NUM, 02));
+        val_print(ACS_PRINT_ERR, "\n       No APMT PMU nodes found", 0);
         return;
     }
 
@@ -62,7 +62,7 @@ static void payload(void)
         cs_com |= val_pmu_get_info(PMU_NODE_CS_COM, node_index);
     }
     if (cs_com != 0x1) {
-        val_set_status(index, RESULT_SKIP(TEST_NUM, 02));
+        val_set_status(index, RESULT_SKIP(TEST_NUM, 03));
         val_print(ACS_PRINT_DEBUG, "\n       No CS PMU nodes found", 0);
         return;
     }
@@ -72,14 +72,14 @@ static void payload(void)
     ret_status = val_pmu_get_multi_traffic_support_interface(&interface_acpiid,
                                                                           &num_traffic_support);
     if (ret_status == NOT_IMPLEMENTED) {
-        val_set_status(index, RESULT_SKIP(TEST_NUM, 3));
+        val_set_status(index, RESULT_SKIP(TEST_NUM, 04));
         return;
     }
 
     /* PMU info table index for the interface */
     pmu_node_index = val_pmu_get_index_acpiid(interface_acpiid);
     if (pmu_node_index == PMU_INVALID_INDEX) {
-        val_set_status(index, RESULT_SKIP(TEST_NUM, 4));
+        val_set_status(index, RESULT_SKIP(TEST_NUM, 05));
         return;
     }
 


### PR DESCRIPTION

Use the BSA API to check if PMU node following coresight regsister layout and skip test accordingly.