### PR TITLE
Update sys PMU test skipped reason in case of no CoreSight PMU

### DIFF
--- a/test_pool/pmu/operating_system/test_pmu004.c
+++ b/test_pool/pmu/operating_system/test_pmu004.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -94,7 +94,11 @@ static void payload(void)
 
     if (node_count == 0) {
         val_set_status(index, RESULT_SKIP(TEST_NUM, 02));
-        val_print(ACS_PRINT_ERR, "\n       No APMT PMU nodes found", 0);
+        val_print(ACS_PRINT_TEST, "\n       No PMU nodes found in APMT table", 0);
+        val_print(ACS_PRINT_TEST, "\n       The test must be considered fail"
+                                   " if system has CoreSight PMU", 0);
+        val_print(ACS_PRINT_TEST, "\n       For non CoreSight PMU, manually verify A.4 PMU rules "
+                                   "in the SBSA specification", 0);
         return;
     }
 
@@ -104,7 +108,9 @@ static void payload(void)
     }
     if (cs_com != 0x1) {
         val_set_status(index, RESULT_SKIP(TEST_NUM, 03));
-        val_print(ACS_PRINT_DEBUG, "\n       No CS PMU nodes found", 0);
+        val_print(ACS_PRINT_TEST, "\n       No CoreSight PMU nodes found", 0);
+        val_print(ACS_PRINT_TEST, "\n       For non CoreSight PMU, manually verify A.4 PMU rules "
+                                   "in the SBSA specification", 0);
         return;
     }
 

--- a/test_pool/pmu/operating_system/test_pmu005.c
+++ b/test_pool/pmu/operating_system/test_pmu005.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -57,7 +57,11 @@ static void payload(void)
 
     if (node_count == 0) {
         val_set_status(index, RESULT_SKIP(TEST_NUM, 02));
-        val_print(ACS_PRINT_ERR, "\n       No APMT PMU nodes found", 0);
+        val_print(ACS_PRINT_TEST, "\n       No PMU nodes found in APMT table", 0);
+        val_print(ACS_PRINT_TEST, "\n       The test must be considered fail"
+                                   " if system has CoreSight PMU", 0);
+        val_print(ACS_PRINT_TEST, "\n       For non CoreSight PMU, manually verify A.4 PMU rules "
+                                   "in the SBSA specification", 0);
         return;
     }
 
@@ -67,7 +71,9 @@ static void payload(void)
     }
     if (cs_com != 0x1) {
         val_set_status(index, RESULT_SKIP(TEST_NUM, 03));
-        val_print(ACS_PRINT_DEBUG, "\n       No CS PMU nodes found", 0);
+        val_print(ACS_PRINT_TEST, "\n       No CoreSight PMU nodes found", 0);
+        val_print(ACS_PRINT_TEST, "\n       For non CoreSight PMU, manually verify A.4 PMU rules "
+                                   "in the SBSA specification", 0);
         return;
     }
 

--- a/test_pool/pmu/operating_system/test_pmu007.c
+++ b/test_pool/pmu/operating_system/test_pmu007.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -103,7 +103,12 @@ static void payload(void)
 
     if (node_count == 0) {
         val_set_status(index, RESULT_SKIP(TEST_NUM, 03));
-        val_print(ACS_PRINT_ERR, "\n       No APMT PMU nodes found", 0);
+        val_print(ACS_PRINT_TEST, "\n       No PMU nodes found in APMT table", 0);
+        val_print(ACS_PRINT_TEST, "\n       The test must be considered fail"
+                                   " if system has CoreSight PMU", 0);
+        val_print(ACS_PRINT_TEST, "\n       For non CoreSight PMU, manually verify A.4 PMU rules "
+                                   "in the SBSA specification", 0);
+
         return;
     }
 
@@ -113,7 +118,9 @@ static void payload(void)
     }
     if (cs_com != 0x1) {
         val_set_status(index, RESULT_SKIP(TEST_NUM, 04));
-        val_print(ACS_PRINT_DEBUG, "\n       No CS PMU nodes found", 0);
+        val_print(ACS_PRINT_TEST, "\n       No CoreSight PMU nodes found", 0);
+        val_print(ACS_PRINT_TEST, "\n       For non CoreSight PMU, manually verify A.4 PMU rules "
+                                   "in the SBSA specification", 0);
         return;
     }
 

--- a/test_pool/pmu/operating_system/test_pmu008.c
+++ b/test_pool/pmu/operating_system/test_pmu008.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -122,7 +122,11 @@ static void payload(void)
 
     if (node_count == 0) {
         val_set_status(index, RESULT_SKIP(TEST_NUM, 02));
-        val_print(ACS_PRINT_ERR, "\n       No APMT PMU nodes found", 0);
+        val_print(ACS_PRINT_TEST, "\n       No PMU nodes found in APMT table", 0);
+        val_print(ACS_PRINT_TEST, "\n       The test must be considered fail"
+                                   " if system has CoreSight PMU", 0);
+        val_print(ACS_PRINT_TEST, "\n       For non CoreSight PMU, manually verify A.4 PMU rules "
+                                   "in the SBSA specification", 0);
         return;
     }
 
@@ -132,7 +136,9 @@ static void payload(void)
     }
     if (cs_com != 0x1) {
         val_set_status(index, RESULT_SKIP(TEST_NUM, 03));
-        val_print(ACS_PRINT_DEBUG, "\n       No CS PMU nodes found", 0);
+        val_print(ACS_PRINT_TEST, "\n       No CoreSight PMU nodes found", 0);
+        val_print(ACS_PRINT_TEST, "\n       For non CoreSight PMU, manually verify A.4 PMU rules "
+                                   "in the SBSA specification", 0);
         return;
     }
 

--- a/test_pool/pmu/operating_system/test_pmu009.c
+++ b/test_pool/pmu/operating_system/test_pmu009.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,7 +53,11 @@ static void payload(void)
 
     if (pmu_node_count == 0) {
         val_set_status(index, RESULT_SKIP(TEST_NUM, 02));
-        val_print(ACS_PRINT_ERR, "\n       No APMT PMU nodes found", 0);
+        val_print(ACS_PRINT_TEST, "\n       No PMU nodes found in APMT table", 0);
+        val_print(ACS_PRINT_TEST, "\n       The test must be considered fail"
+                                   " if system has CoreSight PMU", 0);
+        val_print(ACS_PRINT_TEST, "\n       For non CoreSight PMU, manually verify A.4 PMU rules "
+                                   "in the SBSA specification", 0);
         return;
     }
 
@@ -63,7 +67,9 @@ static void payload(void)
     }
     if (cs_com != 0x1) {
         val_set_status(index, RESULT_SKIP(TEST_NUM, 03));
-        val_print(ACS_PRINT_DEBUG, "\n       No CS PMU nodes found", 0);
+        val_print(ACS_PRINT_TEST, "\n       No CoreSight PMU nodes found", 0);
+        val_print(ACS_PRINT_TEST, "\n       For non CoreSight PMU, manually verify A.4 PMU rules "
+                                   "in the SBSA specification", 0);
         return;
     }
 


### PR DESCRIPTION
Fixes #548 

-The PMU test relies on CoreSight PMU register layout 
-In case if PMU are not CoreSight PMU, manual verification of A.4 PMU rules are required.
- Add the prints with above details for all the PMU tests.