### PR TITLE
README update: BSA and SBSA ACS has been restructured and code moved to new repository sysarch-acs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,20 @@
+### 📢 Repository Notice — Project Restructure
 
+> **Status Update (June 2025)**
+> The **BSA-ACS** and **SBSA-ACS** repositories are now ***read-only***.
+
+> Development has moved to the consolidated **[`sysarch-acs`](https://github.com/ARM-software/sysarch-acs)** repository, which hosts the test suites for BSA, SBSA, and future system-standard compliance suites.
+
+| What changed?                      | Where to contribute now?                               |
+| ---------------------------------- | ------------------------------------------------------ |
+| **Code updates**                   | Open pull requests in **`sysarch-acs`**                |
+| **Bug reports / feature requests** | Create GitHub issues in **`sysarch-acs`**              |
+| **Open PRs & issues here**         | The ACS team will migrate or close them as appropriate |
+
+We appreciate your cooperation as we streamline our codebase.
+For questions, please contact the ACS maintainers or open an issue in **`sysarch-acs`**.
+
+-------------------------------------------------------------------------------------------------------------------
 # Server Base System Architecture - Architecture Compliance Suite
 
 [![SBSA-ACS Build Check](https://github.com/ARM-software/sbsa-acs/actions/workflows/sbsa-acs_build_check.yml/badge.svg)](https://github.com/ARM-software/sbsa-acs/actions/workflows/sbsa-acs_build_check.yml)


### PR DESCRIPTION
Note added to help users know the latest repository which will host BSA and SBSA acs code.