### PR TITLE
Support for MSI and MSI-X

### DIFF
--- a/test_pool/exerciser/operating_system/test_e006.c
+++ b/test_pool/exerciser/operating_system/test_e006.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -339,13 +339,15 @@ payload(void)
           val_print(ACS_PRINT_WARN, "\n       DPC enabled for bdf : 0x%x", erp_bdf);
 
 
-      /* Search for MSI-X Capability */
-      if (val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) {
+      /* Search for MSI-X/MSI Capability */
+      if ((val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) &&
+          (val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSI, &msi_cap_offset))) {
           val_print(ACS_PRINT_DEBUG, "\n       No MSI-X Capability for Bdf 0x%x", e_bdf);
       }
 
-      if (val_pcie_find_capability(erp_bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) {
-          val_print(ACS_PRINT_DEBUG, "\n       No MSI-X Capability for RP Bdf 0x%x", erp_bdf);
+      if ((val_pcie_find_capability(erp_bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) &&
+          (val_pcie_find_capability(erp_bdf, PCIE_CAP, CID_MSI, &msi_cap_offset))) {
+          val_print(ACS_PRINT_DEBUG, "\n       No MSI/MSI-X Capability for RP Bdf 0x%x", erp_bdf);
           goto err_check;
       }
 

--- a/test_pool/exerciser/operating_system/test_e007.c
+++ b/test_pool/exerciser/operating_system/test_e007.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -205,9 +205,10 @@ payload(void)
           fail_cnt++;
       }
 
-      /* Search for MSI-X Capability */
-      if (val_pcie_find_capability(erp_bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) {
-        val_print(ACS_PRINT_ERR, "\n       No MSI-X Capability for Bdf 0x%x", erp_bdf);
+      /* Search for MSI/MSI-X Capability */
+      if ((val_pcie_find_capability(erp_bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) &&
+        (val_pcie_find_capability(erp_bdf, PCIE_CAP, CID_MSI, &msi_cap_offset))) {
+        val_print(ACS_PRINT_ERR, "\n       No MSI/MSI-X Capability for Bdf 0x%x", erp_bdf);
         goto err_check;
       }
 

--- a/test_pool/exerciser/operating_system/test_e010.c
+++ b/test_pool/exerciser/operating_system/test_e010.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -214,9 +214,10 @@ payload(void)
       /* Test will run*/
       test_skip = 0;
 
-      /* Search for MSI-X Capability */
-      if (val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) {
-        val_print(ACS_PRINT_ERR, "\n       No MSI-X Capability, Skipping for Bdf 0x%x", e_bdf);
+      /* Search for MSI-X/MSI Capability */
+      if ((val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) &&
+          (val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSI, &msi_cap_offset))) {
+        val_print(ACS_PRINT_DEBUG, "\n       No MSI/MSI-X Capability, Skipping for 0x%x", e_bdf);
         continue;
       }
 


### PR DESCRIPTION
- Fixes https://github.com/ARM-software/bsa-acs/issues/338
- Provided support for both MSI and MSI-X support
- If both are supported, MSI-X is taken precedence and that is enabled and verified.